### PR TITLE
test(hygiene): PR C — isolate the suite from real ~/.trace data, gate real-data tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ venv.bak/
 .pytest_cache/
 .coverage
 .coverage.*
+.coverage *
 coverage.xml
 htmlcov/
 .tox/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,18 +41,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Test-suite hygiene: the suite is now fully isolated from the developer's
-  real `~/.trace` data.** A root conftest points `TRACE_KNOWLEDGE_DIR` and
-  `TRACE_SESSIONS_DIR` at per-run temp directories (previously, tests that
-  forgot an explicit directory deposited `e2e-*`/`fm-test`/`guard-e2e`/
-  `export-test` stores into the real knowledge dir), config tests no longer
-  read a real `./.env`, and the real-data integration tests are opt-in via
-  `TRACE_REAL_DATA_TESTS=1` (registered `real_data` marker). The suite is
-  deterministic on any machine — contributors no longer see failures caused
-  by the maintainer's personal data. `LearnConfig.openai_api_key` is
-  `repr=False` so the key cannot leak into pytest output or logs;
-  uvx-dependent installation checks skip instead of failing when uv isn't
-  installed.
+- **Test-suite hygiene: the default suite no longer reads or writes the
+  developer's real `~/.trace` data.** A root conftest points
+  `TRACE_KNOWLEDGE_DIR`, `TRACE_SESSIONS_DIR`, and `TRACE_SCRATCHPAD_DIR` at
+  per-run temp directories, set in `pytest_configure` so even module-level
+  imports during collection resolve the isolated paths. Previously, suite
+  runs deposited `e2e-*`/`fm-test`/`guard-e2e`/`export-test` stores into the
+  real knowledge dir and **overwrote the developer's real
+  `.claude/SCRATCHPAD.md` on every run** (session-end scratchpads from e2e
+  server subprocesses). All four real-data test classes
+  (`TestRealDataEmbeddings`, `TestRealDataE2E`, `TestRealSessionDataIntegrity`,
+  `TestCrossProjectConsistency`) are opt-in via `TRACE_REAL_DATA_TESTS=1` — the
+  registered `real_data` marker is load-bearing (a conftest collection hook
+  skips marked tests unless opted in, so a class can't forget its gate), and
+  their recall expectations are derived from store content at runtime instead
+  of pinned learning IDs, so personal-store drift can't fail them. Config
+  tests that need key-absence scrub the env var, `~/.trace/.env`, **and** the
+  checkout's `./.env`; the real-LLM integration tests intentionally still
+  read the developer's real key. `LearnConfig.openai_api_key` is `repr=False`
+  so the key cannot leak into pytest output or logs; the uvx installation
+  check (`test_mcp_json_command_resolves`) skips instead of failing when uv
+  isn't installed.
 
 ## [0.4.2] — 2026-06-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `[all]`. A missing dependency now produces an install hint instead of a
   stack trace.
 
+### Changed
+
+- **Test-suite hygiene: the suite is now fully isolated from the developer's
+  real `~/.trace` data.** A root conftest points `TRACE_KNOWLEDGE_DIR` and
+  `TRACE_SESSIONS_DIR` at per-run temp directories (previously, tests that
+  forgot an explicit directory deposited `e2e-*`/`fm-test`/`guard-e2e`/
+  `export-test` stores into the real knowledge dir), config tests no longer
+  read a real `./.env`, and the real-data integration tests are opt-in via
+  `TRACE_REAL_DATA_TESTS=1` (registered `real_data` marker). The suite is
+  deterministic on any machine — contributors no longer see failures caused
+  by the maintainer's personal data. `LearnConfig.openai_api_key` is
+  `repr=False` so the key cannot leak into pytest output or logs;
+  uvx-dependent installation checks skip instead of failing when uv isn't
+  installed.
+
 ## [0.4.2] — 2026-06-01
 
 > **Crash-surface + publication-hardening release.** Reduces TRACE's contribution to a Claude Code extended-thinking API-400 (a *client-side* signed-thinking-block re-serialization bug that TRACE cannot fix — only avoid triggering), fixes a critical storage data-loss bug, caps query payloads, and makes the package safe and ready to publish. The upstream client report is in `docs/upstream-claude-code-thinking-block-400.md`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -183,6 +183,9 @@ testpaths = ["tests"]
 pythonpath = ["src"]
 addopts = "-v --tb=short"
 asyncio_mode = "auto"
+markers = [
+    "real_data: reads the developer's real ~/.trace data; skipped unless TRACE_REAL_DATA_TESTS=1",
+]
 
 # NB: pyright is configured in the standalone pyrightconfig.json (include
 # src+tests+scripts), which takes precedence over any [tool.pyright] here. A

--- a/src/trace_mcp/extensions/learn/config.py
+++ b/src/trace_mcp/extensions/learn/config.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import logging
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -71,7 +71,9 @@ class LLMFallbackError(RuntimeError):
 class LearnConfig:
     """Configuration for trace-learn matching and extraction backends."""
 
-    openai_api_key: str | None = None
+    # repr=False: the key must never leak into pytest failure output, logs,
+    # or debugger dumps (all of which render the dataclass repr).
+    openai_api_key: str | None = field(default=None, repr=False)
     llm_model: str = "gpt-5.4-mini"
     llm_extraction_model: str = "gpt-5.4-mini"
     llm_enabled: bool = True

--- a/src/trace_mcp/extensions/learn/config.py
+++ b/src/trace_mcp/extensions/learn/config.py
@@ -72,7 +72,9 @@ class LearnConfig:
     """Configuration for trace-learn matching and extraction backends."""
 
     # repr=False: the key must never leak into pytest failure output, logs,
-    # or debugger dumps (all of which render the dataclass repr).
+    # or debugger dumps (all of which render the dataclass repr). It remains
+    # reachable via direct attribute access and dataclasses.asdict() — code
+    # and tests must never log/assert on a real key value through those.
     openai_api_key: str | None = field(default=None, repr=False)
     llm_model: str = "gpt-5.4-mini"
     llm_extraction_model: str = "gpt-5.4-mini"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,45 @@
+"""Root conftest: isolate the whole suite from the developer's real ~/.trace.
+
+TRACE_KNOWLEDGE_DIR and TRACE_SESSIONS_DIR are pointed at per-run temp
+directories for every test, so a test that forgets to pass an explicit
+directory cannot read from or write into real stores. (Before this existed,
+the real ~/.trace/knowledge accumulated fm-test*, e2e-*, guard-e2e*, and
+export-test stores from exactly that leak.) Guarded by
+tests/test_env_isolation.py.
+
+Tests that intentionally target real data must opt in explicitly and pass the
+real path themselves — see TestRealDataEmbeddings (TRACE_REAL_DATA_TESTS=1).
+
+Side effects: mutates os.environ for the pytest session (restored on exit).
+Subprocesses spawned by tests inherit the isolation automatically.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+
+import pytest
+
+_ISOLATED_VARS = ("TRACE_KNOWLEDGE_DIR", "TRACE_SESSIONS_DIR")
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _isolate_trace_env(tmp_path_factory: pytest.TempPathFactory) -> Iterator[None]:
+    """Point TRACE data-directory env vars at per-run temp dirs (session-wide).
+
+    Session-scoped because the built-in monkeypatch fixture is function-scoped;
+    saves and restores any pre-existing values.
+    """
+    previous = {name: os.environ.get(name) for name in _ISOLATED_VARS}
+    base = tmp_path_factory.mktemp("trace-isolated")
+    os.environ["TRACE_KNOWLEDGE_DIR"] = str(base / "knowledge")
+    os.environ["TRACE_SESSIONS_DIR"] = str(base / "sessions")
+    try:
+        yield
+    finally:
+        for name, value in previous.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,45 +1,102 @@
-"""Root conftest: isolate the whole suite from the developer's real ~/.trace.
+"""Root conftest: isolate the suite from the developer's real ~/.trace data.
 
-TRACE_KNOWLEDGE_DIR and TRACE_SESSIONS_DIR are pointed at per-run temp
-directories for every test, so a test that forgets to pass an explicit
-directory cannot read from or write into real stores. (Before this existed,
-the real ~/.trace/knowledge accumulated fm-test*, e2e-*, guard-e2e*, and
-export-test stores from exactly that leak.) Guarded by
-tests/test_env_isolation.py.
+Two mechanisms:
 
-Tests that intentionally target real data must opt in explicitly and pass the
-real path themselves — see TestRealDataEmbeddings (TRACE_REAL_DATA_TESTS=1).
+1. **Data-directory isolation** — TRACE_KNOWLEDGE_DIR, TRACE_SESSIONS_DIR, and
+   TRACE_SCRATCHPAD_DIR point at a per-run temp directory, set in
+   ``pytest_configure`` (NOT a fixture: ``server.py`` binds a module-level
+   ``JsonFileStorage()`` at import, which happens during collection — before
+   any session fixture runs). Subprocesses spawned by tests inherit the
+   isolation via os.environ. Before this existed, suite runs deposited
+   fm-test*/e2e-*/guard-e2e* stores into the real ~/.trace/knowledge and
+   overwrote the developer's real .claude/SCRATCHPAD.md on every run.
+   Guarded by tests/test_env_isolation.py.
 
-Side effects: mutates os.environ for the pytest session (restored on exit).
-Subprocesses spawned by tests inherit the isolation automatically.
+2. **Opt-in gate for real-data tests** — any test or class marked
+   ``@pytest.mark.real_data`` is skipped unless TRACE_REAL_DATA_TESTS is set
+   to 1/true/yes. The marker is load-bearing (enforced here by
+   ``pytest_collection_modifyitems``), so a marked class cannot forget its
+   skipif. Marked tests must pass real paths explicitly — the env defaults
+   point at the isolated temp dirs.
+
+Deliberately NOT isolated: the trace-learn ``.env`` lookup
+(``~/.trace/.env`` / ``./.env``). The real-LLM integration tests intentionally
+read the developer's real key; config tests that need key-absence scrub all
+three sources themselves (env var + _TRACE_ENV_PATH + monkeypatch.chdir).
+
+Side effects: mutates os.environ for the pytest run (restored in
+pytest_unconfigure); creates a temp directory that outlives the run.
 """
 
 from __future__ import annotations
 
 import os
-from collections.abc import Iterator
+import tempfile
+from pathlib import Path
 
 import pytest
 
-_ISOLATED_VARS = ("TRACE_KNOWLEDGE_DIR", "TRACE_SESSIONS_DIR")
+_ISOLATED_VARS = ("TRACE_KNOWLEDGE_DIR", "TRACE_SESSIONS_DIR", "TRACE_SCRATCHPAD_DIR")
+_REAL_DATA_ENV = "TRACE_REAL_DATA_TESTS"
+_previous_env: dict[str, str | None] = {}
 
 
-@pytest.fixture(scope="session", autouse=True)
-def _isolate_trace_env(tmp_path_factory: pytest.TempPathFactory) -> Iterator[None]:
-    """Point TRACE data-directory env vars at per-run temp dirs (session-wide).
+def real_data_opted_in() -> bool:
+    """True when the operator explicitly opted into real-data tests."""
+    return os.environ.get(_REAL_DATA_ENV, "").strip().lower() in {"1", "true", "yes"}
 
-    Session-scoped because the built-in monkeypatch fixture is function-scoped;
-    saves and restores any pre-existing values.
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Point TRACE data-dir env vars at a per-run temp dir before collection.
+
+    Side effect: mutates os.environ (restored in pytest_unconfigure).
     """
-    previous = {name: os.environ.get(name) for name in _ISOLATED_VARS}
-    base = tmp_path_factory.mktemp("trace-isolated")
-    os.environ["TRACE_KNOWLEDGE_DIR"] = str(base / "knowledge")
-    os.environ["TRACE_SESSIONS_DIR"] = str(base / "sessions")
-    try:
-        yield
-    finally:
-        for name, value in previous.items():
-            if value is None:
-                os.environ.pop(name, None)
-            else:
-                os.environ[name] = value
+    base = Path(tempfile.mkdtemp(prefix="trace-isolated-"))
+    for name, sub in zip(_ISOLATED_VARS, ("knowledge", "sessions", "scratchpads"), strict=True):
+        _previous_env[name] = os.environ.get(name)
+        os.environ[name] = str(base / sub)
+
+
+def pytest_unconfigure(config: pytest.Config) -> None:
+    """Restore any pre-existing values of the isolated env vars."""
+    for name, value in _previous_env.items():
+        if value is None:
+            os.environ.pop(name, None)
+        else:
+            os.environ[name] = value
+    _previous_env.clear()
+
+
+def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
+    """Fail the run loudly if any test broke the isolation contract.
+
+    A test that deletes one of the isolated vars (e.g. a bare
+    ``os.environ.pop`` in a finally block instead of monkeypatch) silently
+    disables isolation for every test that runs after it — that exact bug let
+    e2e session-ends overwrite the developer's real .claude/SCRATCHPAD.md.
+    The guard tests in test_env_isolation.py run early and cannot see a
+    later deletion; this hook checks at the end of the run.
+    """
+    broken = [name for name in _ISOLATED_VARS if name not in os.environ]
+    if broken:
+        session.exitstatus = pytest.ExitCode.TESTS_FAILED
+        print(
+            f"\nERROR: isolation env var(s) {broken} were DELETED during the run — "
+            "some test used os.environ.pop/del instead of monkeypatch; tests that ran "
+            "after it executed without ~/.trace isolation."
+        )
+
+
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+    """Enforce the real_data marker: skip unless explicitly opted in."""
+    if real_data_opted_in():
+        return
+    skip = pytest.mark.skip(
+        reason=(
+            "reads the developer's real ~/.trace data (contents drift with personal "
+            "machine state) — opt in with TRACE_REAL_DATA_TESTS=1"
+        )
+    )
+    for item in items:
+        if "real_data" in item.keywords:
+            item.add_marker(skip)

--- a/tests/test_adapter_hooks.py
+++ b/tests/test_adapter_hooks.py
@@ -394,9 +394,14 @@ class TestPreToolGuard:
 
 
 @pytest.fixture(autouse=True)
-def _no_user_env_leak(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Don't let the developer's real ~/.trace/ sneak into test runs."""
-    monkeypatch.delenv("TRACE_SESSIONS_DIR", raising=False)
+def _no_user_env_leak(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Don't let the developer's real ~/.trace/ sneak into test runs.
+
+    TRACE_SESSIONS_DIR is re-pointed (not deleted): deleting it would suspend
+    the suite-wide conftest isolation and fall back to the real
+    ~/.trace/sessions for any code path that doesn't get an explicit dir.
+    """
+    monkeypatch.setenv("TRACE_SESSIONS_DIR", str(tmp_path / "hook-sessions"))
     monkeypatch.delenv("TRACE_RUNTIME_DIR", raising=False)
     monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
     monkeypatch.delenv("TRACE_PROMPT_MIN_TURNS", raising=False)

--- a/tests/test_env_isolation.py
+++ b/tests/test_env_isolation.py
@@ -1,0 +1,66 @@
+"""Suite-wide isolation from the developer's real ~/.trace data.
+
+The root conftest must point TRACE_KNOWLEDGE_DIR and TRACE_SESSIONS_DIR at
+per-run temp directories so that any test which forgets to pass an explicit
+directory cannot read from or write into the developer's real stores. (The
+real ~/.trace/knowledge had accumulated fm-test*, e2e-*, guard-e2e*, and
+export-test stores from exactly this class of leak.)
+
+Tests that *intentionally* target real data must opt in explicitly — see
+TestRealDataEmbeddings (gated behind TRACE_REAL_DATA_TESTS=1).
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from pathlib import Path
+
+from trace_mcp.extensions.learn.store import load_store, save_store
+from trace_mcp.storage.json_file import JsonFileStorage
+
+REAL_TRACE_DIR = Path.home() / ".trace"
+
+
+class TestSuiteEnvIsolation:
+    def test_knowledge_dir_points_at_tmp(self) -> None:
+        """TRACE_KNOWLEDGE_DIR must be set and must not be the real store."""
+        value = os.environ.get("TRACE_KNOWLEDGE_DIR")
+        assert value, "conftest must set TRACE_KNOWLEDGE_DIR for the whole suite"
+        resolved = Path(value).resolve()
+        assert not resolved.is_relative_to(REAL_TRACE_DIR), (
+            f"TRACE_KNOWLEDGE_DIR points inside the real ~/.trace: {resolved}"
+        )
+
+    def test_sessions_dir_points_at_tmp(self) -> None:
+        """TRACE_SESSIONS_DIR must be set and must not be the real store."""
+        value = os.environ.get("TRACE_SESSIONS_DIR")
+        assert value, "conftest must set TRACE_SESSIONS_DIR for the whole suite"
+        resolved = Path(value).resolve()
+        assert not resolved.is_relative_to(REAL_TRACE_DIR), (
+            f"TRACE_SESSIONS_DIR points inside the real ~/.trace: {resolved}"
+        )
+
+    def test_default_knowledge_store_writes_land_in_tmp(self) -> None:
+        """A store saved WITHOUT an explicit directory (the leak pattern that
+        polluted the real ~/.trace/knowledge) must land in the isolated dir.
+
+        The probe name is unique per run so a historic leak (e.g. from running
+        this test against a tree without the conftest) can't shadow the result.
+        """
+        name = f"isolation-probe-{uuid.uuid4().hex[:8]}"
+        ks = load_store(name)
+        save_store(ks)
+        isolated = Path(os.environ["TRACE_KNOWLEDGE_DIR"]) / f"{name}.json"
+        assert isolated.exists(), f"expected probe store at {isolated}"
+        real = REAL_TRACE_DIR / "knowledge" / f"{name}.json"
+        assert not real.exists(), f"probe store leaked into the real store: {real}"
+
+    def test_default_session_storage_writes_land_in_tmp(self) -> None:
+        """JsonFileStorage() with no directory must resolve inside the
+        isolated sessions dir, not the real ~/.trace/sessions."""
+        storage = JsonFileStorage()
+        resolved = Path(str(storage._dir)).resolve()
+        assert resolved.is_relative_to(Path(os.environ["TRACE_SESSIONS_DIR"]).resolve()), (
+            f"default JsonFileStorage dir is {resolved}, expected the isolated sessions dir"
+        )

--- a/tests/test_env_isolation.py
+++ b/tests/test_env_isolation.py
@@ -1,13 +1,16 @@
 """Suite-wide isolation from the developer's real ~/.trace data.
 
-The root conftest must point TRACE_KNOWLEDGE_DIR and TRACE_SESSIONS_DIR at
-per-run temp directories so that any test which forgets to pass an explicit
-directory cannot read from or write into the developer's real stores. (The
-real ~/.trace/knowledge had accumulated fm-test*, e2e-*, guard-e2e*, and
-export-test stores from exactly this class of leak.)
+The root conftest must point TRACE_KNOWLEDGE_DIR, TRACE_SESSIONS_DIR, and
+TRACE_SCRATCHPAD_DIR at per-run temp directories so that any test which
+forgets to pass an explicit directory cannot read from or write into the
+developer's real stores. (The real ~/.trace/knowledge had accumulated
+fm-test*, e2e-*, guard-e2e*, and export-test stores, and suite runs were
+overwriting the developer's real .claude/SCRATCHPAD.md, from exactly this
+class of leak.)
 
