### PR TITLE
fix(core): fail-closed lock, duplicate-id guard, resilient reads, forward-compatible schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Integrity hardening (PR D)
+
+- **The per-session lock now fails closed.** On lock-acquisition timeout,
+  `JsonFileStorage.lock` previously logged to stderr and proceeded **unlocked**,
+  silently reopening the lost-update / duplicate-event-id window the lock exists
+  to close. It now raises `TimeoutError` (surfaced to the MCP caller as a
+  structured error) — a missed lock is visible, never silent. Stale-lock theft
+  is keyed on **holder PID liveness** (single-host) with a `<pid>:<time_ns>`
+  token re-verified before unlink, so a live long-running holder's lock is never
+  stolen and a crashed holder's lock is reclaimed at once. **Behavior change:**
+  session writes can now surface a lock-timeout error rather than degrading to an
+  unsynchronized write.
+- **`append_event` refuses to mint a duplicate event id** instead of silently
+  aliasing `revises_event_id` / `parent_event_id` / `corrects_event_ids`
+  references when the on-disk record is already in an aliased state.
+- **One schema-invalid session file no longer bricks the read aggregates.**
+  `trace_project_summary` and `trace_health_check` now catch per-session
+  `ValidationError` / `JSONDecodeError`, log and skip the bad record, and return
+  the skipped ids in a new **`skipped_sessions`** list — instead of aborting the
+  whole aggregate on one bad file. **Behavior change:** both tools' return dicts
+  gain a `skipped_sessions: list[str]` key.
+- **Forward-compatible schema (no silent field-stripping).** Schema models now
+  preserve unknown fields (`extra="allow"` via a shared `TraceModel` base), so an
+  older server that loads a newer-schema session and rewrites it no longer
+  durably deletes fields it did not recognize; `get_session` logs a version-skew
+  warning. `Environment` intentionally stays closed (legacy-field drop). The
+  generated JSON Schema now carries `additionalProperties: true` on those models.
+- **Consolidated the three session write paths** (`append_event`, `end_session`,
+  `resolve_decision`) onto a single `locked_disk_session` helper (the deferred
+  PR #10 consolidation) so "write under the fail-closed lock against disk truth"
+  is one implementation. Registered as **INV-1** in the new `docs/INVARIANTS.md`.
+
 ### Fixed
 
 - **Wheels built from the sdist were missing 7 runtime files** (`py.typed` and

--- a/docs/INVARIANTS.md
+++ b/docs/INVARIANTS.md
@@ -1,0 +1,101 @@
+# TRACE Invariants Registry
+
+This file is the **single source of truth for TRACE's correctness invariants** —
+the properties that, if violated at *any* site, corrupt the audit record TRACE
+exists to protect. Each invariant lists its exact statement, the **exhaustive
+set of sites** where it must hold, the mechanism that enforces it, and the test
+that pins it.
+
+**Why this file exists.** The 2026-06-10 multi-agent review found that every
+serious defect had the same shape: *an invariant enforced in one place but not
+uniformly* (immutability on append/end but not resolve; validation at
+construction but bypassed on assignment; locking on the happy path but silently
+degrading on timeout). The durable fix for that defect *class* is to name each
+invariant, enumerate its sites once, and add a guard that fails when a new
+unguarded site appears. `tests/test_invariants.py` (added in the
+process-scaffolding work) mechanically checks the site-sets below.
+
+> Status legend: **ENFORCED** = guard + test in place · **PARTIAL** = holds in
+> code but not yet mechanically guarded · **OPEN** = known gap, not yet fixed.
+
+---
+
+## INV-1 — Every session write is a locked, disk-truth read-modify-write  · ENFORCED
+
+**Statement.** No code path mutates a persisted session except by (a) acquiring
+the **fail-closed** per-session lock and (b) writing back the *freshest on-disk*
+`Session` (so a stale in-memory copy can neither clobber a concurrent writer's
+events nor resurrect a completed session). The lock **raises `TimeoutError`**
+rather than ever proceeding unlocked.
+
+**Single implementation.** `src/trace_mcp/storage/locked.py :: locked_disk_session`.
+
+**Exhaustive site-set (all session writes route through the helper):**
+- `src/trace_mcp/tools/session_tools.py :: append_event`
+- `src/trace_mcp/tools/session_tools.py :: end_session`
+- `src/trace_mcp/tools/decision_tools.py :: resolve_decision`
+
+**Enforcement.** `JsonFileStorage.lock` writes a `<pid>:<time_ns>` token and
+steals a lock only when the holder PID is provably dead (single-host) or, for an
+unparseable/legacy token, when older than `steal_after`; it fails closed on
+timeout. A live holder's lock is never stolen.
+
+**Tests.** `tests/test_integrity_hardening.py` (fail-closed, token, holder
+liveness), `tests/test_v042_storage_concurrency.py` (cross-process no-lost-update
+/ no-duplicate-id).
+
+---
+
+## INV-2 — Completed sessions are immutable (one documented exception)  · ENFORCED
+
+**Statement.** Once a session is `completed`, no event may be appended and it may
+not be re-ended. The **only** permitted post-completion mutation is resolving a
+still-`proposed` decision (the documented cross-session decision lifecycle),
+which stamps an audit warning. The check is made against **disk truth** inside
+the lock, not the in-memory copy.
+
+**Site-set:** the same three INV-1 write paths (each guards `disk.status ==
+"completed"` under the lock).
+
+**Tests.** `tests/test_decision_integrity.py` (post-completion resolution +
+stale-copy resurrection), `tests/test_integrity_hardening.py`
+(`test_end_session_refuses_when_disk_already_completed`).
+
+---
+
+## INV-3 — No `DecisionData` reaches disk without full Pydantic validation  · ENFORCED
+
+**Statement.** A decision's resolution state may never be written by assignment
+that bypasses validation (the C1 brick bug: `disposition = "approved"` slipped
+past Pydantic and made the file unreadable forever). Every resolution goes
+through a `DecisionData.model_validate(...)` round-trip, and the MCP edge types
+the parameter as a `Literal`.
+
+**Site:** `src/trace_mcp/tools/decision_tools.py :: resolve_decision`
+(`VALID_RESOLUTIONS` guard + `model_validate` round-trip).
+
+**Tests.** `tests/test_decision_integrity.py` (C1 brick scenario, Literal sweep).
+
+---
+
+## INV-4 — Project scoping uses ONE comparison rule across core and hooks  · OPEN
+
+**Statement.** A project name must resolve to the **same** session set in the
+core query layer and in the adapter hooks. Today they disagree: core
+(`json_file.py :: list_sessions` / `session_brief`) uses case-insensitive
+**substring** match (so `trace_project_summary("trace")` silently merges
+`trace-mcp` and `TRACE-research`), while the hooks use **exact** match.
+
+**Sites:** `src/trace_mcp/storage/json_file.py` (`list_sessions`,
+`session_brief`); `src/trace_mcp/adapters/claude_code/assets/hooks/*.sh`.
+
+**Status.** OPEN — verified still present on `main` (2026-06-16 review). The fix
+(make core exact, or an explicit `exact=` flag defaulting to exact) is tracked
+as a follow-up; `tests/test_invariants.py` should fail until the two layers
+share one predicate.
+
+---
+
+*To add an invariant: give it the next `INV-N`, state it, enumerate the
+exhaustive site-set, name the guard + test, and add a check to
+`tests/test_invariants.py` that fails when a new site violates it.*

--- a/schemas/trace-v0.4.json
+++ b/schemas/trace-v0.4.json
@@ -1,6 +1,7 @@
 {
   "$defs": {
     "Actor": {
+      "additionalProperties": true,
       "description": "Who performed an action.",
       "properties": {
         "type": {
@@ -37,6 +38,7 @@
       "type": "object"
     },
     "AnnotationData": {
+      "additionalProperties": true,
       "description": "Free-form observations, learnings, gotchas, corrections, todos.",
       "properties": {
         "category": {
@@ -87,6 +89,7 @@
       "type": "object"
     },
     "ContributionData": {
+      "additionalProperties": true,
       "description": "Records a contribution with direction-vs-execution attribution.\n\nCaptures who had the idea (direction) vs who did the work (execution),\nlinking back to the decisions that motivated this contribution.",
       "properties": {
         "description": {
@@ -147,6 +150,7 @@
       "type": "object"
     },
     "DecisionData": {
+      "additionalProperties": true,
       "description": "Records a decision with full attribution and resolution status.",
       "properties": {
         "description": {
@@ -302,6 +306,7 @@
       "type": "object"
     },
     "EventContext": {
+      "additionalProperties": true,
       "description": "Shared context attached to any event.",
       "properties": {
         "conversation_turn": {
@@ -352,6 +357,7 @@
       "type": "object"
     },
     "SessionMetadata": {
+      "additionalProperties": true,
       "description": "Descriptive metadata for a session.",
       "properties": {
         "project": {
@@ -432,6 +438,7 @@
       "type": "object"
     },
     "StateChangeData": {
+      "additionalProperties": true,
       "description": "Records a change in environment, configuration, or tools.",
       "properties": {
         "description": {
@@ -478,6 +485,7 @@
       "type": "object"
     },
     "ToolCallData": {
+      "additionalProperties": true,
       "description": "Records a tool or service invocation (MCP, external non-MCP, or host-internal).",
       "properties": {
         "server": {
@@ -604,6 +612,7 @@
       "type": "object"
     },
     "TraceEvent": {
+      "additionalProperties": true,
       "description": "A single audit event. The core unit of TRACE.",
       "properties": {
         "id": {
@@ -702,6 +711,7 @@
       "type": "object"
     }
   },
+  "additionalProperties": true,
   "description": "JSON Schema for a session document conforming to the Decision Provenance for AI-Assisted Workflows specification v0.4.1. See: https://trace-protocol.org/v0.3 (namespace URI kept at v0.3# per ADR 002 D6 \u2014 additive extensions are valid within the same namespace).",
   "properties": {
     "context": {

--- a/src/trace_mcp/schema/events.py
+++ b/src/trace_mcp/schema/events.py
@@ -8,9 +8,9 @@ import warnings
 from datetime import UTC, datetime
 from typing import Any, Literal, Self
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import Field, model_validator
 
-from trace_mcp.schema.session import Actor
+from trace_mcp.schema.session import Actor, TraceModel
 
 # Canonical enum value-sets (single source of truth; server.py imports these
 # for the MCP tool signatures so the protocol edge can never drift from the
@@ -25,7 +25,7 @@ AnnotationCategory = Literal[
 ContributionAttribution = Literal["human", "ai", "collaborative"]
 
 
-class EventContext(BaseModel):
+class EventContext(TraceModel):
     """Shared context attached to any event."""
 
     conversation_turn: int | None = None
@@ -34,7 +34,7 @@ class EventContext(BaseModel):
     related_event_ids: list[str] = Field(default_factory=list)
 
 
-class ToolCallData(BaseModel):
+class ToolCallData(TraceModel):
     """Records a tool or service invocation (MCP, external non-MCP, or host-internal)."""
 
     server: str
@@ -52,7 +52,7 @@ class ToolCallData(BaseModel):
     parent_event_id: str | None = None
 
 
-class DecisionData(BaseModel):
+class DecisionData(TraceModel):
     """Records a decision with full attribution and resolution status."""
 
     description: str
@@ -79,7 +79,7 @@ class DecisionData(BaseModel):
         return self
 
 
-class AnnotationData(BaseModel):
+class AnnotationData(TraceModel):
     """Free-form observations, learnings, gotchas, corrections, todos."""
 
     category: AnnotationCategory
@@ -89,7 +89,7 @@ class AnnotationData(BaseModel):
     tags: list[str] = Field(default_factory=list)
 
 
-class ContributionData(BaseModel):
+class ContributionData(TraceModel):
     """Records a contribution with direction-vs-execution attribution.
 
     Captures who had the idea (direction) vs who did the work (execution),
@@ -104,7 +104,7 @@ class ContributionData(BaseModel):
     tags: list[str] = Field(default_factory=list)
 
 
-class StateChangeData(BaseModel):
+class StateChangeData(TraceModel):
     """Records a change in environment, configuration, or tools."""
 
     description: str
@@ -114,7 +114,7 @@ class StateChangeData(BaseModel):
     reason: str | None = None
 
 
-class TraceEvent(BaseModel):
+class TraceEvent(TraceModel):
     """A single audit event. The core unit of TRACE."""
 
     id: str = ""

--- a/src/trace_mcp/schema/session.py
+++ b/src/trace_mcp/schema/session.py
@@ -8,10 +8,37 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 if TYPE_CHECKING:
     from trace_mcp.schema.events import TraceEvent
+
+
+class TraceModel(BaseModel):
+    """Base for TRACE schema models that PRESERVE unknown fields.
+
+    PR D #4 (forward-compatibility / schema-version gate): Pydantic v2's default
+    ``extra='ignore'`` silently DROPS unknown fields, so an older server that
+    loads a newer-schema session and rewrites it durably DELETES every field it
+    did not recognize — the documented upgrade path's silent-data-loss mode.
+    ``extra='allow'`` round-trips unknown fields through ``model_dump`` so a
+    version-skewed read+write is non-destructive.
+
+    Tradeoff (accepted): preservation is unconditional — a typo'd optional-field
+    key survives as a ghost extra (the real field keeps its default) and any
+    unknown key in a session file is retained through ``model_dump`` and the
+    ``format="json"`` export. That is acceptable for a forward-compatible audit
+    record; it is NOT a guarantee the extras are meaningful. (PROV-LD export is
+    unaffected — it projects only known fields.)
+
+    ``Environment`` is intentionally NOT a ``TraceModel``: it relies on
+    ``extra='ignore'`` to drop the legacy ``environment.trace_version`` field
+    (the v0.4.1 single-source-of-truth decision). It is therefore a closed
+    forward-compat dead zone — future/extension environment data MUST go in
+    ``Environment.custom`` (a real field), not as ad-hoc extra keys.
+    """
+
+    model_config = ConfigDict(extra="allow")
 
 
 SCHEMA_VERSION = "0.4.1"
@@ -31,7 +58,7 @@ changes — never for a packaging/patch release. The spec namespace URL in
 ActorType = Literal["human", "ai", "system"]
 
 
-class Actor(BaseModel):
+class Actor(TraceModel):
     """Who performed an action."""
 
     type: ActorType
@@ -56,7 +83,7 @@ class Environment(BaseModel):
     custom: dict[str, Any] = Field(default_factory=dict)
 
 
-class SessionMetadata(BaseModel):
+class SessionMetadata(TraceModel):
     """Descriptive metadata for a session."""
 
     project: str
@@ -69,7 +96,7 @@ class SessionMetadata(BaseModel):
     custom: dict[str, Any] = Field(default_factory=dict)
 
 
-class Session(BaseModel):
+class Session(TraceModel):
     """Top-level audit session. One session = one TRACE JSON file."""
 
     context: str = "https://trace-protocol.org/v0.3"

--- a/src/trace_mcp/schemas/trace-v0.4.json
+++ b/src/trace_mcp/schemas/trace-v0.4.json
@@ -1,6 +1,7 @@
 {
   "$defs": {
     "Actor": {
+      "additionalProperties": true,
       "description": "Who performed an action.",
       "properties": {
         "type": {
@@ -37,6 +38,7 @@
       "type": "object"
     },
     "AnnotationData": {
+      "additionalProperties": true,
       "description": "Free-form observations, learnings, gotchas, corrections, todos.",
       "properties": {
         "category": {
@@ -87,6 +89,7 @@
       "type": "object"
     },
     "ContributionData": {
+      "additionalProperties": true,
       "description": "Records a contribution with direction-vs-execution attribution.\n\nCaptures who had the idea (direction) vs who did the work (execution),\nlinking back to the decisions that motivated this contribution.",
       "properties": {
         "description": {
@@ -147,6 +150,7 @@
       "type": "object"
     },
     "DecisionData": {
+      "additionalProperties": true,
       "description": "Records a decision with full attribution and resolution status.",
       "properties": {
         "description": {
@@ -302,6 +306,7 @@
       "type": "object"
     },
     "EventContext": {
+      "additionalProperties": true,
       "description": "Shared context attached to any event.",
       "properties": {
         "conversation_turn": {
@@ -352,6 +357,7 @@
       "type": "object"
     },
     "SessionMetadata": {
+      "additionalProperties": true,
       "description": "Descriptive metadata for a session.",
       "properties": {
         "project": {
@@ -432,6 +438,7 @@
       "type": "object"
     },
     "StateChangeData": {
+      "additionalProperties": true,
       "description": "Records a change in environment, configuration, or tools.",
       "properties": {
         "description": {
@@ -478,6 +485,7 @@
       "type": "object"
     },
     "ToolCallData": {
+      "additionalProperties": true,
       "description": "Records a tool or service invocation (MCP, external non-MCP, or host-internal).",
       "properties": {
         "server": {
@@ -604,6 +612,7 @@
       "type": "object"
     },
     "TraceEvent": {
+      "additionalProperties": true,
       "description": "A single audit event. The core unit of TRACE.",
       "properties": {
         "id": {
@@ -702,6 +711,7 @@
       "type": "object"
     }
   },
+  "additionalProperties": true,
   "description": "JSON Schema for a session document conforming to the Decision Provenance for AI-Assisted Workflows specification v0.4.1. See: https://trace-protocol.org/v0.3 (namespace URI kept at v0.3# per ADR 002 D6 \u2014 additive extensions are valid within the same namespace).",
   "properties": {
     "context": {

--- a/src/trace_mcp/storage/json_file.py
+++ b/src/trace_mcp/storage/json_file.py
@@ -18,12 +18,61 @@ from collections.abc import AsyncIterator
 from pathlib import Path
 from typing import Any
 
-from trace_mcp.schema import Session
+from trace_mcp.schema import SCHEMA_VERSION, Session
 from trace_mcp.storage.base import TraceStorage
 
 logger = logging.getLogger(__name__)
 
 _DEFAULT_DIR = os.path.expanduser("~/.trace/sessions")
+
+
+def _minor_version(v: str) -> tuple[int, int]:
+    """Parse the (major, minor) tuple from a dotted version string."""
+    major, _, rest = v.partition(".")
+    minor, _, _ = rest.partition(".")
+    return (int(major), int(minor or 0))
+
+
+def _is_future_schema_version(file_version: str | None) -> bool:
+    """True if a session file declares a (major, minor) newer than this server.
+
+    Used to warn on version skew at read time. Combined with the schema models'
+    ``extra='allow'`` (forward-compat preservation), this surfaces the skew that
+    used to cause silent field-stripping on rewrite. Returns False on any
+    unparseable/missing version (treat as same-or-older).
+    """
+    if not file_version:
+        return False
+    try:
+        return _minor_version(file_version) > _minor_version(SCHEMA_VERSION)
+    except ValueError:
+        return False
+
+
+def _holder_status(token: bytes) -> str:
+    """Liveness of the process named in a lock token (``<pid>:<time_ns>``).
+
+    Returns ``"dead"`` (holder process is gone — safe to steal), ``"alive"``
+    (holder is running — must NOT steal, however old the lock), or
+    ``"unknown"`` (token unparseable / legacy-empty, or liveness not
+    determinable on this platform — fall back to the time-based steal). Valid
+    only under the single-host advisory-lock assumption the lock documents.
+    """
+    try:
+        pid = int(token.split(b":", 1)[0])
+    except (ValueError, IndexError):
+        return "unknown"
+    if pid <= 0:
+        return "unknown"
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return "dead"
+    except PermissionError:
+        return "alive"  # process exists, owned by another user
+    except OSError:
+        return "unknown"  # e.g. signal-0 liveness unsupported on this platform
+    return "alive"
 
 
 def sanitize_name(name: str) -> str:
@@ -93,38 +142,74 @@ class JsonFileStorage(TraceStorage):
         Implemented with an exclusive lock file (``os.O_CREAT | os.O_EXCL``) —
         cross-platform, no fcntl/filelock dependency (keeps core deps = mcp +
         pydantic). A lock older than ``steal_after`` is treated as stale (holder
-        crashed) and stolen. If the lock cannot be acquired within ``timeout``,
-        we proceed anyway (best-effort) rather than deadlock — degrading to the
-        prior unsynchronized behaviour only under pathological contention.
+        crashed) and stolen.
+
+        **Fail-closed (PR D):** if the lock cannot be acquired within
+        ``timeout`` we ``raise TimeoutError`` rather than proceed unlocked. An
+        audit store must never silently degrade to an unsynchronized write —
+        that reopens the lost-update / duplicate-evt_id window the lock exists
+        to close, invisibly to the caller and the record. The lock is
+        single-host advisory only (``O_EXCL`` does not synchronize across NFS /
+        distinct mounts); TRACE's deployment is a local per-user ``~/.trace``.
+
+        The lock file carries an identifying token (``<pid>:<time_ns>``) so the
+        stale-steal path can re-verify the lock is byte- and mtime-identical to
+        the one it judged stale before unlinking it — closing the TOCTOU window
+        where a writer could delete another writer's *fresh* lock.
 
         Side effects: creates/removes ``<session>.lock`` in the sessions dir
         (excluded from list/scan globs, which match ``trace_*.json``).
+
+        Raises:
+            TimeoutError: the lock could not be acquired within ``timeout``.
         """
         self._ensure_dir()
         lock_path = self._dir / f"{sanitize_name(session_id)}.lock"
+        token = f"{os.getpid()}:{time.time_ns()}".encode()
         acquired = False
         waited = 0.0
         while True:
             try:
                 fd = os.open(str(lock_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
-                os.close(fd)
+                try:
+                    os.write(fd, token)
+                finally:
+                    os.close(fd)
                 acquired = True
                 break
             except FileExistsError:
-                try:
-                    if time.time() - os.path.getmtime(lock_path) > steal_after:
+                pass  # someone holds it — decide below whether to steal
+
+            # Steal the lock only if its holder is provably DEAD (single-host
+            # PID liveness), or — for an unparseable/legacy token whose holder
+            # cannot be checked — if it is older than ``steal_after`` (time
+            # backstop). A LIVE holder is never stolen, however old its lock.
+            # The byte+mtime re-verify before unlink avoids deleting a different,
+            # fresher lock (the TOCTOU the empty pre-fix lock file allowed).
+            stole = False
+            try:
+                token_seen = lock_path.read_bytes()
+                before = os.stat(lock_path)
+                holder = _holder_status(token_seen)
+                stale_by_time = (time.time() - before.st_mtime) > steal_after
+                if holder == "dead" or (holder == "unknown" and stale_by_time):
+                    after = os.stat(lock_path)
+                    if after.st_mtime_ns == before.st_mtime_ns and lock_path.read_bytes() == token_seen:
                         os.unlink(lock_path)
-                        continue  # retry immediately after stealing a stale lock
-                except OSError:
-                    continue  # lock vanished between checks — retry
-                if waited >= timeout:
-                    logger.warning(
-                        "Lock acquisition timed out for %s; proceeding best-effort.",
-                        session_id,
-                    )
-                    break
-                await asyncio.sleep(poll)
-                waited += poll
+                        stole = True
+            except OSError:
+                pass  # lock vanished mid-check — fall through to retry (counts vs budget)
+            if stole:
+                continue  # freed it — retry the create immediately
+            if waited >= timeout:
+                raise TimeoutError(
+                    f"Could not acquire the per-session lock for '{session_id}' "
+                    f"within {timeout}s; another writer is holding it. Refusing "
+                    "to write unlocked (fail-closed) to protect provenance "
+                    "integrity. Retry, or investigate a stuck/leaked lock file."
+                )
+            await asyncio.sleep(poll)
+            waited += poll
         try:
             yield
         finally:
@@ -154,6 +239,17 @@ class JsonFileStorage(TraceStorage):
             raise FileNotFoundError(f"Session not found: {session_id}")
         with open(path) as f:
             raw = json.load(f)
+        file_version = raw.get("trace_version") if isinstance(raw, dict) else None
+        if _is_future_schema_version(file_version):
+            logger.warning(
+                "Session %s declares schema version %s, newer than this server's "
+                "%s. Unknown fields are preserved (extra='allow'), but this server "
+                "may not understand newer semantics — upgrade trace-mcp to read it "
+                "fully.",
+                session_id,
+                file_version,
+                SCHEMA_VERSION,
+            )
         return Session.model_validate(raw)
 
     async def list_sessions(self, project: str | None = None, limit: int = 50) -> list[dict[str, Any]]:

--- a/src/trace_mcp/storage/locked.py
+++ b/src/trace_mcp/storage/locked.py
@@ -1,0 +1,70 @@
+"""Shared locked read-modify-write helper for session write paths.
+
+PR D: ``append_event``, ``end_session``, and ``resolve_decision`` each performed
+the same acquire-lock → reload-authoritative-disk-state → mutate → write dance,
+but as three hand-copied blocks (the consolidation deferred in PR #10). Three
+copies is exactly how the H1/H2 immutability gaps arose in the first place — a
+new write path copies two of the three guards and silently drops the third.
+Routing every session write through ONE helper makes "write under the
+per-session lock against the freshest on-disk truth" a single implementation,
+registered as invariant INV-1 in docs/INVARIANTS.md.
+
+Exports:
+    locked_disk_session — async context manager yielding the disk-truth Session
+        under the per-session lock.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from collections.abc import AsyncIterator
+
+from trace_mcp.schema import Session
+from trace_mcp.storage.base import TraceStorage
+
+
+@contextlib.asynccontextmanager
+async def locked_disk_session(
+    storage: TraceStorage,
+    session_id: str,
+    *,
+    fallback: Session,
+) -> AsyncIterator[Session]:
+    """Acquire the per-session lock and yield the authoritative on-disk Session.
+
+    Yields the freshest disk-loaded ``Session`` so every read-modify-write path
+    sees disk truth: no stale in-memory copy can clobber a concurrent writer's
+    events or resurrect a completed session (the H1 class). If the session is
+    not yet persisted — a brand-new session whose first write creates the file —
+    yields ``fallback`` (the caller's in-memory ``Session``).
+
+    The lock fails closed (raises ``TimeoutError``) rather than degrading to an
+    unsynchronized write; see ``JsonFileStorage.lock``. Storage backends without
+    a ``lock`` method degrade to a no-op context (single-threaded use only).
+
+    The caller owns its own status / immutability policy and MUST call
+    ``storage.update_session(...)`` inside the ``with`` block for its mutation to
+    persist. Use ``yielded is fallback`` to tell a not-yet-persisted session from
+    a disk-loaded one.
+
+    Args:
+        storage: the session store.
+        session_id: the session to lock and load.
+        fallback: the in-memory Session to yield if nothing is on disk yet.
+
+    Yields:
+        The disk-loaded Session, or ``fallback`` if not yet persisted.
+
+    Side effects: acquires/releases the ``<session>.lock`` file.
+
+    Raises:
+        TimeoutError: the per-session lock could not be acquired (fail-closed).
+    """
+    lock_factory = getattr(storage, "lock", None)
+    lock_cm = lock_factory(session_id) if lock_factory is not None else contextlib.nullcontext()
+    async with lock_cm:
+        try:
+            disk = await storage.get_session(session_id)
+        except FileNotFoundError:
+            disk = fallback
+        yield disk

--- a/src/trace_mcp/tools/decision_tools.py
+++ b/src/trace_mcp/tools/decision_tools.py
@@ -3,12 +3,12 @@
 from __future__ import annotations
 
 import os
-from contextlib import nullcontext
 from datetime import UTC, datetime
 from typing import get_args
 
 from trace_mcp.schema import Actor, DecisionData, DecisionDisposition, Session, TraceEvent
 from trace_mcp.storage.base import TraceStorage
+from trace_mcp.storage.locked import locked_disk_session
 from trace_mcp.tools.session_tools import append_event
 
 # Terminal dispositions a proposed decision may transition to. Derived from
@@ -92,16 +92,11 @@ async def resolve_decision(
     # append/resolve persisted since the caller loaded its Session is neither
     # clobbered nor judged from stale state (e.g. is_multi_actor on a copy
     # that is missing a concurrently-appended actor).
-    lock_factory = getattr(storage, "lock", None)
-    lock_cm = lock_factory(session.id) if lock_factory is not None else nullcontext()
-    async with lock_cm:
-        # Write back the disk-loaded object (not the caller's in-memory copy)
-        # so a stale in-memory status/metadata can't clobber disk state —
-        # e.g. resurrect a session completed by another process (H1).
-        try:
-            write_session = await storage.get_session(session.id)
-        except FileNotFoundError:
-            write_session = session  # not yet persisted; in-memory is authoritative
+    # The helper yields the disk-loaded object (not the caller's in-memory copy)
+    # so a stale in-memory status/metadata can't clobber disk state — e.g.
+    # resurrect a session completed by another process (H1) — and acquires the
+    # fail-closed per-session lock (INV-1).
+    async with locked_disk_session(storage, session.id, fallback=session) as write_session:
         target = next(
             (e for e in write_session.events if e.id == event_id and e.type == "decision"),
             None,

--- a/src/trace_mcp/tools/query_tools.py
+++ b/src/trace_mcp/tools/query_tools.py
@@ -2,13 +2,19 @@
 
 from __future__ import annotations
 
+import json
+import logging
 import os
 from pathlib import Path
 from typing import Any
 
+from pydantic import ValidationError
+
 import trace_mcp
 from trace_mcp.schema import Session
 from trace_mcp.storage.base import TraceStorage
+
+logger = logging.getLogger(__name__)
 
 # v0.4.2 Phase 3: HARD payload caps. Unbounded query results are the primary
 # context-bloat surface compounding the API-400 crash. These ceilings bind even
@@ -242,11 +248,21 @@ async def project_summary(
     session_summaries = await storage.list_sessions(project=project, limit=scan_cap)
     scan_truncated = len(session_summaries) >= scan_cap
     sessions: list[Session] = []
+    skipped_sessions: list[str] = []
     for s in session_summaries:
         try:
             sessions.append(await storage.get_session(s["id"]))
         except FileNotFoundError:
             continue
+        except (ValidationError, json.JSONDecodeError) as exc:
+            # PR D #3: a schema-invalid / corrupt record must not abort the
+            # whole aggregate. Skip it, LOG it (so the omission isn't silent),
+            # and report it so paper-ready stats stay honest, not silently
+            # wrong. (JSON-corrupt files are already pre-filtered by
+            # list_sessions, so in practice this catches schema-invalid
+            # valid-JSON records.)
+            logger.warning("project_summary(%s): skipping unreadable session %s: %s", project, s["id"], exc)
+            skipped_sessions.append(s["id"])
 
     total_events = 0
     events_by_type: dict[str, int] = {}
@@ -323,6 +339,7 @@ async def project_summary(
     return {
         "project": project,
         "session_count": len(sessions),
+        "skipped_sessions": skipped_sessions,
         "scan_truncated": scan_truncated,
         "total_events": total_events,
         "events_by_type": events_by_type,
@@ -380,12 +397,16 @@ async def health_check(
 
     # Load sessions (bounded: read at most scan_cap most-recent files).
     sessions: list[Session] = []
+    skipped_sessions: list[str] = []
     scan_truncated = False
     if session_id:
         try:
             sessions.append(await storage.get_session(session_id))
         except FileNotFoundError:
             pass
+        except (ValidationError, json.JSONDecodeError) as exc:
+            logger.warning("health_check: skipping unreadable session %s: %s", session_id, exc)
+            skipped_sessions.append(session_id)
     else:
         summaries = await storage.list_sessions(project=project, limit=scan_cap)
         scan_truncated = len(summaries) >= scan_cap
@@ -394,6 +415,11 @@ async def health_check(
                 sessions.append(await storage.get_session(s["id"]))
             except FileNotFoundError:
                 continue
+            except (ValidationError, json.JSONDecodeError) as exc:
+                # PR D #3: skip-and-report (and log) a schema-invalid/corrupt
+                # record rather than aborting the health probe entirely.
+                logger.warning("health_check: skipping unreadable session %s: %s", s["id"], exc)
+                skipped_sessions.append(s["id"])
 
     # Tally events
     total = 0
@@ -416,6 +442,7 @@ async def health_check(
         },
         "session_count": len(sessions),
         "sessions_scanned": len(sessions),
+        "skipped_sessions": skipped_sessions,
         "scan_truncated": scan_truncated,
         "project_filter": project,
         "session_filter": session_id,

--- a/src/trace_mcp/tools/session_tools.py
+++ b/src/trace_mcp/tools/session_tools.py
@@ -6,7 +6,6 @@ import platform
 import re
 import sys
 import uuid
-from contextlib import nullcontext
 from datetime import UTC, datetime
 from typing import Any
 
@@ -14,6 +13,7 @@ from pydantic import BaseModel, Field
 
 from trace_mcp.schema import Actor, Environment, Session, SessionMetadata, TraceEvent
 from trace_mcp.storage.base import TraceStorage
+from trace_mcp.storage.locked import locked_disk_session
 
 # ── Attribution Audit Models ─────────────────────────────────────────────
 
@@ -295,7 +295,7 @@ def _build_attribution_audit(session: Session) -> AttributionAudit:
                 window_start = e.timestamp - discovery_window
                 has_anchor = any(
                     window_start <= ts <= e.timestamp
-                    for _id, ts in discovery_anchors
+                    for _, ts in discovery_anchors
                 )
                 if not has_anchor:
                     orphan_discovery_ids.append(e.id)
@@ -612,19 +612,14 @@ async def end_session(
     # the per-session lock, reloading authoritative on-disk events first, so a
     # concurrent append landing between read and write is preserved (not
     # clobbered) and the immutability guard sees disk truth.
-    lock_factory = getattr(storage, "lock", None)
-    lock_cm = lock_factory(session_id) if lock_factory is not None else nullcontext()
-    async with lock_cm:
-        try:
-            disk = await storage.get_session(session_id)
+    async with locked_disk_session(storage, session_id, fallback=session) as disk:
+        if disk is not session:
             if disk.status == "completed":
                 return (
                     f"Error: Session '{session_id}' already ended at {disk.ended}. "
                     f"Completed sessions are immutable and cannot be ended again."
                 )
             session.events = disk.events
-        except FileNotFoundError:
-            pass  # brand-new session, not yet persisted
         session.ended = datetime.now(UTC)
         session.status = "completed"
         session.summary = summary
@@ -746,25 +741,36 @@ async def append_event(
             f"Session ended at {session.ended}. Start a new session instead."
         )
 
-    lock_factory = getattr(storage, "lock", None)
-    lock_cm = lock_factory(session.id) if lock_factory is not None else nullcontext()
-    async with lock_cm:
+    async with locked_disk_session(storage, session.id, fallback=session) as disk:
         # Reload authoritative on-disk state so we never clobber events another
-        # writer persisted since this Session was last read.
-        try:
-            disk = await storage.get_session(session.id)
+        # writer persisted since this Session was last read. `disk is session`
+        # only when nothing is persisted yet (brand-new session).
+        if disk is not session:
             if disk.status == "completed":
                 raise ValueError(
                     f"Cannot append events to completed session '{session.id}'. "
                     f"Session ended at {disk.ended}. Start a new session instead."
                 )
             session.events = disk.events
-        except FileNotFoundError:
-            pass  # brand-new session, not yet persisted
 
         if not event.id:
             event.id = session.next_event_id()
         event.session_id = session.id
+
+        # PR D #2: refuse to mint/accept an id that already exists in the
+        # reloaded on-disk session. A positional next_event_id() can only
+        # collide if the record is already aliased (e.g. after a pre-fix
+        # unlocked write left two events sharing an id); writing another event
+        # under that id would silently alias revises_event_id / parent_event_id
+        # / corrects_event_ids references. Fail loudly instead of corrupting.
+        if any(e.id == event.id for e in session.events):
+            raise ValueError(
+                f"Refusing to append event with duplicate id '{event.id}' in "
+                f"session '{session.id}': that id already exists on disk. This "
+                f"indicates an aliased/corrupted session record — writing under "
+                f"the same id would alias references. Investigate the session "
+                f"file rather than appending."
+            )
 
         # FM13/FM16/FM17: validate referential integrity against the merged state.
         ref_errors = _check_referential_integrity(session, event)

--- a/tests/test_integrity_hardening.py
+++ b/tests/test_integrity_hardening.py
@@ -1,0 +1,389 @@
+"""PR D — integrity-hardening cluster regression tests.
+
+Covers the four still-open core-integrity findings re-verified against main on
+2026-06-16 (post PRs #10/#11/#12), per the accepted decision evt_002:
+
+  #1  The per-session lock must FAIL CLOSED on timeout (raise) instead of
+      silently yielding unlocked, and the stale-lock steal must verify an
+      identifying token before unlinking (close the TOCTOU window).
+  #2  append_event must REFUSE to mint an event id that already exists in the
+      reloaded on-disk session (no silent reference-aliasing), keeping the
+      human-readable positional evt_NNN format.
+  #3  Read aggregates (project_summary / health_check) must skip-and-report a
+      schema-invalid session file (in a `skipped_sessions` list) instead of
+      aborting the whole aggregate.
+  #4  Loading a future-schema-version session must not silently strip and
+      durably delete unknown fields on the next rewrite.
+
+The final section covers the PR-D adversarial-review hardening round (lock
+holder-liveness steal, true timeout ceiling, extra='allow' at event/nested
+level, version-skew negative cases, the under-lock end_session guard).
+
+These are TDD regression tests: each was written RED first.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from trace_mcp.schema import SCHEMA_VERSION
+from trace_mcp.storage.json_file import JsonFileStorage
+from trace_mcp.tools import logging_tools, query_tools, session_tools
+
+
+def _write_invalid_session(directory, session_id: str, project: str) -> Path:
+    """Write a VALID-JSON but SCHEMA-INVALID session file (bad status enum)."""
+    path = Path(str(directory)) / f"{session_id}.json"
+    path.write_text(json.dumps({
+        "id": session_id,
+        "status": "not-a-valid-status",  # invalid enum -> pydantic ValidationError
+        "created": "2026-06-16T00:00:00Z",
+        "metadata": {"project": project},
+        "events": [],
+    }))
+    return path
+
+
+@pytest.fixture
+def storage(tmp_path):
+    return JsonFileStorage(directory=str(tmp_path))
+
+
+# ── #1 fail-closed lock ──────────────────────────────────────────────────
+
+
+async def test_lock_raises_on_timeout_instead_of_proceeding_unlocked(storage, tmp_path):
+    """A held (non-stale) lock must make lock() RAISE on timeout, not yield unlocked.
+
+    The pre-fix behaviour logged a warning to stderr and proceeded unlocked —
+    reopening the exact lost-update / duplicate-id window the lock exists to
+    close, invisibly to the LLM and the audit record. An audit store must fail
+    closed: a missed lock has to be visible to the caller.
+    """
+    session_id = "trace_20260616_lock01"
+    storage._ensure_dir()
+    lock_path = Path(str(tmp_path)) / f"{session_id}.lock"
+    lock_path.write_text("held-by-another-writer")  # fresh, not stale
+
+    with pytest.raises(TimeoutError):
+        async with storage.lock(session_id, timeout=0.1, steal_after=600.0, poll=0.02):
+            pass
+
+
+async def test_lock_writes_identifying_token_for_steal_safety(storage, tmp_path):
+    """While held, the lock file must carry an identifying token (this PID).
+
+    An empty lock file (the pre-fix state) makes the stale-steal os.unlink a
+    blind TOCTOU: the stealer cannot verify it is deleting the same lock it
+    observed. A token lets the steal path re-verify before unlinking.
+    """
+    session_id = "trace_20260616_tok01"
+    lock_path = Path(str(tmp_path)) / f"{session_id}.lock"
+
+    async with storage.lock(session_id):
+        content = lock_path.read_text()
+    assert str(os.getpid()) in content, f"lock file had no PID token: {content!r}"
+
+
+async def test_stale_lock_is_still_stolen_and_released(storage, tmp_path):
+    """A genuinely stale lock (older than steal_after) must still be stolen.
+
+    Guards the fail-closed change against over-correcting into a deadlock after
+    a crashed holder leaks a lock file.
+    """
+    session_id = "trace_20260616_stale1"
+    storage._ensure_dir()
+    lock_path = Path(str(tmp_path)) / f"{session_id}.lock"
+    lock_path.write_text("crashed-holder")
+    old = time.time() - 10_000
+    os.utime(lock_path, (old, old))
+
+    async with storage.lock(session_id, timeout=0.1, steal_after=1.0):
+        pass  # must not raise — the stale lock is stolen
+
+    assert not lock_path.exists()  # released cleanly
+
+
+# ── #2 duplicate-id guard ────────────────────────────────────────────────
+
+
+async def test_append_refuses_to_mint_a_duplicate_event_id(storage):
+    """append_event must refuse to assign an id already present on disk.
+
+    If the on-disk session is in an aliased state (e.g. ids evt_001 + evt_003
+    with len==2 so next_event_id() recomputes evt_003), minting that id again
+    would silently alias revises_event_id / parent_event_id / corrects_event_ids
+    references. The append must raise instead.
+    """
+    active: dict = {}
+    session = await session_tools.create_session(storage, active, project="cc")
+    await logging_tools.log_annotation(storage, session, category="gotcha", content="a")  # evt_001
+    await logging_tools.log_annotation(storage, session, category="gotcha", content="b")  # evt_002
+
+    # Corrupt the on-disk state so events are evt_001 + evt_003 (len 2 ->
+    # next_event_id() == evt_003, which already exists).
+    path = storage._session_path(session.id)
+    raw = json.loads(path.read_text())
+    raw["events"][1]["id"] = "evt_003"
+    path.write_text(json.dumps(raw))
+
+    fresh = await storage.get_session(session.id)
+    with pytest.raises(ValueError, match="evt_003"):
+        await logging_tools.log_annotation(storage, fresh, category="gotcha", content="c")
+
+
+# ── #3 skip-and-report read aggregates ───────────────────────────────────
+
+
+async def test_project_summary_skips_and_reports_schema_invalid_session(storage, tmp_path):
+    """One schema-invalid file must not abort the whole project aggregate."""
+    active: dict = {}
+    good = await session_tools.create_session(storage, active, project="proj1")
+    await logging_tools.log_annotation(storage, good, category="gotcha", content="ok")
+    _write_invalid_session(tmp_path, "trace_20260616_badbad", "proj1")
+
+    result = await query_tools.project_summary(storage, project="proj1")
+
+    assert result["skipped_sessions"] == ["trace_20260616_badbad"]
+    assert result["session_count"] == 1  # the good session is still counted
+
+
+async def test_health_check_skips_and_reports_schema_invalid_session(storage, tmp_path):
+    """health_check must skip-and-report a schema-invalid file, not raise."""
+    active: dict = {}
+    await session_tools.create_session(storage, active, project="proj2")
+    _write_invalid_session(tmp_path, "trace_20260616_baddd2", "proj2")
+
+    result = await query_tools.health_check(storage, project="proj2")
+
+    assert result["skipped_sessions"] == ["trace_20260616_baddd2"]
+    assert result["session_count"] == 1  # the good session still loaded
+
+
+# ── #4 schema-version gate ───────────────────────────────────────────────
+
+
+async def test_future_version_session_preserves_unknown_fields_on_rewrite(storage, tmp_path):
+    """A newer-schema session's unknown fields must survive a rewrite.
+
+    Pre-fix, Pydantic's default extra='ignore' silently stripped unknown
+    top-level / nested fields on model_validate, so the next update_session
+    durably deleted them — the documented upgrade path's silent-data-loss mode.
+    """
+    sid = "trace_20260616_futur1"
+    path = Path(str(tmp_path)) / f"{sid}.json"
+    path.write_text(json.dumps({
+        "id": sid,
+        "trace_version": "0.9.9",
+        "status": "active",
+        "created": "2026-06-16T00:00:00Z",
+        "metadata": {"project": "p", "future_meta_field": "keep-meta"},
+        "events": [],
+        "future_top_level_field": "keep-top",
+    }))
+
+    s = await storage.get_session(sid)
+    await storage.update_session(s)  # full-file rewrite
+
+    raw = json.loads(path.read_text())
+    assert raw.get("future_top_level_field") == "keep-top"
+    assert raw.get("metadata", {}).get("future_meta_field") == "keep-meta"
+
+
+async def test_get_session_warns_on_future_schema_version(storage, tmp_path, caplog):
+    """Loading a newer-schema session must surface a version-skew warning."""
+    import logging
+
+    sid = "trace_20260616_futur2"
+    path = Path(str(tmp_path)) / f"{sid}.json"
+    path.write_text(json.dumps({
+        "id": sid,
+        "trace_version": "0.9.9",
+        "status": "active",
+        "created": "2026-06-16T00:00:00Z",
+        "metadata": {"project": "p"},
+        "events": [],
+    }))
+
+    with caplog.at_level(logging.WARNING):
+        await storage.get_session(sid)
+
+    assert any("0.9.9" in r.message or "version" in r.message.lower() for r in caplog.records)
+
+
+# ── adversarial-review hardening (PR D round 2) ──────────────────────────
+
+
+def _dead_pid() -> int:
+    """A PID that is guaranteed dead: spawn a trivial child and reap it."""
+    proc = subprocess.Popen([sys.executable, "-c", "pass"])
+    proc.wait()
+    return proc.pid
+
+
+async def test_dead_holder_lock_is_stolen_immediately(storage, tmp_path):
+    """A lock whose holder PID is dead is reclaimed at once, regardless of age.
+
+    Steal must key on holder LIVENESS, not just wall-clock age: the default
+    steal_after (60s) would otherwise force a long wait (or a TimeoutError on a
+    short timeout) to reclaim a freshly-crashed holder's lock.
+    """
+    session_id = "trace_20260616_deadpid"
+    storage._ensure_dir()
+    lock_path = Path(str(tmp_path)) / f"{session_id}.lock"
+    lock_path.write_text(f"{_dead_pid()}:0")  # fresh mtime, but holder is dead
+
+    async with storage.lock(session_id, timeout=2.0):  # << steal_after (60s)
+        pass
+
+    assert not lock_path.exists()
+
+
+async def test_live_holder_lock_is_never_stolen(storage, tmp_path):
+    """A lock whose holder PID is alive must NEVER be stolen, even if old.
+
+    The pre-hardening code stole any lock older than steal_after purely on
+    mtime — silently evicting a legitimately long-running holder.
+    """
+    session_id = "trace_20260616_livepid"
+    storage._ensure_dir()
+    lock_path = Path(str(tmp_path)) / f"{session_id}.lock"
+    lock_path.write_text(f"{os.getpid()}:0")  # this very test process is alive
+    old = time.time() - 10_000
+    os.utime(lock_path, (old, old))  # and the lock looks very old
+
+    with pytest.raises(TimeoutError):
+        async with storage.lock(session_id, timeout=0.1, steal_after=1.0):
+            pass
+
+    assert lock_path.exists()  # the live holder's lock was left intact
+
+
+async def test_lock_state_after_timeout_then_clean_reacquire(storage, tmp_path):
+    """After a fail-closed timeout the foreign lock survives; a later acquire works."""
+    session_id = "trace_20260616_react1"
+    storage._ensure_dir()
+    lock_path = Path(str(tmp_path)) / f"{session_id}.lock"
+    lock_path.write_text(f"{os.getpid()}:0")  # alive -> not stolen
+
+    with pytest.raises(TimeoutError):
+        async with storage.lock(session_id, timeout=0.1, steal_after=600.0):
+            pass
+    assert lock_path.exists()  # untouched
+
+    lock_path.unlink()  # holder releases
+    async with storage.lock(session_id, timeout=0.1):
+        pass
+    assert not lock_path.exists()  # reacquired and released cleanly
+
+
+async def test_extra_allow_preserves_unknown_event_and_nested_fields(storage, tmp_path):
+    """extra='allow' must preserve unknown fields at the EVENT and NESTED-data
+    level (not just top-level / metadata) through a rewrite."""
+    sid = "trace_20260616_xtraev"
+    path = Path(str(tmp_path)) / f"{sid}.json"
+    path.write_text(json.dumps({
+        "id": sid,
+        "trace_version": "0.9.9",
+        "status": "active",
+        "created": "2026-06-16T00:00:00Z",
+        "metadata": {"project": "p"},
+        "events": [{
+            "id": "evt_001",
+            "session_id": sid,
+            "type": "annotation",
+            "timestamp": "2026-06-16T00:00:00Z",
+            "actor": {"type": "ai", "id": "claude"},
+            "annotation": {"category": "gotcha", "content": "x", "future_anno_field": "keep-anno"},
+            "future_event_field": "keep-evt",
+        }],
+    }))
+
+    s = await storage.get_session(sid)
+    await storage.update_session(s)
+
+    raw = json.loads(path.read_text())
+    ev = raw["events"][0]
+    assert ev.get("future_event_field") == "keep-evt"
+    assert ev["annotation"].get("future_anno_field") == "keep-anno"
+
+
+async def test_no_version_skew_warning_for_equal_or_older_version(storage, tmp_path, caplog):
+    """A same-version or older session must NOT trigger the skew warning."""
+    import logging
+
+    for ver in (SCHEMA_VERSION, "0.3.0"):
+        sid = f"trace_20260616_v{ver.replace('.', '')}"
+        path = Path(str(tmp_path)) / f"{sid}.json"
+        path.write_text(json.dumps({
+            "id": sid,
+            "trace_version": ver,
+            "status": "active",
+            "created": "2026-06-16T00:00:00Z",
+            "metadata": {"project": "p"},
+            "events": [],
+        }))
+        caplog.clear()
+        with caplog.at_level(logging.WARNING):
+            await storage.get_session(sid)
+        assert not any("newer than this server" in r.message for r in caplog.records), (
+            f"unexpected version-skew warning for {ver}"
+        )
+
+
+async def test_end_session_refuses_when_disk_already_completed(storage):
+    """The under-lock disk-truth guard must block ending an already-completed
+    session via a stale in-memory handle (and must not overwrite the summary)."""
+    active: dict = {}
+    session = await session_tools.create_session(storage, active, project="cc")
+    await session_tools.end_session(storage, active, session_id=session.id, summary="first")
+
+    # A stale handle that still believes the session is active.
+    stale = await storage.get_session(session.id)
+    stale.status = "active"
+    stale.ended = None
+    active2 = {session.id: stale}
+
+    result = await session_tools.end_session(
+        storage, active2, session_id=session.id, summary="SECOND"
+    )
+
+    assert "already ended" in result
+    disk = await storage.get_session(session.id)
+    assert disk.summary == "first"  # the second end did not clobber it
+
+
+async def test_locked_disk_session_without_lock_method():
+    """The helper degrades to a no-op context for a storage backend with no lock."""
+    from trace_mcp.schema import Session, SessionMetadata
+    from trace_mcp.storage.locked import locked_disk_session
+
+    class NoLockStore:
+        def __init__(self) -> None:
+            self._store: dict = {}
+
+        async def get_session(self, sid: str) -> Session:
+            if sid not in self._store:
+                raise FileNotFoundError(sid)
+            return self._store[sid]
+
+        async def update_session(self, s: Session) -> None:
+            self._store[s.id] = s
+
+    store = NoLockStore()
+    mem = Session(id="trace_nolock", metadata=SessionMetadata(project="p"))
+
+    # Not persisted -> yields the fallback (by identity).
+    async with locked_disk_session(store, "trace_nolock", fallback=mem) as disk:
+        assert disk is mem
+    store._store["trace_nolock"] = mem
+    # Persisted -> yields the disk-loaded object.
+    async with locked_disk_session(store, "trace_nolock", fallback=mem) as disk:
+        assert disk is mem  # same object the stub returns


### PR DESCRIPTION
## What this changes

Four data-integrity fixes to the session storage paths, plus a consolidation that stops the same class of gap from recurring. No on-disk format change (positional `evt_NNN` ids and the schema version are unchanged).

- **Fail-closed per-session lock.** On lock-acquisition timeout, `JsonFileStorage.lock` previously logged to stderr and proceeded **unlocked**, silently reopening the lost-update / duplicate-id window the lock exists to close. It now raises `TimeoutError` (surfaced to the caller). Stale-lock theft is gated on holder-PID liveness (single-host) with a `<pid>:<time_ns>` token re-verified before unlink, so a live holder's lock is never stolen and a crashed holder's is reclaimed at once. **Behavior change:** a write can now surface a lock-timeout error instead of degrading to an unsynchronized write.
- **Duplicate event-id guard.** `append_event` refuses to assign an id already present in the reloaded session, instead of silently aliasing `revises_event_id` / `parent_event_id` / `corrects_event_ids` when a record is already in an aliased state.
- **Resilient read aggregates.** `project_summary` and `health_check` catch per-session `ValidationError` / `JSONDecodeError`, log and skip the bad record, and return the skipped ids in a new `skipped_sessions` list — one unreadable file no longer aborts the whole aggregate. **Behavior change:** both return dicts gain `skipped_sessions: list[str]`.
- **Forward-compatible schema.** Schema models preserve unknown fields (`extra="allow"` via a shared `TraceModel` base), so an older server that loads a newer-schema session and rewrites it no longer durably deletes fields it does not recognize; `get_session` logs a version-skew warning. `Environment` stays closed. The generated JSON Schema gains `additionalProperties: true` on those models.
- **One write path.** `append_event`, `end_session`, and `resolve_decision` now route through a single `locked_disk_session` helper, so "write under the fail-closed lock against disk truth" has one implementation. Registered as INV-1 in `docs/INVARIANTS.md`.

## Verification
- 14 regression tests in `tests/test_integrity_hardening.py` (test-first).
- Full suite: 949 passed, 11 skipped. `ruff` + `pyright` clean.
- No version bump or tag.