### PR TITLE
fix(core): decision-integrity cluster (C1/H1/H2 + Literal param sweep)

### DIFF
--- a/src/trace_mcp/schema/__init__.py
+++ b/src/trace_mcp/schema/__init__.py
@@ -1,17 +1,24 @@
 """TRACE schema definitions — Pydantic models for sessions and events."""
 
 from trace_mcp.schema.events import (
+    AnnotationCategory,
     AnnotationData,
+    ContributionAttribution,
     ContributionData,
     DecisionData,
+    DecisionDisposition,
     EventContext,
     StateChangeData,
+    SuggestionType,
     ToolCallData,
+    ToolCallHost,
+    ToolCallStatus,
     TraceEvent,
 )
 from trace_mcp.schema.session import (
     SCHEMA_VERSION,
     Actor,
+    ActorType,
     Environment,
     Session,
     SessionMetadata,
@@ -24,6 +31,13 @@ Session.model_rebuild()
 __all__ = [
     "SCHEMA_VERSION",
     "Actor",
+    "ActorType",
+    "AnnotationCategory",
+    "ContributionAttribution",
+    "DecisionDisposition",
+    "SuggestionType",
+    "ToolCallHost",
+    "ToolCallStatus",
     "AnnotationData",
     "ContributionData",
     "DecisionData",

--- a/src/trace_mcp/schema/events.py
+++ b/src/trace_mcp/schema/events.py
@@ -12,6 +12,18 @@ from pydantic import BaseModel, Field, model_validator
 
 from trace_mcp.schema.session import Actor
 
+# Canonical enum value-sets (single source of truth; server.py imports these
+# for the MCP tool signatures so the protocol edge can never drift from the
+# schema).
+ToolCallStatus = Literal["success", "error", "timeout"]
+ToolCallHost = Literal["mcp", "internal", "external"]
+DecisionDisposition = Literal["proposed", "accepted", "revised", "rejected"]
+SuggestionType = Literal["proactive", "requested", "collaborative"]
+AnnotationCategory = Literal[
+    "learning", "gotcha", "observation", "correction", "todo", "question", "discovery", "other"
+]
+ContributionAttribution = Literal["human", "ai", "collaborative"]
+
 
 class EventContext(BaseModel):
     """Shared context attached to any event."""
@@ -33,10 +45,10 @@ class ToolCallData(BaseModel):
     output_truncated: bool | None = None
     output_hash: str | None = None
     duration_ms: int | None = None
-    status: Literal["success", "error", "timeout"] = "success"
+    status: ToolCallStatus = "success"
     error_message: str | None = None
     retries_event_id: str | None = None
-    host: Literal["mcp", "internal", "external"] = "mcp"
+    host: ToolCallHost = "mcp"
     parent_event_id: str | None = None
 
 
@@ -46,11 +58,11 @@ class DecisionData(BaseModel):
     description: str
     rationale: str | None = None
     proposed_by: Actor
-    disposition: Literal["proposed", "accepted", "revised", "rejected"] = "proposed"
+    disposition: DecisionDisposition = "proposed"
     resolved_by: Actor | None = None
     revision_note: str | None = None
     revises_event_id: str | None = None
-    suggestion_type: Literal["proactive", "requested", "collaborative"] | None = None
+    suggestion_type: SuggestionType | None = None
     tags: list[str] = Field(default_factory=list)
     warnings: list[str] = Field(default_factory=list)
 
@@ -70,7 +82,7 @@ class DecisionData(BaseModel):
 class AnnotationData(BaseModel):
     """Free-form observations, learnings, gotchas, corrections, todos."""
 
-    category: Literal["learning", "gotcha", "observation", "correction", "todo", "question", "discovery", "other"]
+    category: AnnotationCategory
     content: str
     corrects_event_ids: list[str] = Field(default_factory=list)
     related_event_ids: list[str] = Field(default_factory=list)
@@ -86,8 +98,8 @@ class ContributionData(BaseModel):
 
     description: str
     artifact: str | None = None
-    direction: Literal["human", "ai", "collaborative"]
-    execution: Literal["human", "ai", "collaborative"]
+    direction: ContributionAttribution
+    execution: ContributionAttribution
     related_decision_ids: list[str] = Field(default_factory=list)
     tags: list[str] = Field(default_factory=list)
 

--- a/src/trace_mcp/schema/session.py
+++ b/src/trace_mcp/schema/session.py
@@ -25,10 +25,16 @@ changes — never for a packaging/patch release. The spec namespace URL in
 """
 
 
+# Canonical enum value-sets. Single source of truth — the MCP tool
+# signatures in server.py import these so the protocol edge can never
+# drift from the schema.
+ActorType = Literal["human", "ai", "system"]
+
+
 class Actor(BaseModel):
     """Who performed an action."""
 
-    type: Literal["human", "ai", "system"]
+    type: ActorType
     id: str
     role: str | None = None
 

--- a/src/trace_mcp/server.py
+++ b/src/trace_mcp/server.py
@@ -17,7 +17,16 @@ from mcp.server.fastmcp import FastMCP
 
 from trace_mcp import __version__
 from trace_mcp import extension_hooks as hooks
-from trace_mcp.schema import Session
+from trace_mcp.schema import (
+    ActorType,
+    AnnotationCategory,
+    ContributionAttribution,
+    DecisionDisposition,
+    Session,
+    SuggestionType,
+    ToolCallHost,
+    ToolCallStatus,
+)
 from trace_mcp.storage.json_file import JsonFileStorage
 from trace_mcp.tools import (
     decision_tools,
@@ -90,8 +99,16 @@ async def _ensure_session(session_id: str | None) -> tuple[Session, str]:
         # explicit session_id targeting a completed session (e.g. resolving
         # a decision proposed in a prior, now-closed session) must not move
         # the pointer — otherwise every subsequent pointer-less call tries
-        # to append to the completed session and fails.
-        if session.status == "active":
+        # to append to the completed session and fails. The cached copy may
+        # be stale (another process may have completed the session), so the
+        # status is confirmed against disk before the pointer moves.
+        status = session.status
+        if status == "active":
+            try:
+                status = (await storage.get_session(session_id)).status
+            except FileNotFoundError:
+                pass  # not yet persisted — in-memory status is authoritative
+        if status == "active":
             _current_session_id = session_id
         return session, ""
 
@@ -101,7 +118,13 @@ async def _ensure_session(session_id: str | None) -> tuple[Session, str]:
             session = await session_tools.get_or_load_session(
                 storage, active_sessions, _current_session_id
             )
-            return session, ""
+            if session.status == "active":
+                return session, ""
+            # The current session was completed/abandoned (e.g. ended from
+            # another process): clear the pointer and fall through to
+            # auto-create rather than wedging every subsequent pointer-less
+            # call on an immutable session.
+            _current_session_id = None
         except FileNotFoundError:
             _current_session_id = None
 
@@ -282,14 +305,14 @@ async def trace_log_tool_call(
     input: dict[str, Any],
     output: Any = None,
     duration_ms: int | None = None,
-    status: Literal["success", "error", "timeout"] = "success",
+    status: ToolCallStatus = "success",
     error_message: str | None = None,
     retries_event_id: str | None = None,
-    actor_type: Literal["human", "ai", "system"] = "ai",
+    actor_type: ActorType = "ai",
     actor_id: str = "ai-assistant",
     reasoning: str | None = None,
     conversation_turn: int | None = None,
-    host: Literal["mcp", "internal", "external"] = "mcp",
+    host: ToolCallHost = "mcp",
     parent_event_id: str | None = None,
     session_id: str | None = None,
 ) -> str:
@@ -340,12 +363,12 @@ async def trace_log_tool_call(
 
 @mcp.tool()
 async def trace_log_annotation(
-    category: Literal["learning", "gotcha", "observation", "correction", "todo", "question", "discovery", "other"],
+    category: AnnotationCategory,
     content: str,
     tags: list[str] | None = None,
     corrects_event_ids: list[str] | None = None,
     related_event_ids: list[str] | None = None,
-    actor_type: Literal["human", "ai", "system"] = "ai",
+    actor_type: ActorType = "ai",
     actor_id: str = "ai-assistant",
     conversation_snippet: str | None = None,
     session_id: str | None = None,
@@ -388,12 +411,12 @@ async def trace_log_annotation(
 @mcp.tool()
 async def trace_log_contribution(
     description: str,
-    direction: Literal["human", "ai", "collaborative"],
-    execution: Literal["human", "ai", "collaborative"],
+    direction: ContributionAttribution,
+    execution: ContributionAttribution,
     artifact: str | None = None,
     related_decision_ids: list[str] | None = None,
     tags: list[str] | None = None,
-    actor_type: Literal["human", "ai", "system"] = "ai",
+    actor_type: ActorType = "ai",
     actor_id: str = "ai-assistant",
     conversation_snippet: str | None = None,
     session_id: str | None = None,
@@ -440,7 +463,7 @@ async def trace_log_state_change(
     old_value: Any = None,
     new_value: Any = None,
     reason: str | None = None,
-    actor_type: Literal["human", "ai", "system"] = "ai",
+    actor_type: ActorType = "ai",
     actor_id: str = "ai-assistant",
     session_id: str | None = None,
 ) -> str:
@@ -482,11 +505,11 @@ async def trace_log_state_change(
 @mcp.tool()
 async def trace_propose_decision(
     description: str,
-    proposed_by_type: Literal["human", "ai", "system"],
+    proposed_by_type: ActorType,
     proposed_by_id: str,
     rationale: str | None = None,
     revises_event_id: str | None = None,
-    suggestion_type: Literal["proactive", "requested", "collaborative"] | None = None,
+    suggestion_type: SuggestionType | None = None,
     tags: list[str] | None = None,
     conversation_snippet: str | None = None,
     session_id: str | None = None,
@@ -543,7 +566,7 @@ async def trace_propose_decision(
 async def trace_resolve_decision(
     event_id: str,
     disposition: Literal["accepted", "revised", "rejected"],
-    resolved_by_type: Literal["human", "ai", "system"],
+    resolved_by_type: ActorType,
     resolved_by_id: str,
     revision_note: str | None = None,
     session_id: str | None = None,
@@ -612,8 +635,8 @@ async def trace_get_events(
 @mcp.tool()
 async def trace_get_decisions(
     session_id: str,
-    disposition: Literal["proposed", "accepted", "revised", "rejected"] | None = None,
-    proposed_by_type: Literal["human", "ai", "system"] | None = None,
+    disposition: DecisionDisposition | None = None,
+    proposed_by_type: ActorType | None = None,
 ) -> str:
     """List all decisions in a session, optionally filtered by disposition status and/or proposer type."""
     try:

--- a/src/trace_mcp/server.py
+++ b/src/trace_mcp/server.py
@@ -11,7 +11,7 @@ import json
 import logging
 import os
 import sys
-from typing import Any
+from typing import Any, Literal
 
 from mcp.server.fastmcp import FastMCP
 
@@ -86,7 +86,13 @@ async def _ensure_session(session_id: str | None) -> tuple[Session, str]:
         session = await session_tools.get_or_load_session(
             storage, active_sessions, session_id
         )
-        _current_session_id = session_id
+        # Only an ACTIVE session may become the new current session. An
+        # explicit session_id targeting a completed session (e.g. resolving
+        # a decision proposed in a prior, now-closed session) must not move
+        # the pointer — otherwise every subsequent pointer-less call tries
+        # to append to the completed session and fails.
+        if session.status == "active":
+            _current_session_id = session_id
         return session, ""
 
     # 2. Re-use the current session from earlier in this server process
@@ -276,14 +282,14 @@ async def trace_log_tool_call(
     input: dict[str, Any],
     output: Any = None,
     duration_ms: int | None = None,
-    status: str = "success",
+    status: Literal["success", "error", "timeout"] = "success",
     error_message: str | None = None,
     retries_event_id: str | None = None,
-    actor_type: str = "ai",
+    actor_type: Literal["human", "ai", "system"] = "ai",
     actor_id: str = "ai-assistant",
     reasoning: str | None = None,
     conversation_turn: int | None = None,
-    host: str = "mcp",
+    host: Literal["mcp", "internal", "external"] = "mcp",
     parent_event_id: str | None = None,
     session_id: str | None = None,
 ) -> str:
@@ -334,12 +340,12 @@ async def trace_log_tool_call(
 
 @mcp.tool()
 async def trace_log_annotation(
-    category: str,
+    category: Literal["learning", "gotcha", "observation", "correction", "todo", "question", "discovery", "other"],
     content: str,
     tags: list[str] | None = None,
     corrects_event_ids: list[str] | None = None,
     related_event_ids: list[str] | None = None,
-    actor_type: str = "ai",
+    actor_type: Literal["human", "ai", "system"] = "ai",
     actor_id: str = "ai-assistant",
     conversation_snippet: str | None = None,
     session_id: str | None = None,
@@ -382,12 +388,12 @@ async def trace_log_annotation(
 @mcp.tool()
 async def trace_log_contribution(
     description: str,
-    direction: str,
-    execution: str,
+    direction: Literal["human", "ai", "collaborative"],
+    execution: Literal["human", "ai", "collaborative"],
     artifact: str | None = None,
     related_decision_ids: list[str] | None = None,
     tags: list[str] | None = None,
-    actor_type: str = "ai",
+    actor_type: Literal["human", "ai", "system"] = "ai",
     actor_id: str = "ai-assistant",
     conversation_snippet: str | None = None,
     session_id: str | None = None,
@@ -434,7 +440,7 @@ async def trace_log_state_change(
     old_value: Any = None,
     new_value: Any = None,
     reason: str | None = None,
-    actor_type: str = "ai",
+    actor_type: Literal["human", "ai", "system"] = "ai",
     actor_id: str = "ai-assistant",
     session_id: str | None = None,
 ) -> str:
@@ -476,11 +482,11 @@ async def trace_log_state_change(
 @mcp.tool()
 async def trace_propose_decision(
     description: str,
-    proposed_by_type: str,
+    proposed_by_type: Literal["human", "ai", "system"],
     proposed_by_id: str,
     rationale: str | None = None,
     revises_event_id: str | None = None,
-    suggestion_type: str | None = None,
+    suggestion_type: Literal["proactive", "requested", "collaborative"] | None = None,
     tags: list[str] | None = None,
     conversation_snippet: str | None = None,
     session_id: str | None = None,
@@ -536,8 +542,8 @@ async def trace_propose_decision(
 @mcp.tool()
 async def trace_resolve_decision(
     event_id: str,
-    disposition: str,
-    resolved_by_type: str,
+    disposition: Literal["accepted", "revised", "rejected"],
+    resolved_by_type: Literal["human", "ai", "system"],
     resolved_by_id: str,
     revision_note: str | None = None,
     session_id: str | None = None,
@@ -606,8 +612,8 @@ async def trace_get_events(
 @mcp.tool()
 async def trace_get_decisions(
     session_id: str,
-    disposition: str | None = None,
-    proposed_by_type: str | None = None,
+    disposition: Literal["proposed", "accepted", "revised", "rejected"] | None = None,
+    proposed_by_type: Literal["human", "ai", "system"] | None = None,
 ) -> str:
     """List all decisions in a session, optionally filtered by disposition status and/or proposer type."""
     try:
@@ -712,7 +718,7 @@ async def trace_health_check(
 @mcp.tool()
 async def trace_export(
     session_id: str,
-    format: str,
+    format: Literal["json", "markdown", "prov-jsonld"],
     pretty: bool = True,
 ) -> str:
     """Export a session in a specific format.

--- a/src/trace_mcp/tools/decision_tools.py
+++ b/src/trace_mcp/tools/decision_tools.py
@@ -10,6 +10,12 @@ from trace_mcp.schema import Actor, DecisionData, Session, TraceEvent
 from trace_mcp.storage.base import TraceStorage
 from trace_mcp.tools.session_tools import append_event
 
+# Terminal dispositions a proposed decision may transition to. Validated here
+# (not only via the Literal in the MCP signature) so direct library callers
+# can never write an invalid disposition that bricks the session file on the
+# next load (C1).
+VALID_RESOLUTIONS = ("accepted", "revised", "rejected")
+
 
 async def propose_decision(
     storage: TraceStorage,
@@ -55,7 +61,26 @@ async def resolve_decision(
     resolved_by_id: str,
     revision_note: str | None = None,
 ) -> str:
-    """Resolve a previously proposed decision."""
+    """Resolve a previously proposed decision.
+
+    Integrity guarantees (C1/H1/H2):
+    - *disposition* must be one of ``VALID_RESOLUTIONS`` — rejected up front,
+      and the updated decision is re-validated through Pydantic before any
+      write, so an invalid value can never reach disk.
+    - Only ``proposed`` decisions can be resolved; re-resolving raises with
+      guidance to propose a superseding decision via ``revises_event_id``.
+    - Resolution is the single permitted post-completion mutation: resolving
+      a still-proposed decision in a completed session succeeds but stamps an
+      audit warning on the decision (cross-session resolution is part of the
+      documented decision lifecycle). All writes go to the freshest on-disk
+      session object under the per-session lock.
+    """
+    if disposition not in VALID_RESOLUTIONS:
+        raise ValueError(
+            f"Invalid disposition '{disposition}'. Must be one of {', '.join(VALID_RESOLUTIONS)}. "
+            "Note: 'proposed' is the initial state, not a resolution."
+        )
+
     # Find the decision event
     target = None
     for evt in session.events:
@@ -136,22 +161,47 @@ async def resolve_decision(
     lock_factory = getattr(storage, "lock", None)
     lock_cm = lock_factory(session.id) if lock_factory is not None else nullcontext()
     async with lock_cm:
+        # Write back the disk-loaded object (not the caller's in-memory copy)
+        # so a stale in-memory status/metadata can't clobber disk state —
+        # e.g. resurrect a session completed by another process (H1).
+        write_session = session
         try:
-            disk = await storage.get_session(session.id)
-            session.events = disk.events
+            write_session = await storage.get_session(session.id)
         except FileNotFoundError:
             pass  # session not yet persisted; mutate the in-memory target
         write_target = next(
-            (e for e in session.events if e.id == event_id and e.type == "decision"),
+            (e for e in write_session.events if e.id == event_id and e.type == "decision"),
             None,
         )
         if write_target is None or write_target.decision is None:
             raise ValueError(f"Decision event '{event_id}' not found in session '{session.id}'")
-        write_target.decision.disposition = disposition  # type: ignore[assignment]
-        write_target.decision.resolved_by = resolver
-        write_target.decision.revision_note = revision_note
-        write_target.decision.warnings = guard_warnings
-        await storage.update_session(session)
+        if write_target.decision.disposition != "proposed":
+            raise ValueError(
+                f"Decision '{event_id}' is already resolved "
+                f"(disposition='{write_target.decision.disposition}'). Re-resolution is not "
+                "allowed: propose a new decision with revises_event_id pointing at "
+                f"'{event_id}' and resolve that one instead."
+            )
+        if write_session.status == "completed":
+            guard_warnings.append(
+                "Resolved after session completion. Cross-session resolution of a "
+                "proposed decision is the only permitted post-completion mutation; "
+                "it is recorded here for audit transparency."
+            )
+        updated = write_target.decision.model_copy(
+            update={
+                "disposition": disposition,
+                "resolved_by": resolver,
+                "revision_note": revision_note,
+                "warnings": guard_warnings,
+            }
+        )
+        # Round-trip through validation so an invalid resolution state can
+        # never reach disk and brick the session file on the next load (C1).
+        write_target.decision = DecisionData.model_validate(updated.model_dump())
+        await storage.update_session(write_session)
+        # Keep the caller's in-memory view coherent with what was persisted.
+        session.events = write_session.events
 
     result = f"Decision {event_id} resolved: {disposition}"
     if guard_warnings:

--- a/src/trace_mcp/tools/decision_tools.py
+++ b/src/trace_mcp/tools/decision_tools.py
@@ -5,16 +5,18 @@ from __future__ import annotations
 import os
 from contextlib import nullcontext
 from datetime import UTC, datetime
+from typing import get_args
 
-from trace_mcp.schema import Actor, DecisionData, Session, TraceEvent
+from trace_mcp.schema import Actor, DecisionData, DecisionDisposition, Session, TraceEvent
 from trace_mcp.storage.base import TraceStorage
 from trace_mcp.tools.session_tools import append_event
 
-# Terminal dispositions a proposed decision may transition to. Validated here
-# (not only via the Literal in the MCP signature) so direct library callers
-# can never write an invalid disposition that bricks the session file on the
-# next load (C1).
-VALID_RESOLUTIONS = ("accepted", "revised", "rejected")
+# Terminal dispositions a proposed decision may transition to. Derived from
+# the schema's canonical Literal (minus the initial state) so the two can
+# never drift. Validated here — not only via the Literal in the MCP
+# signature — so direct library callers can never write an invalid
+# disposition that bricks the session file on the next load (C1).
+VALID_RESOLUTIONS = tuple(v for v in get_args(DecisionDisposition) if v != "proposed")
 
 
 async def propose_decision(
@@ -81,124 +83,120 @@ async def resolve_decision(
             "Note: 'proposed' is the initial state, not a resolution."
         )
 
-    # Find the decision event
-    target = None
-    for evt in session.events:
-        if evt.id == event_id and evt.type == "decision":
-            target = evt
-            break
-
-    if target is None:
-        raise ValueError(f"Decision event '{event_id}' not found in session '{session.id}'")
-
-    if target.decision is None:
-        raise ValueError(f"Event '{event_id}' has no decision data")
-
-    # --- Guard rails ---
-    guard_warnings: list[str] = []
+    resolver = Actor(type=resolved_by_type, id=resolved_by_id)  # type: ignore[arg-type]
     suppress = os.environ.get("TRACE_SUPPRESS_SELF_RESOLVE_WARNING", "").lower() == "true"
 
-    # FM1: Same-instance self-resolution
-    # v0.4.1 + Round-3 A1 / evt_016: generalized from ai-only per spec §3.6
-    # Proposer Identity Rule. Detects when the same Actor instance (type AND
-    # id) proposes and resolves. The ai→ai case warns unconditionally; the
-    # generalized non-ai case is gated to multi-actor sessions (see below).
-    proposer = target.decision.proposed_by
-    is_self_resolution = (
-        proposer.type == resolved_by_type
-        and proposer.id == resolved_by_id
-    )
-
-    if is_self_resolution and not suppress:
-        if resolved_by_type == "ai":
-            # Backward-compat message preserved for ai→ai (the original v0.3
-            # case). Fires unconditionally — AI must not resolve its own
-            # proposal regardless of how many actor types the session has.
-            guard_warnings.append(
-                "AI resolved its own proposal. Decisions proposed by AI "
-                "should normally be resolved by a human."
-            )
-        elif session.is_multi_actor():
-            # v0.4.1 + Round-3 A1 / evt_016: the evt_025 pattern —
-            # human→human (or system→system) same-instance self-resolution.
-            # Gated to multi-actor sessions (≥2 actor types): in a
-            # single-actor session this is legitimate, not an attribution
-            # concern (the false positive A1 named with production data).
-            guard_warnings.append(
-                "Same actor instance proposed and resolved this decision. "
-                "Per spec §3.6, in multi-actor workflows the proposer should "
-                "differ from the resolver."
-            )
-
-    # FM25: Suspiciously fast resolution (propose + resolve <5s by same
-    # instance). ai→ai always warns (fast AI self-resolution is suspicious
-    # regardless of actor count); the general non-ai case is gated to
-    # multi-actor sessions, mirroring FM1 (Round-3 amendment A-R3-1 — without
-    # this split, gating FM25 wholesale would silently drop the §3-correct
-    # ai→ai FM25 warning).
-    elapsed = (datetime.now(UTC) - target.timestamp).total_seconds()
-    if elapsed < 5.0 and is_self_resolution and not suppress:
-        if resolved_by_type == "ai" or session.is_multi_actor():
-            guard_warnings.append(
-                f"Decision proposed and self-resolved in {elapsed:.1f}s. "
-                "Was the other actor consulted before resolving?"
-            )
-
-    # FM31: Rejection -> suggest correction annotation
-    if disposition == "rejected":
-        guard_warnings.append(
-            "Decision rejected. Consider logging a correction annotation "
-            "(category='correction') linking to this decision, to capture "
-            "the reasoning in the knowledge store."
-        )
-
-    resolver = Actor(type=resolved_by_type, id=resolved_by_id)  # type: ignore[arg-type]
-
-    # Concurrency-safe write (symmetry with append_event / end_session): reload
-    # the authoritative on-disk events under the per-session lock and re-find the
-    # target there, so a concurrent append/resolve persisted since this Session
-    # was read is not clobbered by this write.
+    # Concurrency-safe write (symmetry with append_event / end_session): all
+    # reads, guard-rail computation, and the write happen under the per-session
+    # lock against the authoritative on-disk session, so a concurrent
+    # append/resolve persisted since the caller loaded its Session is neither
+    # clobbered nor judged from stale state (e.g. is_multi_actor on a copy
+    # that is missing a concurrently-appended actor).
     lock_factory = getattr(storage, "lock", None)
     lock_cm = lock_factory(session.id) if lock_factory is not None else nullcontext()
     async with lock_cm:
         # Write back the disk-loaded object (not the caller's in-memory copy)
         # so a stale in-memory status/metadata can't clobber disk state —
         # e.g. resurrect a session completed by another process (H1).
-        write_session = session
         try:
             write_session = await storage.get_session(session.id)
         except FileNotFoundError:
-            pass  # session not yet persisted; mutate the in-memory target
-        write_target = next(
+            write_session = session  # not yet persisted; in-memory is authoritative
+        target = next(
             (e for e in write_session.events if e.id == event_id and e.type == "decision"),
             None,
         )
-        if write_target is None or write_target.decision is None:
+        if target is None:
             raise ValueError(f"Decision event '{event_id}' not found in session '{session.id}'")
-        if write_target.decision.disposition != "proposed":
+        if target.decision is None:
+            raise ValueError(f"Event '{event_id}' has no decision data")
+        if target.decision.disposition != "proposed":
             raise ValueError(
                 f"Decision '{event_id}' is already resolved "
-                f"(disposition='{write_target.decision.disposition}'). Re-resolution is not "
-                "allowed: propose a new decision with revises_event_id pointing at "
-                f"'{event_id}' and resolve that one instead."
+                f"(disposition='{target.decision.disposition}'), possibly by a concurrent "
+                "or earlier call. Re-resolution is not allowed: to supersede it, propose "
+                f"a new decision with revises_event_id pointing at '{event_id}' and "
+                "resolve that one instead."
             )
+
+        # --- Guard rails (computed from the authoritative disk state) ---
+        guard_warnings: list[str] = []
+
+        # FM1: Same-instance self-resolution
+        # v0.4.1 + Round-3 A1 / evt_016: generalized from ai-only per spec §3.6
+        # Proposer Identity Rule. Detects when the same Actor instance (type AND
+        # id) proposes and resolves. The ai→ai case warns unconditionally; the
+        # generalized non-ai case is gated to multi-actor sessions (see below).
+        proposer = target.decision.proposed_by
+        is_self_resolution = (
+            proposer.type == resolved_by_type
+            and proposer.id == resolved_by_id
+        )
+
+        if is_self_resolution and not suppress:
+            if resolved_by_type == "ai":
+                # Backward-compat message preserved for ai→ai (the original v0.3
+                # case). Fires unconditionally — AI must not resolve its own
+                # proposal regardless of how many actor types the session has.
+                guard_warnings.append(
+                    "AI resolved its own proposal. Decisions proposed by AI "
+                    "should normally be resolved by a human."
+                )
+            elif write_session.is_multi_actor():
+                # v0.4.1 + Round-3 A1 / evt_016: the evt_025 pattern —
+                # human→human (or system→system) same-instance self-resolution.
+                # Gated to multi-actor sessions (≥2 actor types): in a
+                # single-actor session this is legitimate, not an attribution
+                # concern (the false positive A1 named with production data).
+                guard_warnings.append(
+                    "Same actor instance proposed and resolved this decision. "
+                    "Per spec §3.6, in multi-actor workflows the proposer should "
+                    "differ from the resolver."
+                )
+
+        # FM25: Suspiciously fast resolution (propose + resolve <5s by same
+        # instance). ai→ai always warns (fast AI self-resolution is suspicious
+        # regardless of actor count); the general non-ai case is gated to
+        # multi-actor sessions, mirroring FM1 (Round-3 amendment A-R3-1 — without
+        # this split, gating FM25 wholesale would silently drop the §3-correct
+        # ai→ai FM25 warning).
+        if is_self_resolution and not suppress:
+            elapsed = (datetime.now(UTC) - target.timestamp).total_seconds()
+            if elapsed < 5.0 and (resolved_by_type == "ai" or write_session.is_multi_actor()):
+                guard_warnings.append(
+                    f"Decision proposed and self-resolved in {elapsed:.1f}s. "
+                    "Was the other actor consulted before resolving?"
+                )
+
+        # FM31: Rejection -> suggest correction annotation
+        if disposition == "rejected":
+            guard_warnings.append(
+                "Decision rejected. Consider logging a correction annotation "
+                "(category='correction') linking to this decision, to capture "
+                "the reasoning in the knowledge store."
+            )
+
         if write_session.status == "completed":
             guard_warnings.append(
                 "Resolved after session completion. Cross-session resolution of a "
                 "proposed decision is the only permitted post-completion mutation; "
                 "it is recorded here for audit transparency."
             )
-        updated = write_target.decision.model_copy(
-            update={
+
+        # Single validated construction (model_copy skips validation in
+        # Pydantic v2, so the model_validate round-trip IS the C1 guarantee:
+        # an invalid resolution state can never reach disk and brick the
+        # session file on the next load). Existing warnings are preserved,
+        # not clobbered.
+        target.decision = DecisionData.model_validate(
+            {
+                **target.decision.model_dump(),
                 "disposition": disposition,
-                "resolved_by": resolver,
+                "resolved_by": resolver.model_dump(),
                 "revision_note": revision_note,
-                "warnings": guard_warnings,
+                "warnings": [*target.decision.warnings, *guard_warnings],
             }
         )
-        # Round-trip through validation so an invalid resolution state can
-        # never reach disk and brick the session file on the next load (C1).
-        write_target.decision = DecisionData.model_validate(updated.model_dump())
         await storage.update_session(write_session)
         # Keep the caller's in-memory view coherent with what was persisted.
         session.events = write_session.events

--- a/tests/test_decision_integrity.py
+++ b/tests/test_decision_integrity.py
@@ -178,6 +178,32 @@ class TestH1PostCompletionResolution:
         assert reloaded.status == "completed"
 
 
+class TestWarningsPreserved:
+    async def test_resolution_merges_existing_warnings(self, storage, active):
+        """Warnings already on the decision must survive resolution, not be clobbered."""
+        session, event_id = await _session_with_proposal(storage, active)
+        # Simulate a proposal-time warning persisted by an earlier writer.
+        disk = await storage.get_session(session.id)
+        evt = next(e for e in disk.events if e.id == event_id)
+        assert evt.decision is not None
+        evt.decision.warnings = ["pre-existing proposal warning"]
+        await storage.update_session(disk)
+
+        await decision_tools.resolve_decision(
+            storage,
+            session,
+            event_id=event_id,
+            disposition="rejected",
+            resolved_by_type="human",
+            resolved_by_id="human",
+            revision_note="not needed",
+        )
+        reloaded = await storage.get_session(session.id)
+        warnings = next(e for e in reloaded.events if e.id == event_id).decision.warnings
+        assert "pre-existing proposal warning" in warnings
+        assert any("Decision rejected" in w for w in warnings)  # FM31 added too
+
+
 class TestCurrentSessionPointerGuard:
     async def test_completed_session_does_not_become_current(
         self, storage, active, monkeypatch
@@ -208,6 +234,54 @@ class TestCurrentSessionPointerGuard:
         looked_up, _ = await server._ensure_session(session.id)
         assert looked_up.id == session.id
         assert server._current_session_id == session.id
+
+    async def test_stale_cached_active_but_disk_completed_does_not_move_pointer(
+        self, storage, active, monkeypatch
+    ):
+        """Pointer guard must trust disk status, not the in-memory cache."""
+        from trace_mcp import server
+
+        session, _ = await _session_with_proposal(storage, active)
+        # Another process completes the session on disk; this process's cache
+        # still holds the stale 'active' object.
+        await session_tools.end_session(storage, {}, session_id=session.id)
+        assert active[session.id].status == "active"  # stale by construction
+
+        monkeypatch.setattr(server, "storage", storage)
+        monkeypatch.setattr(server, "active_sessions", active)
+        monkeypatch.setattr(server, "_current_session_id", "sentinel-current")
+
+        looked_up, _ = await server._ensure_session(session.id)
+        assert looked_up.id == session.id
+        assert server._current_session_id == "sentinel-current"
+
+    async def test_completed_current_session_falls_through_to_autocreate(
+        self, storage, active, monkeypatch
+    ):
+        """A completed current session must not wedge pointer-less calls."""
+        from trace_mcp import server
+
+        session, _ = await _session_with_proposal(storage, active)
+        await session_tools.end_session(storage, active, session_id=session.id)
+
+        monkeypatch.setattr(server, "storage", storage)
+        monkeypatch.setattr(server, "active_sessions", active)
+        monkeypatch.setattr(server, "_current_session_id", session.id)
+
+        async def _fake_infer_project() -> str:
+            return "integrity-test"
+
+        async def _no_recall(*args, **kwargs):
+            return []
+
+        monkeypatch.setattr(server, "_infer_project", _fake_infer_project)
+        monkeypatch.setattr(server.hooks, "recall_if_available", _no_recall)
+
+        fresh, auto_msg = await server._ensure_session(None)
+        assert fresh.id != session.id
+        assert fresh.status == "active"
+        assert "Auto-created TRACE session" in auto_msg
+        assert server._current_session_id == fresh.id
 
 
 class TestLiteralSignatureSweep:

--- a/tests/test_decision_integrity.py
+++ b/tests/test_decision_integrity.py
@@ -1,0 +1,270 @@
+"""Regression tests for the decision-integrity cluster (PR #10).
+
+Covers the 2026-06-10 status-review findings:
+
+- C1: an invalid disposition must be rejected before any write, and the
+  on-disk session file must remain loadable afterwards (previously a raw
+  string like "approved" was assigned past Pydantic validation, permanently
+  bricking the session file on the next load).
+- H2: re-resolving an already-resolved decision must be refused with
+  guidance to propose a superseding decision via ``revises_event_id``.
+- H1: resolution of a still-proposed decision is the single permitted
+  post-completion mutation — allowed on completed sessions but stamped with
+  an audit warning, written back to the freshest disk object (a stale
+  in-memory copy must not resurrect a completed session).
+- Pointer guard: an explicit ``session_id`` pointing at a completed session
+  must not move the server's current-session pointer.
+- Literal sweep: enum-ish MCP tool params are ``Literal``-typed so invalid
+  values are rejected at the protocol edge.
+"""
+
+from __future__ import annotations
+
+import typing
+from pathlib import Path
+
+import pytest
+
+from trace_mcp.schema import Session
+from trace_mcp.storage.json_file import JsonFileStorage
+from trace_mcp.tools import decision_tools, session_tools
+
+
+@pytest.fixture
+def storage(tmp_path: Path) -> JsonFileStorage:
+    return JsonFileStorage(directory=str(tmp_path))
+
+
+@pytest.fixture
+def active() -> dict[str, Session]:
+    return {}
+
+
+async def _session_with_proposal(
+    storage: JsonFileStorage, active: dict[str, Session]
+) -> tuple[Session, str]:
+    """Create a session containing one proposed decision; return (session, event_id)."""
+    session = await session_tools.create_session(
+        storage, active, project="integrity-test", description="decision integrity"
+    )
+    event_id = await decision_tools.propose_decision(
+        storage,
+        session,
+        description="Use approach X",
+        rationale="It is simplest",
+        proposed_by_type="ai",
+        proposed_by_id="claude",
+        suggestion_type="proactive",
+    )
+    return session, event_id
+
+
+class TestC1InvalidDisposition:
+    async def test_invalid_disposition_rejected(self, storage, active):
+        session, event_id = await _session_with_proposal(storage, active)
+        with pytest.raises(ValueError, match="Invalid disposition 'approved'"):
+            await decision_tools.resolve_decision(
+                storage,
+                session,
+                event_id=event_id,
+                disposition="approved",
+                resolved_by_type="human",
+                resolved_by_id="human",
+            )
+
+    async def test_proposed_is_not_a_resolution(self, storage, active):
+        session, event_id = await _session_with_proposal(storage, active)
+        with pytest.raises(ValueError, match="'proposed' is the initial state"):
+            await decision_tools.resolve_decision(
+                storage,
+                session,
+                event_id=event_id,
+                disposition="proposed",
+                resolved_by_type="human",
+                resolved_by_id="human",
+            )
+
+    async def test_session_file_loadable_after_rejected_write(self, storage, active):
+        """The C1 data-loss scenario: file must stay loadable after the attempt."""
+        session, event_id = await _session_with_proposal(storage, active)
+        with pytest.raises(ValueError):
+            await decision_tools.resolve_decision(
+                storage,
+                session,
+                event_id=event_id,
+                disposition="approved",
+                resolved_by_type="human",
+                resolved_by_id="human",
+            )
+        reloaded = await storage.get_session(session.id)  # must not raise
+        decision_evt = next(e for e in reloaded.events if e.id == event_id)
+        assert decision_evt.decision is not None
+        assert decision_evt.decision.disposition == "proposed"
+
+
+class TestH2ReResolution:
+    async def test_re_resolution_refused(self, storage, active):
+        session, event_id = await _session_with_proposal(storage, active)
+        await decision_tools.resolve_decision(
+            storage,
+            session,
+            event_id=event_id,
+            disposition="accepted",
+            resolved_by_type="human",
+            resolved_by_id="human",
+        )
+        with pytest.raises(ValueError, match="already resolved.*revises_event_id"):
+            await decision_tools.resolve_decision(
+                storage,
+                session,
+                event_id=event_id,
+                disposition="rejected",
+                resolved_by_type="human",
+                resolved_by_id="human",
+                revision_note="changed my mind",
+            )
+        reloaded = await storage.get_session(session.id)
+        decision_evt = next(e for e in reloaded.events if e.id == event_id)
+        assert decision_evt.decision is not None
+        assert decision_evt.decision.disposition == "accepted"
+
+
+class TestH1PostCompletionResolution:
+    async def test_resolve_proposed_in_completed_session_allowed_with_warning(
+        self, storage, active
+    ):
+        """Cross-session resolution (the documented decision lifecycle) keeps working."""
+        session, event_id = await _session_with_proposal(storage, active)
+        await session_tools.end_session(storage, active, session_id=session.id)
+
+        # Fresh load, as a later session/process would see it.
+        later = await storage.get_session(session.id)
+        result = await decision_tools.resolve_decision(
+            storage,
+            later,
+            event_id=event_id,
+            disposition="accepted",
+            resolved_by_type="human",
+            resolved_by_id="human",
+        )
+        assert "resolved: accepted" in result
+
+        reloaded = await storage.get_session(session.id)
+        assert reloaded.status == "completed"  # resolution must not resurrect it
+        decision_evt = next(e for e in reloaded.events if e.id == event_id)
+        assert decision_evt.decision is not None
+        assert decision_evt.decision.disposition == "accepted"
+        assert any("after session completion" in w for w in decision_evt.decision.warnings)
+
+    async def test_stale_in_memory_copy_cannot_resurrect_completed_session(
+        self, storage, active
+    ):
+        """The write must target the disk object, not the caller's stale copy."""
+        session, event_id = await _session_with_proposal(storage, active)
+        # Another process completes the session; our in-memory copy still says active.
+        await session_tools.end_session(storage, {}, session_id=session.id)
+        assert session.status == "active"  # stale by construction
+
+        await decision_tools.resolve_decision(
+            storage,
+            session,
+            event_id=event_id,
+            disposition="rejected",
+            resolved_by_type="human",
+            resolved_by_id="human",
+            revision_note="not needed",
+        )
+        reloaded = await storage.get_session(session.id)
+        assert reloaded.status == "completed"
+
+
+class TestCurrentSessionPointerGuard:
+    async def test_completed_session_does_not_become_current(
+        self, storage, active, monkeypatch
+    ):
+        """Explicit session_id to a completed session must not move the pointer."""
+        from trace_mcp import server
+
+        session, _ = await _session_with_proposal(storage, active)
+        await session_tools.end_session(storage, active, session_id=session.id)
+
+        monkeypatch.setattr(server, "storage", storage)
+        monkeypatch.setattr(server, "active_sessions", active)
+        monkeypatch.setattr(server, "_current_session_id", "sentinel-current")
+
+        looked_up, _ = await server._ensure_session(session.id)
+        assert looked_up.id == session.id
+        assert server._current_session_id == "sentinel-current"
+
+    async def test_active_session_does_become_current(self, storage, active, monkeypatch):
+        from trace_mcp import server
+
+        session, _ = await _session_with_proposal(storage, active)
+
+        monkeypatch.setattr(server, "storage", storage)
+        monkeypatch.setattr(server, "active_sessions", active)
+        monkeypatch.setattr(server, "_current_session_id", None)
+
+        looked_up, _ = await server._ensure_session(session.id)
+        assert looked_up.id == session.id
+        assert server._current_session_id == session.id
+
+
+class TestLiteralSignatureSweep:
+    """Enum-ish MCP tool params must be Literal-typed at the protocol edge."""
+
+    @pytest.mark.parametrize(
+        ("tool_name", "param", "expected_values"),
+        [
+            ("trace_resolve_decision", "disposition", {"accepted", "revised", "rejected"}),
+            ("trace_resolve_decision", "resolved_by_type", {"human", "ai", "system"}),
+            ("trace_propose_decision", "proposed_by_type", {"human", "ai", "system"}),
+            (
+                "trace_propose_decision",
+                "suggestion_type",
+                {"proactive", "requested", "collaborative", None},
+            ),
+            (
+                "trace_log_annotation",
+                "category",
+                {
+                    "learning",
+                    "gotcha",
+                    "observation",
+                    "correction",
+                    "todo",
+                    "question",
+                    "discovery",
+                    "other",
+                },
+            ),
+            ("trace_log_contribution", "direction", {"human", "ai", "collaborative"}),
+            ("trace_log_contribution", "execution", {"human", "ai", "collaborative"}),
+            ("trace_log_tool_call", "status", {"success", "error", "timeout"}),
+            ("trace_log_tool_call", "host", {"mcp", "internal", "external"}),
+            ("trace_export", "format", {"json", "markdown", "prov-jsonld"}),
+        ],
+    )
+    def test_param_is_literal(self, tool_name: str, param: str, expected_values: set):
+        from trace_mcp import server
+
+        fn = getattr(server, tool_name)
+        fn = getattr(fn, "fn", fn)  # unwrap FastMCP tool object if needed
+        hints = typing.get_type_hints(fn)
+        assert param in hints, f"{tool_name} has no parameter '{param}'"
+        literal_values: set = set()
+        if typing.get_origin(hints[param]) is typing.Literal:
+            literal_values = set(typing.get_args(hints[param]))
+        else:  # Literal[...] | None (or other unions of Literals)
+            for arg in typing.get_args(hints[param]):
+                if arg is type(None):
+                    literal_values.add(None)
+                else:
+                    assert typing.get_origin(arg) is typing.Literal, (
+                        f"{tool_name}.{param} union member {arg!r} is not a Literal"
+                    )
+                    literal_values.update(typing.get_args(arg))
+        assert literal_values == expected_values, (
+            f"{tool_name}.{param}: expected Literal{sorted(map(str, expected_values))}, "
+            f"got {hints[param]!r}"
+        )


### PR DESCRIPTION
## Summary

First PR of the accepted 2026-06-10 biggest-wins plan (PR A, integrity cluster). Fixes the three verified integrity findings from the status review plus the Literal sweep, and one bonus bug found live during implementation.

- **C1 — validated dispositions**: `trace_resolve_decision` previously assigned a raw string past Pydantic validation (`decision_tools.py` assignment-bypass); a near-miss like `"approved"` permanently bricked the session file on the next load. Now: `Literal` at the MCP edge, `ValueError` in core for direct library callers, and a full `DecisionData.model_validate` round-trip before any write.
- **H1 — completed-session safety**: the locked write span now writes back the **disk-loaded** session object, so a stale in-memory copy can't resurrect a completed session. Design choice (logged as a TRACE decision): resolution of a still-*proposed* decision remains allowed on completed sessions — cross-session resolution is the documented decision lifecycle (proposals are routinely resolved by the human after the session closes) — but it now stamps an audit warning on the decision. Strict mirroring of append/end immutability was considered and rejected for that reason.
- **H2 — no re-resolution**: resolving an already-resolved decision is refused with an instructive error pointing at `revises_event_id`.
- **Bonus — current-session pointer guard**: an explicit `session_id` targeting a completed session no longer moves the server's current-session pointer (previously, resolving a decision in a closed prior session wedged every subsequent pointer-less call; observed live).
- **Literal sweep**: `category`, `direction`, `execution`, `suggestion_type`, `host`, `status`, `actor_type`, `proposed_by_type`/`resolved_by_type`, `trace_get_decisions` filters, `trace_export.format`.

Deferred (follow-up, not regression-risk-free under this PR's scope): the shared `_locked_disk_session` helper across append/end/resolve — each site has a different status policy.

## Tests

- 18 new regression tests in `tests/test_decision_integrity.py` (C1 brick-scenario, H2, post-completion resolution + warning, stale-copy resurrection, pointer guard, Literal signature sweep).
- Full suite: 902 passed. 3 local-only failures are pre-existing PR C scope: 1 known `.env`-induced config test, 2 `TestRealDataEmbeddings` tests that hard-code learning IDs against the developer's personal `~/.trace/knowledge/TRACE.json` (skipped in CI; the store legitimately changed during today's learn-extraction recovery).
- `ruff` clean, `pyright` 0 errors on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)