-Tests that *intentionally* target real data must opt in explicitly — see
-TestRealDataEmbeddings (gated behind TRACE_REAL_DATA_TESTS=1).
+Tests that *intentionally* target real data must be marked
+``@pytest.mark.real_data`` (load-bearing — the conftest skips them unless
+TRACE_REAL_DATA_TESTS=1) and pass real paths explicitly.
 """
 
 from __future__ import annotations
@@ -17,50 +20,75 @@ import uuid
 from pathlib import Path
 
 from trace_mcp.extensions.learn.store import load_store, save_store
+from trace_mcp.schema import Session, SessionMetadata
+from trace_mcp.scratchpad import _scratchpad_path
 from trace_mcp.storage.json_file import JsonFileStorage
 
-REAL_TRACE_DIR = Path.home() / ".trace"
+# Resolved so the containment checks are symlink-stable.
+REAL_TRACE_DIR = (Path.home() / ".trace").resolve()
+
+
+def _assert_isolated(var: str) -> Path:
+    """Assert env var `var` is set and points outside the real ~/.trace.
+
+    Returns the resolved isolated path. Used as a pre-write safety check by
+    the probe tests so they cannot themselves write into real stores when the
+    isolation is broken.
+    """
+    value = os.environ.get(var)
+    assert value, f"conftest must set {var} for the whole suite"
+    resolved = Path(value).resolve()
+    assert not resolved.is_relative_to(REAL_TRACE_DIR), f"{var} points inside the real ~/.trace: {resolved}"
+    return resolved
 
 
 class TestSuiteEnvIsolation:
     def test_knowledge_dir_points_at_tmp(self) -> None:
-        """TRACE_KNOWLEDGE_DIR must be set and must not be the real store."""
-        value = os.environ.get("TRACE_KNOWLEDGE_DIR")
-        assert value, "conftest must set TRACE_KNOWLEDGE_DIR for the whole suite"
-        resolved = Path(value).resolve()
-        assert not resolved.is_relative_to(REAL_TRACE_DIR), (
-            f"TRACE_KNOWLEDGE_DIR points inside the real ~/.trace: {resolved}"
-        )
+        _assert_isolated("TRACE_KNOWLEDGE_DIR")
 
     def test_sessions_dir_points_at_tmp(self) -> None:
-        """TRACE_SESSIONS_DIR must be set and must not be the real store."""
-        value = os.environ.get("TRACE_SESSIONS_DIR")
-        assert value, "conftest must set TRACE_SESSIONS_DIR for the whole suite"
-        resolved = Path(value).resolve()
-        assert not resolved.is_relative_to(REAL_TRACE_DIR), (
-            f"TRACE_SESSIONS_DIR points inside the real ~/.trace: {resolved}"
+        _assert_isolated("TRACE_SESSIONS_DIR")
+
+    def test_scratchpad_dir_points_at_tmp(self) -> None:
+        """trace_end_session writes SCRATCHPAD.md by default; unisolated it
+        overwrites cwd/.claude/SCRATCHPAD.md (the developer's real
+        context-restoration file) or falls back to ~/.trace/scratchpads."""
+        isolated = _assert_isolated("TRACE_SCRATCHPAD_DIR")
+        resolved = _scratchpad_path().resolve()
+        assert resolved.is_relative_to(isolated), (
+            f"scratchpad resolves to {resolved}, expected inside {isolated}"
+        )
+        assert not resolved.is_relative_to((Path.cwd() / ".claude").resolve()), (
+            "scratchpad would overwrite the developer's real .claude/SCRATCHPAD.md"
         )
 
     def test_default_knowledge_store_writes_land_in_tmp(self) -> None:
         """A store saved WITHOUT an explicit directory (the leak pattern that
         polluted the real ~/.trace/knowledge) must land in the isolated dir.
 
