### PR TITLE
docs: make integrity-fix comments and docs self-contained

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Integrity hardening (PR D)
+### Integrity hardening
 
 - **The per-session lock now fails closed.** On lock-acquisition timeout,
   `JsonFileStorage.lock` previously logged to stderr and proceeded **unlocked**,
@@ -35,9 +35,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   warning. `Environment` intentionally stays closed (legacy-field drop). The
   generated JSON Schema now carries `additionalProperties: true` on those models.
 - **Consolidated the three session write paths** (`append_event`, `end_session`,
-  `resolve_decision`) onto a single `locked_disk_session` helper (the deferred
-  PR #10 consolidation) so "write under the fail-closed lock against disk truth"
-  is one implementation. Registered as **INV-1** in the new `docs/INVARIANTS.md`.
+  `resolve_decision`) onto a single `locked_disk_session` helper — the lock +
+  disk-reload + immutability sequence was previously hand-copied across all three
+  — so "write under the fail-closed lock against disk truth" is one
+  implementation. Registered as **INV-1** in the new `docs/INVARIANTS.md`.
 
 ### Fixed
 

--- a/docs/INVARIANTS.md
+++ b/docs/INVARIANTS.md
@@ -6,14 +6,14 @@ exists to protect. Each invariant lists its exact statement, the **exhaustive
 set of sites** where it must hold, the mechanism that enforces it, and the test
 that pins it.
 
-**Why this file exists.** The 2026-06-10 multi-agent review found that every
-serious defect had the same shape: *an invariant enforced in one place but not
+**Why this file exists.** Every serious data-integrity defect found in this
+codebase has had the same shape: *an invariant enforced in one place but not
 uniformly* (immutability on append/end but not resolve; validation at
 construction but bypassed on assignment; locking on the happy path but silently
 degrading on timeout). The durable fix for that defect *class* is to name each
 invariant, enumerate its sites once, and add a guard that fails when a new
-unguarded site appears. `tests/test_invariants.py` (added in the
-process-scaffolding work) mechanically checks the site-sets below.
+unguarded site appears. `tests/test_invariants.py` mechanically checks the
+site-sets below.
 
 > Status legend: **ENFORCED** = guard + test in place · **PARTIAL** = holds in
 > code but not yet mechanically guarded · **OPEN** = known gap, not yet fixed.
@@ -74,7 +74,7 @@ the parameter as a `Literal`.
 **Site:** `src/trace_mcp/tools/decision_tools.py :: resolve_decision`
 (`VALID_RESOLUTIONS` guard + `model_validate` round-trip).
 
-**Tests.** `tests/test_decision_integrity.py` (C1 brick scenario, Literal sweep).
+**Tests.** `tests/test_decision_integrity.py` (disposition-brick scenario, Literal sweep).
 
 ---
 
@@ -89,7 +89,7 @@ core query layer and in the adapter hooks. Today they disagree: core
 **Sites:** `src/trace_mcp/storage/json_file.py` (`list_sessions`,
 `session_brief`); `src/trace_mcp/adapters/claude_code/assets/hooks/*.sh`.
 
-**Status.** OPEN — verified still present on `main` (2026-06-16 review). The fix
+**Status.** OPEN — still present on `main`. The fix
 (make core exact, or an explicit `exact=` flag defaulting to exact) is tracked
 as a follow-up; `tests/test_invariants.py` should fail until the two layers
 share one predicate.

--- a/src/trace_mcp/schema/session.py
+++ b/src/trace_mcp/schema/session.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 class TraceModel(BaseModel):
     """Base for TRACE schema models that PRESERVE unknown fields.
 
-    PR D #4 (forward-compatibility / schema-version gate): Pydantic v2's default
+    Forward-compatibility: Pydantic v2's default
     ``extra='ignore'`` silently DROPS unknown fields, so an older server that
     loads a newer-schema session and rewrites it durably DELETES every field it
     did not recognize — the documented upgrade path's silent-data-loss mode.

--- a/src/trace_mcp/storage/json_file.py
+++ b/src/trace_mcp/storage/json_file.py
@@ -144,7 +144,7 @@ class JsonFileStorage(TraceStorage):
         pydantic). A lock older than ``steal_after`` is treated as stale (holder
         crashed) and stolen.
 
-        **Fail-closed (PR D):** if the lock cannot be acquired within
+        **Fail closed:** if the lock cannot be acquired within
         ``timeout`` we ``raise TimeoutError`` rather than proceed unlocked. An
         audit store must never silently degrade to an unsynchronized write —
         that reopens the lost-update / duplicate-evt_id window the lock exists

--- a/src/trace_mcp/storage/locked.py
+++ b/src/trace_mcp/storage/locked.py
@@ -1,13 +1,11 @@
 """Shared locked read-modify-write helper for session write paths.
 