-        The probe name is unique per run so a historic leak (e.g. from running
-        this test against a tree without the conftest) can't shadow the result.
+        The probe name is unique per run so a historic leak can't shadow the
+        result, and the env is checked BEFORE writing so this test can't
+        itself pollute the real store when isolation is broken.
         """
+        isolated = _assert_isolated("TRACE_KNOWLEDGE_DIR")
         name = f"isolation-probe-{uuid.uuid4().hex[:8]}"
         ks = load_store(name)
         save_store(ks)
-        isolated = Path(os.environ["TRACE_KNOWLEDGE_DIR"]) / f"{name}.json"
-        assert isolated.exists(), f"expected probe store at {isolated}"
+        assert (isolated / f"{name}.json").exists(), f"expected probe store under {isolated}"
         real = REAL_TRACE_DIR / "knowledge" / f"{name}.json"
         assert not real.exists(), f"probe store leaked into the real store: {real}"
 
-    def test_default_session_storage_writes_land_in_tmp(self) -> None:
-        """JsonFileStorage() with no directory must resolve inside the
-        isolated sessions dir, not the real ~/.trace/sessions."""
+    async def test_default_session_storage_writes_land_in_tmp(self) -> None:
+        """A session created WITHOUT an explicit directory must be written
+        inside the isolated sessions dir, not the real ~/.trace/sessions."""
+        isolated = _assert_isolated("TRACE_SESSIONS_DIR")
         storage = JsonFileStorage()
-        resolved = Path(str(storage._dir)).resolve()
-        assert resolved.is_relative_to(Path(os.environ["TRACE_SESSIONS_DIR"]).resolve()), (
-            f"default JsonFileStorage dir is {resolved}, expected the isolated sessions dir"
+        assert Path(storage.location()).resolve().is_relative_to(isolated), (
+            f"default JsonFileStorage dir is {storage.location()}, expected inside {isolated}"
+        )
+        session_id = f"trace_20260610_probe{uuid.uuid4().hex[:6]}"
+        await storage.create_session(Session(id=session_id, metadata=SessionMetadata(project="isolation-probe")))
+        assert (isolated / f"{session_id}.json").exists()
+        assert not (REAL_TRACE_DIR / "sessions" / f"{session_id}.json").exists(), (
+            "probe session leaked into the real ~/.trace/sessions"
         )

--- a/tests/test_hardening_e2e.py
+++ b/tests/test_hardening_e2e.py
@@ -11,7 +11,6 @@ schema and tooling against patterns drawn from real research workflows.
 from __future__ import annotations
 
 import json
-import os
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -542,49 +541,54 @@ class TestScratchpadGeneration:
         # No crash on empty events
         assert "### Summary" not in section  # no summary set
 
-    def test_scratchpad_write_creates_file(self, scratchpad_dir: Path) -> None:
-        """write_scratchpad creates SCRATCHPAD.md with header and content."""
+    def test_scratchpad_write_creates_file(
+        self, scratchpad_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """write_scratchpad creates SCRATCHPAD.md with header and content.
+
+        monkeypatch (not set/pop) so the suite-wide TRACE_SCRATCHPAD_DIR
+        isolation from conftest is RESTORED, not deleted — a bare
+        os.environ.pop() here silently turned isolation off for every test
+        that ran afterwards, letting e2e session-ends overwrite the real
+        cwd/.claude/SCRATCHPAD.md.
+        """
         session = _make_green_narrative_session()
         session.summary = "Test session"
         session.ended = datetime.now(UTC)
         session.status = "completed"
 
-        os.environ["TRACE_SCRATCHPAD_DIR"] = str(scratchpad_dir)
-        try:
-            path = write_scratchpad(session)
-            assert path.exists()
-            content = path.read_text()
-            assert "# SCRATCHPAD" in content
-            assert "narrative-analysis" in content
-            assert "Test session" in content
-        finally:
-            os.environ.pop("TRACE_SCRATCHPAD_DIR", None)
+        monkeypatch.setenv("TRACE_SCRATCHPAD_DIR", str(scratchpad_dir))
+        path = write_scratchpad(session)
+        assert path.exists()
+        content = path.read_text()
+        assert "# SCRATCHPAD" in content
+        assert "narrative-analysis" in content
+        assert "Test session" in content
 
-    def test_scratchpad_replaces_previous_session(self, scratchpad_dir: Path) -> None:
+    def test_scratchpad_replaces_previous_session(
+        self, scratchpad_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """write_scratchpad keeps only the most recent session."""
-        os.environ["TRACE_SCRATCHPAD_DIR"] = str(scratchpad_dir)
-        try:
-            # First session
-            s1 = _make_green_narrative_session("trace_session_1")
-            s1.summary = "First session"
-            s1.ended = datetime.now(UTC)
-            s1.status = "completed"
-            write_scratchpad(s1)
+        monkeypatch.setenv("TRACE_SCRATCHPAD_DIR", str(scratchpad_dir))
+        # First session
+        s1 = _make_green_narrative_session("trace_session_1")
+        s1.summary = "First session"
+        s1.ended = datetime.now(UTC)
+        s1.status = "completed"
+        write_scratchpad(s1)
 
-            # Second session replaces first
-            s2 = _make_green_narrative_session("trace_session_2")
-            s2.summary = "Second session"
-            s2.ended = datetime.now(UTC)
-            s2.status = "completed"
-            write_scratchpad(s2)
+        # Second session replaces first
+        s2 = _make_green_narrative_session("trace_session_2")
+        s2.summary = "Second session"
+        s2.ended = datetime.now(UTC)
+        s2.status = "completed"
+        write_scratchpad(s2)
 
-            content = (scratchpad_dir / "SCRATCHPAD.md").read_text()
-            assert "trace_session_2" in content
-            assert "Second session" in content
-            assert "trace_session_1" not in content, "Old session should be replaced"
-            assert "First session" not in content, "Old session should be replaced"
-        finally:
-            os.environ.pop("TRACE_SCRATCHPAD_DIR", None)
+        content = (scratchpad_dir / "SCRATCHPAD.md").read_text()
+        assert "trace_session_2" in content
+        assert "Second session" in content
+        assert "trace_session_1" not in content, "Old session should be replaced"
+        assert "First session" not in content, "Old session should be replaced"
 
     def test_scratchpad_with_todos(self) -> None:
         """TODO annotations appear in the TODOs section."""
@@ -1148,6 +1152,7 @@ class TestAttributionAuditAccuracy:
 
     async def test_audit_detects_ai_self_resolution(
         self, storage: JsonFileStorage, active: dict[str, Session],
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Audit must flag decisions where AI resolved its own proposal."""
         sid, session = await _create_session(storage, active)
@@ -1158,14 +1163,14 @@ class TestAttributionAuditAccuracy:
             proposed_by_type="ai", proposed_by_id="claude",
         )
 
-        os.environ["TRACE_SUPPRESS_SELF_RESOLVE_WARNING"] = "true"
-        try:
-            await decision_tools.resolve_decision(
-                storage, session, event_id=d1, disposition="accepted",
-                resolved_by_type="ai", resolved_by_id="claude",
-            )
-        finally:
-            os.environ.pop("TRACE_SUPPRESS_SELF_RESOLVE_WARNING", None)
+        # monkeypatch (not set/pop): a bare os.environ.pop() would delete any
+        # pre-existing value instead of restoring it.
+        monkeypatch.setenv("TRACE_SUPPRESS_SELF_RESOLVE_WARNING", "true")
+        await decision_tools.resolve_decision(
+            storage, session, event_id=d1, disposition="accepted",
+            resolved_by_type="ai", resolved_by_id="claude",
+        )
+        monkeypatch.delenv("TRACE_SUPPRESS_SELF_RESOLVE_WARNING")
 
         result = await session_tools.end_session(
             storage, active, session_id=sid, summary="test",
@@ -1288,12 +1293,18 @@ class TestToolCallRetryChains:
 _REAL_SESSIONS_DIR = Path.home() / ".trace" / "sessions"
 
 
+@pytest.mark.real_data
 @pytest.mark.skipif(
     not _REAL_SESSIONS_DIR.exists(),
     reason="No ~/.trace/sessions/ directory — skipping real data tests",
 )
 class TestRealSessionDataIntegrity:
-    """Load real TRACE session files and verify data integrity."""
+    """Load real TRACE session files and verify data integrity.
+
+    Opt-in via TRACE_REAL_DATA_TESTS=1 (real_data marker, enforced in
+    conftest): reads the developer's real ~/.trace/sessions, whose contents
+    depend on personal machine state.
+    """
 
     def _load_session(self, filename: str) -> Session | None:
         path = _REAL_SESSIONS_DIR / filename
@@ -1390,12 +1401,19 @@ class TestRealSessionDataIntegrity:
 # ═══════════════════════════════════════════════════════════════════════════
 
 
+@pytest.mark.real_data
 @pytest.mark.skipif(
     not _REAL_SESSIONS_DIR.exists(),
     reason="No ~/.trace/sessions/ directory — skipping cross-project tests",
 )
 class TestCrossProjectConsistency:
-    """Verify consistency across all projects using TRACE."""
+    """Verify consistency across all projects using TRACE.
+
+    Opt-in via TRACE_REAL_DATA_TESTS=1 (real_data marker, enforced in
+    conftest): asserts properties over EVERY session in the developer's real
+    ~/.trace/sessions — a single unsummarized completed session anywhere in
+    personal data would otherwise fail the suite.
+    """
 
     def test_all_completed_sessions_have_summary(self) -> None:
         """Every completed session should have a summary."""

--- a/tests/test_installation_health.py
+++ b/tests/test_installation_health.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -158,8 +159,14 @@ class TestMCPConfiguration:
             f"--refresh) so local edits are rebuilt. Got: {args}"
         )
 