-PR D: ``append_event``, ``end_session``, and ``resolve_decision`` each performed
-the same acquire-lock → reload-authoritative-disk-state → mutate → write dance,
-but as three hand-copied blocks (the consolidation deferred in PR #10). Three
-copies is exactly how the H1/H2 immutability gaps arose in the first place — a
-new write path copies two of the three guards and silently drops the third.
-Routing every session write through ONE helper makes "write under the
-per-session lock against the freshest on-disk truth" a single implementation,
-registered as invariant INV-1 in docs/INVARIANTS.md.
+``append_event``, ``end_session``, and ``resolve_decision`` each perform the same
+acquire-lock → reload-authoritative-disk-state → mutate → write sequence. Routing
+every session write through this ONE helper keeps "write under the per-session
+lock against the freshest on-disk truth" a single implementation — so a new write
+path cannot silently reintroduce a lost-update or immutability gap by hand-copying
+only part of the sequence. This is invariant INV-1 in docs/INVARIANTS.md.
 
 Exports:
     locked_disk_session — async context manager yielding the disk-truth Session
@@ -34,7 +32,7 @@ async def locked_disk_session(
 
     Yields the freshest disk-loaded ``Session`` so every read-modify-write path
     sees disk truth: no stale in-memory copy can clobber a concurrent writer's
-    events or resurrect a completed session (the H1 class). If the session is
+    events or resurrect a completed session. If the session is
     not yet persisted — a brand-new session whose first write creates the file —
     yields ``fallback`` (the caller's in-memory ``Session``).
 

--- a/src/trace_mcp/tools/decision_tools.py
+++ b/src/trace_mcp/tools/decision_tools.py
@@ -15,7 +15,7 @@ from trace_mcp.tools.session_tools import append_event
 # the schema's canonical Literal (minus the initial state) so the two can
 # never drift. Validated here — not only via the Literal in the MCP
 # signature — so direct library callers can never write an invalid
-# disposition that bricks the session file on the next load (C1).
+# disposition that bricks the session file on the next load.
 VALID_RESOLUTIONS = tuple(v for v in get_args(DecisionDisposition) if v != "proposed")
 
 
@@ -65,7 +65,7 @@ async def resolve_decision(
 ) -> str:
     """Resolve a previously proposed decision.
 
-    Integrity guarantees (C1/H1/H2):
+    Integrity guarantees:
     - *disposition* must be one of ``VALID_RESOLUTIONS`` — rejected up front,
       and the updated decision is re-validated through Pydantic before any
       write, so an invalid value can never reach disk.
@@ -94,8 +94,8 @@ async def resolve_decision(
     # that is missing a concurrently-appended actor).
     # The helper yields the disk-loaded object (not the caller's in-memory copy)
     # so a stale in-memory status/metadata can't clobber disk state — e.g.
-    # resurrect a session completed by another process (H1) — and acquires the
-    # fail-closed per-session lock (INV-1).
+    # resurrect a session completed by another process — and acquires the
+    # fail-closed per-session lock (INV-1, docs/INVARIANTS.md).
     async with locked_disk_session(storage, session.id, fallback=session) as write_session:
         target = next(
             (e for e in write_session.events if e.id == event_id and e.type == "decision"),

--- a/src/trace_mcp/tools/query_tools.py
+++ b/src/trace_mcp/tools/query_tools.py
@@ -255,12 +255,11 @@ async def project_summary(
         except FileNotFoundError:
             continue
         except (ValidationError, json.JSONDecodeError) as exc:
-            # PR D #3: a schema-invalid / corrupt record must not abort the
-            # whole aggregate. Skip it, LOG it (so the omission isn't silent),
-            # and report it so paper-ready stats stay honest, not silently
-            # wrong. (JSON-corrupt files are already pre-filtered by
-            # list_sessions, so in practice this catches schema-invalid
-            # valid-JSON records.)
+            # A schema-invalid / corrupt record must not abort the whole
+            # aggregate. Skip it, LOG it (so the omission isn't silent), and
+            # report it so the aggregate stats stay honest, not silently wrong.
+            # (JSON-corrupt files are already pre-filtered by list_sessions, so
+            # in practice this catches schema-invalid valid-JSON records.)
             logger.warning("project_summary(%s): skipping unreadable session %s: %s", project, s["id"], exc)
             skipped_sessions.append(s["id"])
 
@@ -416,8 +415,8 @@ async def health_check(
             except FileNotFoundError:
                 continue
             except (ValidationError, json.JSONDecodeError) as exc:
-                # PR D #3: skip-and-report (and log) a schema-invalid/corrupt
-                # record rather than aborting the health probe entirely.
+                # Skip-and-report (and log) a schema-invalid/corrupt record
+                # rather than aborting the health probe entirely.
                 logger.warning("health_check: skipping unreadable session %s: %s", s["id"], exc)
                 skipped_sessions.append(s["id"])
 

--- a/src/trace_mcp/tools/session_tools.py
+++ b/src/trace_mcp/tools/session_tools.py
@@ -757,10 +757,10 @@ async def append_event(
             event.id = session.next_event_id()
         event.session_id = session.id
 
-        # PR D #2: refuse to mint/accept an id that already exists in the
-        # reloaded on-disk session. A positional next_event_id() can only
-        # collide if the record is already aliased (e.g. after a pre-fix
-        # unlocked write left two events sharing an id); writing another event
+        # Refuse to mint/accept an id that already exists in the reloaded
+        # on-disk session. A positional next_event_id() can only collide if the
+        # record is already aliased (e.g. an earlier unlocked write left two
+        # events sharing an id); writing another event
         # under that id would silently alias revises_event_id / parent_event_id
         # / corrects_event_ids references. Fail loudly instead of corrupting.
         if any(e.id == event.id for e in session.events):

--- a/tests/test_integrity_hardening.py
+++ b/tests/test_integrity_hardening.py
@@ -1,7 +1,6 @@
-"""PR D — integrity-hardening cluster regression tests.
+"""Regression tests for the session write/read data-integrity properties.
 
-Covers the four still-open core-integrity findings re-verified against main on
-2026-06-16 (post PRs #10/#11/#12), per the accepted decision evt_002:
+Cover four properties of the session storage paths:
 
   #1  The per-session lock must FAIL CLOSED on timeout (raise) instead of
       silently yielding unlocked, and the stale-lock steal must verify an
@@ -15,9 +14,9 @@ Covers the four still-open core-integrity findings re-verified against main on
   #4  Loading a future-schema-version session must not silently strip and
       durably delete unknown fields on the next rewrite.
 
-The final section covers the PR-D adversarial-review hardening round (lock
-holder-liveness steal, true timeout ceiling, extra='allow' at event/nested
-level, version-skew negative cases, the under-lock end_session guard).
+The final section covers additional hardening: lock holder-liveness steal, a
+true timeout ceiling, extra='allow' at the event/nested level, version-skew
+negative cases, and the under-lock end_session guard.
 
 These are TDD regression tests: each was written RED first.
 """
@@ -218,7 +217,7 @@ async def test_get_session_warns_on_future_schema_version(storage, tmp_path, cap
     assert any("0.9.9" in r.message or "version" in r.message.lower() for r in caplog.records)
 
 
-# ── adversarial-review hardening (PR D round 2) ──────────────────────────
+# ── additional hardening ────────────────────────────────────────────────
 
 
 def _dead_pid() -> int:


### PR DESCRIPTION
Follow-up to #13, which merged before this rewording landed. Reword code comments, docstrings, `docs/INVARIANTS.md`, the `CHANGELOG` heading, and the integrity-test header so they describe what changed and why in terms a reader needs no prior context to follow — removing cluster labels, review dates, and bare finding codes. No behavior change (comment/docstring/doc text only).