+    @pytest.mark.skipif(
+        shutil.which("uvx") is None,
+        reason="uvx not installed — the .mcp.json launch path can't be exercised on this machine",
+    )
     def test_mcp_json_command_resolves(self) -> None:
-        """The uvx command should be available on PATH."""
+        """When uvx is installed, it must resolve on PATH (skip otherwise:
+        contributors without uv shouldn't fail the suite over the maintainer's
+        launch mechanism)."""
         result = subprocess.run(
             ["which", "uvx"],
             capture_output=True,

--- a/tests/test_learn_e2e.py
+++ b/tests/test_learn_e2e.py
@@ -495,7 +495,7 @@ class TestE2EConfig:
         config = load_config()
         assert config.openai_api_key == "sk-from-env"
 
-    def test_config_no_key_disables_llm(self, monkeypatch):
+    def test_config_no_key_disables_llm(self, monkeypatch, tmp_path):
         """When no API key is found, LLM is automatically disabled."""
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
 
@@ -504,9 +504,21 @@ class TestE2EConfig:
 
         # Prevent load_config from reading the real ~/.trace/.env
         monkeypatch.setattr(_cfg, "_TRACE_ENV_PATH", Path("/nonexistent/.env"))
+        # ...and from reading a real ./.env in the developer's checkout
+        # (load_config also merges Path.cwd()/.env — the repo root has one).
+        monkeypatch.chdir(tmp_path)
 
         config = load_config()
         assert config.llm_enabled is False
+
+    def test_api_key_never_appears_in_repr(self):
+        """The API key must not leak into reprs (pytest failure output, logs,
+        and debugger dumps all use repr)."""
+        from trace_mcp.extensions.learn.config import LearnConfig
+
+        config = LearnConfig(openai_api_key="sk-secret-test-123")
+        assert "sk-secret-test-123" not in repr(config)
+        assert "sk-secret-test-123" not in str(config)
 
     def test_config_explicit_disable(self, monkeypatch):
         """TRACE_LLM_ENABLED=false disables LLM even with API key."""

--- a/tests/test_learn_embeddings_e2e.py
+++ b/tests/test_learn_embeddings_e2e.py
@@ -119,9 +119,15 @@ class TestEmbeddingE2ESubprocess:
 _REAL_STORE = Path.home() / ".trace" / "knowledge" / "TRACE.json"
 
 
+@pytest.mark.real_data
 @pytest.mark.skipif(not _REAL_STORE.exists(), reason="No real TRACE knowledge store")
 class TestRealDataE2E:
-    """E2E tests using real TRACE knowledge data."""
+    """E2E tests using real TRACE knowledge data.
+
+    Opt-in via TRACE_REAL_DATA_TESTS=1 (real_data marker, enforced in
+    conftest): recall assertions depend on the personal store's contents,
+    which drift over time.
+    """
 
     async def test_recall_real_knowledge(self):
         """Recall against real TRACE knowledge store via MCP server."""

--- a/tests/test_learn_embeddings_integration.py
+++ b/tests/test_learn_embeddings_integration.py
@@ -6,6 +6,7 @@ backend fallback chains, model change detection, real-data tests.
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from unittest.mock import AsyncMock
 
@@ -207,16 +208,32 @@ class TestModelChangeIntegration:
 
 # ── Real data tests ──────────────────────────────────────────────────────
 
-_REAL_STORE = Path.home() / ".trace" / "knowledge" / "TRACE.json"
+_REAL_KNOWLEDGE_DIR = Path.home() / ".trace" / "knowledge"
+_REAL_STORE = _REAL_KNOWLEDGE_DIR / "TRACE.json"
 
 
+@pytest.mark.real_data
+@pytest.mark.skipif(
+    not os.environ.get("TRACE_REAL_DATA_TESTS"),
+    reason=(
+        "Reads the developer's real ~/.trace/knowledge/TRACE.json — results depend on "
+        "personal machine state, and the store's contents drift over time (the Jun 2026 "
+        "learn-recovery grew it 5→29 learnings). Opt in with TRACE_REAL_DATA_TESTS=1."
+    ),
+)
 @pytest.mark.skipif(not _REAL_STORE.exists(), reason="No real TRACE knowledge store")
 class TestRealDataEmbeddings:
-    """Tests using the real TRACE.json knowledge store (~27 learnings)."""
+    """Tests using the real TRACE.json knowledge store.
+
+    Opt-in only (TRACE_REAL_DATA_TESTS=1): the suite-wide conftest isolation
+    points TRACE_KNOWLEDGE_DIR at a temp dir, so these tests pass the real
+    knowledge directory explicitly. Their assertions encode expectations about
+    specific learning IDs and may drift as the real store evolves.
+    """
 
     def test_load_real_store(self):
         """Real store loads cleanly with new code (backward compat)."""
-        ks = load_store("TRACE")
+        ks = load_store("TRACE", directory=str(_REAL_KNOWLEDGE_DIR))
         assert len(ks.learnings) > 0
         # Old stores won't have embeddings — that's fine
         for lrn in ks.learnings:
@@ -225,7 +242,7 @@ class TestRealDataEmbeddings:
 
     async def test_bm25_recall_on_real_data(self):
         """BM25 recall works on real data (baseline for comparison)."""
-        ks = load_store("TRACE")
+        ks = load_store("TRACE", directory=str(_REAL_KNOWLEDGE_DIR))
         bm25 = BM25Backend()
         results = await recall_learnings(
             ks.learnings, "schema validation rules for actors",
@@ -245,7 +262,7 @@ class TestRealDataEmbeddings:
         if provider is None:
             pytest.skip("model2vec not available")
 
-        ks = load_store("TRACE")
+        ks = load_store("TRACE", directory=str(_REAL_KNOWLEDGE_DIR))
         # Generate embeddings for all learnings
         texts = [lrn.content for lrn in ks.learnings]
         vecs = await provider.embed_texts(texts)

--- a/tests/test_learn_embeddings_integration.py
+++ b/tests/test_learn_embeddings_integration.py
@@ -6,7 +6,6 @@ backend fallback chains, model change detection, real-data tests.
 
 from __future__ import annotations
 
-import os
 from pathlib import Path
 from unittest.mock import AsyncMock
 
@@ -213,23 +212,23 @@ _REAL_STORE = _REAL_KNOWLEDGE_DIR / "TRACE.json"
 
 
 @pytest.mark.real_data
-@pytest.mark.skipif(
-    not os.environ.get("TRACE_REAL_DATA_TESTS"),
-    reason=(
-        "Reads the developer's real ~/.trace/knowledge/TRACE.json — results depend on "
-        "personal machine state, and the store's contents drift over time (the Jun 2026 "
-        "learn-recovery grew it 5→29 learnings). Opt in with TRACE_REAL_DATA_TESTS=1."
-    ),
-)
 @pytest.mark.skipif(not _REAL_STORE.exists(), reason="No real TRACE knowledge store")
 class TestRealDataEmbeddings:
     """Tests using the real TRACE.json knowledge store.
 
-    Opt-in only (TRACE_REAL_DATA_TESTS=1): the suite-wide conftest isolation
-    points TRACE_KNOWLEDGE_DIR at a temp dir, so these tests pass the real
-    knowledge directory explicitly. Their assertions encode expectations about
-    specific learning IDs and may drift as the real store evolves.
+    Opt-in only via the real_data marker (TRACE_REAL_DATA_TESTS=1, enforced in
+    conftest): the suite-wide isolation points TRACE_KNOWLEDGE_DIR at a temp
+    dir, so these tests pass the real knowledge directory explicitly. Recall
+    expectations are derived from the store's CONTENT at runtime (never pinned
+    IDs) because the real store drifts — the Jun 2026 learn-recovery grew it
+    5→29 learnings and re-issued IDs, which broke the previous hardcoded
+    lrn_001/lrn_003 assertions.
     """
+
+    @staticmethod
+    def _ids_with_content(ks, keyword: str) -> set[str]:
+        """IDs of learnings whose content mentions `keyword` (case-insensitive)."""
+        return {lrn.id for lrn in ks.learnings if keyword.lower() in lrn.content.lower()}
 
     def test_load_real_store(self):
         """Real store loads cleanly with new code (backward compat)."""
@@ -243,15 +242,19 @@ class TestRealDataEmbeddings:
     async def test_bm25_recall_on_real_data(self):
         """BM25 recall works on real data (baseline for comparison)."""
         ks = load_store("TRACE", directory=str(_REAL_KNOWLEDGE_DIR))
+        expected = self._ids_with_content(ks, "actor")
+        if not expected:
+            pytest.skip("real store currently has no actor-related learning to recall")
         bm25 = BM25Backend()
         results = await recall_learnings(
             ks.learnings, "schema validation rules for actors",
             backend=bm25, threshold=0.0, limit=5,
         )
         assert len(results) > 0
-        # lrn_001 is about actor type validation — should be in results
-        ids = [r["learning"]["id"] for r in results]
-        assert "lrn_001" in ids
+        ids = {r["learning"]["id"] for r in results}
+        assert ids & expected, (
+            f"Expected an actor-related learning ({sorted(expected)}) in the top results, got: {sorted(ids)}"
+        )
 
     async def test_embedding_recall_on_real_data(self):
         """Embedding recall with model2vec on real data."""
@@ -276,6 +279,10 @@ class TestRealDataEmbeddings:
             backend=backend, threshold=0.0, limit=5,
         )
         assert len(results) > 0
-        # lrn_003 is about ffmpeg audio device issues on macOS
-        ids = [r["learning"]["id"] for r in results[:5]]
-        assert "lrn_003" in ids, f"Expected lrn_003 in top 5, got: {ids}"
+        expected = self._ids_with_content(ks, "audio") | self._ids_with_content(ks, "ffmpeg")
+        if not expected:
+            pytest.skip("real store currently has no audio/ffmpeg-related learning to recall")
+        ids = {r["learning"]["id"] for r in results[:5]}
+        assert ids & expected, (
+            f"Expected an audio/ffmpeg-related learning ({sorted(expected)}) in the top 5, got: {sorted(ids)}"
+        )


### PR DESCRIPTION
## Summary

PR C of the post-review hardening plan (PR A = #10, PR B = #11). Makes the test suite deterministic on any machine: the default suite can no longer read from or write into the developer's real `~/.trace` data, and every real-data test is explicitly opt-in. Hardened by a 4-lens adversarial review (18 agents; 23 findings confirmed across 9 distinct defects, 0 refuted — including two HIGH ones the original cluster missed).

### Suite-wide isolation (root conftest)
`TRACE_KNOWLEDGE_DIR`, `TRACE_SESSIONS_DIR`, and `TRACE_SCRATCHPAD_DIR` point at per-run temp dirs, set in `pytest_configure` so even module-level imports during collection (server.py binds a default `JsonFileStorage()` at import) resolve isolated paths. Subprocesses inherit the isolation. Guarded by `tests/test_env_isolation.py` — whose RED run reproduced the leak live (the pre-conftest probe landed in the real store).

**What this fixes on real machines:** suite runs had deposited `e2e-*`/`fm-test`/`guard-e2e`/`export-test` stores into the real `~/.trace/knowledge` (cleaned up; 7 stores), and — found by the adversarial review — **overwrote the developer's real `.claude/SCRATCHPAD.md` on every run** via e2e session-ends.

The review's nastiest catch: after isolating the scratchpad var, the file *still* got clobbered. File-pair bisection traced it to two tests "restoring" `TRACE_SCRATCHPAD_DIR` with a bare `os.environ.pop()` in a `finally:` — a no-op before the conftest existed, but now it deleted the suite-wide isolation for every test that ran afterwards. They use `monkeypatch` now, and a `pytest_sessionfinish` hook fails the run loudly if any isolated var has been deleted mid-run (early-running guard tests can't see a later deletion).

### Real-data tests are opt-in (`TRACE_REAL_DATA_TESTS=1`)
All four classes that intentionally read real personal data (`TestRealDataEmbeddings`, `TestRealDataE2E`, `TestRealSessionDataIntegrity`, `TestCrossProjectConsistency` — the latter three found un-gated by the review, running by default off `Path.home()`) carry the registered `real_data` marker. The marker is **load-bearing**: a conftest collection hook skips marked items unless `TRACE_REAL_DATA_TESTS` ∈ {1, true, yes} (an explicit truth-set — `0`/`false` no longer enable). Recall expectations are derived from store content at runtime instead of pinned learning IDs, so personal-store drift can't fail the opted-in path (it previously shipped red against the post-recovery store).

### Config/.env hygiene
`test_config_no_key_disables_llm` (one of the 3 known local-only failures) also scrubs the checkout's `./.env` (`load_config` merges `Path.cwd()/.env`); `LearnConfig.openai_api_key` is `field(repr=False)` so the key can't leak into pytest output or logs (TDD: repr test RED first). The real-LLM integration tests intentionally still read the developer's real key — documented in the conftest.

### Misc
uvx installation check skips (not fails) without uv; `.coverage *` gitignore pattern for macOS duplication cruft (the stray `.coverage 2` is gone); adapter-hooks fixture re-points `TRACE_SESSIONS_DIR` instead of deleting it.

## Test plan
- [x] Default suite: **934 passed, 11 skipped, 0 failed** — with the real `.claude/SCRATCHPAD.md` byte-identical before and after (previously clobbered every run)
- [x] Opted-in suite (`TRACE_REAL_DATA_TESTS=1`): **942 passed, 3 skipped, 0 failed** (previously 2 failures from drifted store IDs)
- [x] Clobber reproduction (hardening + failure-modes combined run): clean
- [x] `ruff` clean; `pyright src/` 0 errors (3 known-baseline warnings)
- [x] No version bump, no tag; nothing can trigger release.yml

🤖 Generated with [Claude Code](https://claude.com/claude-code)