### PR TITLE
docs: make pre-existing audit/provenance comments self-contained

### DIFF
--- a/docs/adr/002-v041-protocol-additions.md
+++ b/docs/adr/002-v041-protocol-additions.md
@@ -2,7 +2,7 @@
 
 **Status:** Accepted
 **Date:** 2026-05-14
-**Context:** Quality audit of session `trace_20260513_446733` (waggle project) surfaced five issues in TRACE's audit fidelity. Fix plan (`audit_2026-05-13_waggle_session/trace_v1_FINAL_fix_plan.md`) proposed ~65 items across 11 layers. This ADR documents the v0.4.1 release decisions; deferred items are tracked for later releases.
+**Context:** A quality audit of a production TRACE session surfaced five issues in TRACE's audit fidelity; the remediation plan proposed ~65 items across 11 layers. This ADR documents the v0.4.1 release decisions; deferred items are tracked for later releases.
 
 ---
 
@@ -27,17 +27,17 @@ The protocol stays in the 0.4.x family. Pre-v0.4.1 session files load unchanged 
 
 The v0.3 spec at §3.6 line 220 says "the actor who proposes a decision MUST NOT be the same instance that resolves it, when the workflow involves multiple actors." But the field semantics for `proposed_by` were never precise enough: when a human asks a question, an AI proposes a course of action, and the human accepts ("proceed"), is the proposer the human (who initiated the conversation) or the AI (who authored the proposal content)?
 
-The waggle audit's `evt_025` made this concrete: TRACE logged `proposed_by=human` even though the AI's words populated the entire `description` field. Three rounds of independent verification all concluded this was the dominant attribution failure mode.
+A real multi-actor session made this concrete: TRACE logged `proposed_by=human` even though the AI's words populated the entire `description` field. Independent verification concluded this was the dominant attribution failure mode.
 
-**Decision:** `proposed_by` MUST identify the actor who authored the CONTENT of the proposal (whose words populate `description`), regardless of who spoke last. A 4-row disambiguation table was added to spec §3.6 covering the canonical patterns. The rule is enforced at log time (FM1/FM25) AND at session-end (`attribution_warning_count` in `AttributionAudit`).
+**Decision:** `proposed_by` MUST identify the actor who authored the CONTENT of the proposal (whose words populate `description`), regardless of who spoke last. A 4-row disambiguation table was added to spec §3.6 covering the canonical patterns. The rule is enforced at proposal-resolution time AND at session-end (`attribution_warning_count` in `AttributionAudit`).
 
-**Amended 2026-05-18 (Round-3 A1 / decision `evt_016`):** the original v0.4.1 implementation generalized FM1 to *all* same-instance pairs unconditionally, which false-fired on legitimate single-actor sessions (solo human, `system→system`) — the exact false positive the waggle audit identified with production data. The generalized **non-`ai`** same-instance check now fires only when the session involves **≥2 distinct actor *types*** (union of `metadata.participants` and event actors; mirrored in `Session.is_multi_actor()` and the `decision-audit.sh` hook). The pre-existing v0.3 **`ai→ai`** self-resolution warning remains **unconditional** (AI must not resolve its own proposal regardless of actor count). Spec §3.6 ("when the workflow involves multiple actors") was already correct; only the implementation and this record were brought into line with it.
+**Amended 2026-05-18:** the original v0.4.1 implementation generalized the same-instance self-resolution check to *all* same-instance pairs unconditionally, which false-fired on legitimate single-actor sessions (solo human, `system→system`) — the exact false positive identified with production data. The generalized **non-`ai`** same-instance check now fires only when the session involves **≥2 distinct actor *types*** (union of `metadata.participants` and event actors; mirrored in `Session.is_multi_actor()` and the `decision-audit.sh` hook). The pre-existing v0.3 **`ai→ai`** self-resolution warning remains **unconditional** (AI must not resolve its own proposal regardless of actor count). Spec §3.6 ("when the workflow involves multiple actors") was already correct; only the implementation and this record were brought into line with it.
 
 **Considered and rejected:** adding a new field like `proposal_authored_by` separate from `proposed_by`. This would just shift the bug to a new location.
 
 ### D2: URI-form `corrects_event_ids` rather than new event types
 
-The audit's `evt_003` had `corrects_event_ids: []` because the corrected entity (a subagent's false claim) was not a TRACE event. The existing field semantics required event-ID references and `_check_referential_integrity` would reject anything else.
+A real correction had `corrects_event_ids: []` because the corrected entity (a subagent's false claim) was not a TRACE event. The existing field semantics required event-ID references and `_check_referential_integrity` would reject anything else.
 
 **Decision:** widen `corrects_event_ids` to accept URI-form references prefix-discriminated by `[a-z][a-z0-9-]+:`. Define `external:<uri>` as the normative universal fallback; `jsonl:`, `subagent:`, `tool-result:` as non-normative implementer examples. Carve out URI-form entries in `_check_referential_integrity` so they bypass in-session existence checking.
 
@@ -87,7 +87,7 @@ The audit's Issue 5 (42 uncaptured Agent dispatches) could be partially closed b
 
 ### D8: Three-round verification gates the release
 
-The fix plan was developed over multiple rounds of independent subagent verification. Each round identified gaps the previous round missed — Round 1 produced 10 findings, Round 2 produced 13 additional corrections, Round 3 produced 10 more amendments, and a Final Verifier round identified 7 more spec/test/installer fixes.
+The fix plan was developed over multiple rounds of independent verification, plus a final verifier pass. Each round identified gaps the previous round missed — corrections, amendments, and additional spec/test/installer fixes accumulated across the rounds, with each pass narrowing the remaining gap.
 
 **Decision:** establish three rounds of independent verification as the gate for the release. Document deferred items explicitly (in CHANGELOG, in HTML checklist, in this ADR). The discipline of "match implementation to CHANGELOG before push" is itself a release-quality contract that follows from the protocol's own "Never fabricate" rule.
 
@@ -99,7 +99,7 @@ The fix plan was developed over multiple rounds of independent subagent verifica
 
 **Adapter assets updated:**
 - `CLAUDE_BLOCK.md` (the block `trace-mcp-init` installs into consumer projects) now documents Proposer Identity Rule, URI-form references, discovery category, snippet absence markers, and subagent dispatch logging.
-- `decision-audit.sh` hook script generalizes the `ai`-only self-resolution check to non-`ai` same-instance pairs **in multi-actor sessions** (Round-3 A1 / `evt_016`; mirrors the server-side `Session.is_multi_actor()` guard — single-actor sessions are exempt), and surfaces the new audit fields (missing snippets, attribution warnings).
+- `decision-audit.sh` hook script generalizes the `ai`-only self-resolution check to non-`ai` same-instance pairs **in multi-actor sessions** (mirrors the server-side `Session.is_multi_actor()` guard — single-actor sessions are exempt), and surfaces the new audit fields (missing snippets, attribution warnings).
 
 **Delivered in this batch (originally listed as deferred):**
 - Schema file rename `schemas/trace-v0.3.json` → `schemas/trace-v0.4.json` with the `$id` cascade applied to `scripts/generate_schema.py`, `scripts/validate_session.py`, README, CONTRIBUTING, spec, and conformance tests. The PROV namespace URI and `Session.context` URL remain at v0.3 per D6.
@@ -111,8 +111,6 @@ The fix plan was developed over multiple rounds of independent subagent verifica
 
 ## References
 
-- Source audit: `audit_2026-05-13_waggle_session/trace_audit_findings.md`
-- Remediation plan: `audit_2026-05-13_waggle_session/trace_v1_FINAL_fix_plan.md`
-- Round 3 amendments: `audit_2026-05-13_waggle_session/trace_v1_round3_amendments.md`
+- These decisions derive from an attribution audit of a production TRACE session and its multi-round remediation plan.
 - Spec changes: `docs/specification.md` (sections 3.4.1, 3.5, 3.6, 3.7, 3.7.1, 4.4, 5.2, 6, 8.1, 8.2, Appendix B)
 - W3C PROV-O qualified influence pattern: https://www.w3.org/TR/prov-o/#qualifiedInfluence

--- a/docs/adr/003-core-extension-boundary.md
+++ b/docs/adr/003-core-extension-boundary.md
@@ -7,15 +7,15 @@
 TRACE's identity is **decision provenance**. The `trace-learn` extension
 (cross-session knowledge: recall, dedup, decay, and the planned Tier-3
 RL-style feedback loop + cross-project knowledge) is valuable and likely
-popular, but it is *not* the core thesis. Round-1/2/3 of the 2026-05-18
-quality review found this boundary was asserted only in a single
+popular, but it is *not* the core thesis. A multi-round quality review
+found this boundary was asserted only in a single
 under-scoped CONTRIBUTING line and — worse — was **violated in `main`**:
 `tools/query_tools.py` hard-imported `trace_mcp.extensions.learn`
 unguarded, so deleting the extension broke the core tool
-`trace_project_summary` (finding G2). The user set an explicit governance
-constraint (TRACE session `trace_20260518_5dd958`, decision **`evt_002`**)
-that adaptive learning must remain a strict optional extension with no
-scope creep into core.
+`trace_project_summary`. The user set an explicit governance
+constraint — the core/extension boundary decision — that adaptive
+learning must remain a strict optional extension with no scope creep
+into core.
 
 ## Decision
 

--- a/src/trace_mcp/adapters/claude_code/assets/hooks/decision-audit.sh
+++ b/src/trace_mcp/adapters/claude_code/assets/hooks/decision-audit.sh
@@ -6,8 +6,9 @@
 #
 # Detection logic generalized per spec §3.6 Proposer Identity Rule —
 # self-resolution check now fires on ANY same-instance pair (type AND
-# id match), not just ai→ai. Catches the evt_025 pattern (human→human
-# self-resolution in multi-actor session).
+# id match), not just ai→ai. This catches same-instance self-resolution
+# between non-ai actors (e.g. human→human in a multi-actor session), not
+# only the ai→ai case.
 
 SESSIONS_DIR="${TRACE_SESSIONS_DIR:-$HOME/.trace/sessions}"
 
@@ -35,12 +36,13 @@ except Exception:
 
 events = data.get("events", [])
 
-# Round-3 A1 / decision evt_016: multi-actor guard, mirroring server-side
-# Session.is_multi_actor(). Union of declared participants and observed
-# event actor *types*; the generalized (non-ai) same-instance warning only
-# fires when the session has >=2 distinct actor types. A single-actor
-# session (solo human, system->system) legitimately self-resolves and must
-# NOT be flagged (the false positive the audit named with production data).
+# Multi-actor guard, mirroring server-side Session.is_multi_actor()
+# (see docs/adr/002-v041-protocol-additions.md). Union of declared
+# participants and observed event actor *types*; the generalized (non-ai)
+# same-instance warning only fires when the session has >=2 distinct actor
+# types. A single-actor session (solo human, system->system) legitimately
+# self-resolves and must NOT be flagged — gating on multi-actor avoids that
+# false positive.
 _meta = data.get("metadata") or {}
 _actor_types = {
     (p or {}).get("type")
@@ -84,7 +86,7 @@ for e in events:
             if pb.get("type") == rb.get("type") == "ai":
                 ai_self_resolved += 1
             # v0.4.1 generalized: same (type, id) pair, gated to
-            # multi-actor sessions per Round-3 A1 / decision evt_016.
+            # multi-actor sessions (see docs/adr/002-v041-protocol-additions.md).
             if multi_actor and pb.get("type") == rb.get("type") and pb.get("id") == rb.get("id"):
                 same_instance_self_resolved += 1
 
@@ -93,7 +95,7 @@ for e in events:
             orphan_correction += 1
         # Missing snippet on a correction is a spec §3.4.1 MUST violation.
         # v0.4.1 amendment: also count whitespace-only / empty snippet as
-        # missing (closes the silent-bypass path Verifier C identified).
+        # missing — a blank snippet would otherwise silently pass this check.
         if snip is None or (not is_absence(snip) and not snip.strip()):
             missing_snippet_correction += 1
 

--- a/src/trace_mcp/exporters/prov_jsonld.py
+++ b/src/trace_mcp/exporters/prov_jsonld.py
@@ -7,8 +7,8 @@ PROV-O triples.
 
 History: v0.4.x originally emitted W3C *PROV-JSON* (a different
 serialization) under a JSON-LD ``@context`` — a conformant JSON-LD
-parser extracted **zero** triples from it. P5 / Round-3 A-R3-7 replaced
-that with this conformant node-object form (verified by an rdflib
+parser extracted **zero** triples from it; this was replaced with
+this conformant node-object form (verified by an rdflib
 round-trip test). Semantics are unchanged: the v0.4.1 correction split
 (event-ID target → ``prov:wasInvalidatedBy``; URI-form target →
 ``prov:qualifiedInfluence`` → a ``prov:Influence`` node bearing

--- a/src/trace_mcp/extension_status.py
+++ b/src/trace_mcp/extension_status.py
@@ -7,7 +7,8 @@ Claude Code) at session start and recorded in the session JSON.
 
 Lives in core (not under ``extensions/``) and probes the OPTIONAL
 trace-learn extension defensively via guarded imports — this keeps the
-core/extension boundary intact (governance: TRACE decision evt_002) and
+core/extension boundary intact (the optional extension must never be a
+hard dependency of core; see docs/adr/003-core-extension-boundary.md) and
 makes the probe fail-safe: a status check must never break session start.
 """
 

--- a/src/trace_mcp/extensions/learn/__init__.py
+++ b/src/trace_mcp/extensions/learn/__init__.py
@@ -100,10 +100,10 @@ def register(mcp: FastMCP, storage: TraceStorage) -> None:
         tags: list[str] | None,
         limit: int,
     ) -> list[dict]:
-        # P9(b) / A-R3-2: lock the full load→embed→save RMW span. This is
+        # Lock the full load→embed→save read-modify-write span. This is
         # the highest-frequency knowledge-store mutator (core auto-recall);
         # leaving it unlocked allowed a concurrent locked add to be
-        # clobbered (lost-update — caught by the final-gate reviewers).
+        # clobbered (a lost update).
         with store.project_lock(project):
             ks = store.load_store(project)
             if not ks.learnings:
@@ -124,7 +124,7 @@ def register(mcp: FastMCP, storage: TraceStorage) -> None:
             return results
 
     async def _extract_hook(project: str, session_id: str) -> list[str]:
-        with store.project_lock(project):  # P9(b) / A-R3-2
+        with store.project_lock(project):  # lock the full read-modify-write span
             ks = store.load_store(project)
             sess = await storage.get_session(session_id)
             new_ids = await extraction.extract_from_session_auto(ks, sess, _config)
@@ -154,7 +154,7 @@ def register(mcp: FastMCP, storage: TraceStorage) -> None:
         When threshold is None, uses the backend's default (BM25: 0.15, LLM: 0.2).
         """
         try:
-            # P9(b) / A-R3-2: lock the full span (recall may backfill
+            # Lock the full span (recall may backfill
             # embeddings and save — a read-modify-write).
             with store.project_lock(project):
                 ks = store.load_store(project)
@@ -210,9 +210,9 @@ def register(mcp: FastMCP, storage: TraceStorage) -> None:
                 return json.dumps({
                     "error": f"Invalid category '{category}'. Must be one of: {_VALID_CATEGORIES}",
                 })
-            # P9(b) / Round-3 A-R3-2: lock the full load→mutate→save span
-            # so concurrent multi-session adds to the same project don't
-            # lose updates (last-writer-wins on the shared store).
+            # Lock the full load->mutate->save span so concurrent
+            # multi-session adds to the same project don't lose updates
+            # (last-writer-wins on the shared store).
             with store.project_lock(project):
                 ks = store.load_store(project)
                 if _config.dedup_enabled:
@@ -284,7 +284,7 @@ def register(mcp: FastMCP, storage: TraceStorage) -> None:
         Use this when a learning is outdated, wrong, or no longer relevant.
         """
         try:
-            with store.project_lock(project):  # P9(b) / A-R3-2
+            with store.project_lock(project):  # lock the full read-modify-write span
                 ks = store.load_store(project)
                 removed = store.remove_learning(ks, learning_id)
                 if not removed:
@@ -312,7 +312,7 @@ def register(mcp: FastMCP, storage: TraceStorage) -> None:
         Otherwise, extracts from all sessions for the project.
         """
         try:
-            # P9(b) / A-R3-2: lock the full multi-session extract→embed→save.
+            # Lock the full multi-session extract→embed→save span.
             with store.project_lock(project):
                 ks = store.load_store(project)
                 all_new_ids: list[str] = []

--- a/src/trace_mcp/extensions/learn/embeddings.py
+++ b/src/trace_mcp/extensions/learn/embeddings.py
@@ -60,7 +60,7 @@ class EmbeddingProvider(Protocol):
     @property
     def dimensions(self) -> int:
         """Embedding vector dimensionality. Read-only so providers may
-        compute it lazily (P9(a)) without violating Protocol invariance;
+        compute it lazily without violating Protocol invariance;
         a concrete ``int`` attribute also satisfies this."""
         ...
 
@@ -107,15 +107,15 @@ class Model2VecEmbeddingProvider:
         if not _HAS_MODEL2VEC:
             raise RuntimeError("model2vec package is required for local embeddings")
         self.model_name = model_name
-        # P9(a): the StaticModel is loaded LAZILY on first embedding use, not
+        # The StaticModel is loaded LAZILY on first embedding use, not
         # at construction. The provider is built in the extension's
         # register() at server startup; eager loading meant every concurrent
         # session held a resident model (large idle RAM) and paid a
-        # cold-start latency (the FM7 E2E-flake root cause).
+        # cold-start latency (a root cause of E2E test flakiness).
         self._model: Any = None
 
     def _get_model(self) -> Any:
-        """Load and cache the StaticModel on first use (P9(a) lazy load)."""
+        """Load and cache the StaticModel on first use (lazy load)."""
         if self._model is None:
             from model2vec import StaticModel
 

--- a/src/trace_mcp/extensions/learn/store.py
+++ b/src/trace_mcp/extensions/learn/store.py
@@ -46,7 +46,7 @@ _warned_no_filelock = False
 def project_lock(project: str, directory: str | None = None) -> Iterator[None]:
     """Per-project cross-process lock around a load→mutate→save span.
 
-    P9(b) / Round-3 amendment A-R3-2. The shared knowledge store is
+    The shared knowledge store is
     read-modify-write; without a lock, two TRACE sessions mutating the
     SAME project concurrently silently lose one update (last-writer-wins).
     The lock is keyed per-project (not whole-directory) so unrelated
@@ -315,7 +315,7 @@ def save_embeddings_cache(store: KnowledgeStore, directory: str | None = None) -
             matrix[i] = lrn.embedding
 
     path = _embeddings_cache_path(store.project, directory)
-    # P9(c) / Round-3 A-R3-8: atomic write — a crash or a concurrent reader
+    # Atomic write — a crash or a concurrent reader
     # must never observe a torn .npy sidecar. Mirrors the temp + os.replace
     # atomic pattern used for the JSON store. Same-directory temp guarantees
     # os.replace is an atomic rename on the same filesystem.

--- a/src/trace_mcp/schema/session.py
+++ b/src/trace_mcp/schema/session.py
@@ -123,9 +123,10 @@ class Session(TraceModel):
     def distinct_actor_types(self) -> set[str]:
         """Unique actor types across declared participants ∪ event actors.
 
-        Per Round-3 amendment A1 / decision evt_016: the union of declared
-        participants and observed event actors. When participants is empty
-        this naturally falls back to the event actors alone (Round-3 A7).
+        Returns the union of declared participants and observed event
+        actors (see docs/adr/002-v041-protocol-additions.md). When
+        participants is empty this naturally falls back to the event actors
+        alone.
         """
         types: set[str] = {p.type for p in self.metadata.participants}
         types.update(e.actor.type for e in self.events)
@@ -137,7 +138,7 @@ class Session(TraceModel):
         Gates the general-case (non-ai) same-instance self-resolution
         warning (spec §3.6 Proposer Identity Rule). In a single-actor
         session the same actor proposing and resolving is legitimate, not
-        an attribution concern — flagging it is the false positive Round-3
-        amendment A1 identified with production data.
+        an attribution concern — flagging it is a known false positive,
+        confirmed against real multi-actor session data.
         """
         return len(self.distinct_actor_types()) >= 2

--- a/src/trace_mcp/tools/decision_tools.py
+++ b/src/trace_mcp/tools/decision_tools.py
@@ -117,9 +117,10 @@ async def resolve_decision(
         # --- Guard rails (computed from the authoritative disk state) ---
         guard_warnings: list[str] = []
 
-        # FM1: Same-instance self-resolution
-        # v0.4.1 + Round-3 A1 / evt_016: generalized from ai-only per spec §3.6
-        # Proposer Identity Rule. Detects when the same Actor instance (type AND
+        # Same-instance self-resolution
+        # v0.4.1: generalized from ai-only to all same-instance pairs in
+        # multi-actor sessions, per spec §3.6 Proposer Identity Rule. Detects
+        # when the same Actor instance (type AND
         # id) proposes and resolves. The ai→ai case warns unconditionally; the
         # generalized non-ai case is gated to multi-actor sessions (see below).
         proposer = target.decision.proposed_by
@@ -138,23 +139,23 @@ async def resolve_decision(
                     "should normally be resolved by a human."
                 )
             elif write_session.is_multi_actor():
-                # v0.4.1 + Round-3 A1 / evt_016: the evt_025 pattern —
-                # human→human (or system→system) same-instance self-resolution.
-                # Gated to multi-actor sessions (≥2 actor types): in a
-                # single-actor session this is legitimate, not an attribution
-                # concern (the false positive A1 named with production data).
+                # v0.4.1: human→human (or system→system) same-instance
+                # self-resolution. Gated to multi-actor sessions (≥2 actor
+                # types): in a single-actor session this is legitimate, not an
+                # attribution concern (gating here avoids the false positive that
+                # a single-actor session would otherwise raise).
                 guard_warnings.append(
                     "Same actor instance proposed and resolved this decision. "
                     "Per spec §3.6, in multi-actor workflows the proposer should "
                     "differ from the resolver."
                 )
 
-        # FM25: Suspiciously fast resolution (propose + resolve <5s by same
+        # Suspiciously fast resolution (propose + resolve <5s by same
         # instance). ai→ai always warns (fast AI self-resolution is suspicious
         # regardless of actor count); the general non-ai case is gated to
-        # multi-actor sessions, mirroring FM1 (Round-3 amendment A-R3-1 — without
-        # this split, gating FM25 wholesale would silently drop the §3-correct
-        # ai→ai FM25 warning).
+        # multi-actor sessions, mirroring the same-instance self-resolution
+        # check above — without this split, gating this wholesale would silently
+        # drop the spec-correct ai→ai warning.
         if is_self_resolution and not suppress:
             elapsed = (datetime.now(UTC) - target.timestamp).total_seconds()
             if elapsed < 5.0 and (resolved_by_type == "ai" or write_session.is_multi_actor()):
@@ -163,7 +164,7 @@ async def resolve_decision(
                     "Was the other actor consulted before resolving?"
                 )
 
-        # FM31: Rejection -> suggest correction annotation
+        # Rejection -> suggest correction annotation
         if disposition == "rejected":
             guard_warnings.append(
                 "Decision rejected. Consider logging a correction annotation "

--- a/src/trace_mcp/tools/logging_tools.py
+++ b/src/trace_mcp/tools/logging_tools.py
@@ -46,7 +46,7 @@ async def log_tool_call(
     """
     warnings: list[str] = []
 
-    # FM22: Block logging TRACE's own tool calls
+    # Block logging TRACE's own tool calls
     server_lower = server.lower()
     tool_lower = tool_name.lower()
     if "trace" in server_lower or tool_lower.startswith("trace_"):
@@ -55,7 +55,7 @@ async def log_tool_call(
             "This event was logged but should be avoided."
         )
 
-    # FM23: Hint about exploratory tool calls
+    # Hint about exploratory tool calls
     # v0.4.1: scoped to host="mcp" only. Host-internal tools have their own
     # exploratory names (e.g., Claude Code's Read/Grep/Bash) and don't share
     # the MCP-side convention.
@@ -112,7 +112,7 @@ async def log_annotation(
     effective_corrects = corrects_event_ids or []
     effective_related = related_event_ids or []
 
-    # FM17: Correction without any anchor.
+    # Correction without any anchor.
     # v0.4.1: relaxed — only fires when BOTH corrects_event_ids AND
     # conversation_snippet are empty. A correction needs SOME anchor
     # (event ID, URI-form ref, or quoted snippet) per spec §5.2.
@@ -124,10 +124,11 @@ async def log_annotation(
             "(c) a conversation_snippet quoting the corrected statement. See spec §3.7.1."
         )
 
-    # FM17 co-occurrence (v0.4.1, new): when a correction has empty
+    # Co-occurrence check (v0.4.1, new): when a correction has empty
     # corrects_event_ids but non-empty related_event_ids, the related_event_ids
     # is likely being used as a workaround for the correction relationship.
-    # This is the evt_003 anti-pattern surfaced by the waggle audit.
+    # This is the anti-pattern of a correction with no corrects_event_ids and
+    # no anchor, where related_event_ids stands in for the correction link.
     if (
         category == "correction"
         and not effective_corrects
@@ -140,7 +141,7 @@ async def log_annotation(
             "the correction relationship. See spec §3.7.1."
         )
 
-    # FM5: Correction without conversation_snippet (v0.4.1 sharpened).
+    # Correction without conversation_snippet (v0.4.1 sharpened).
     if category == "correction" and conversation_snippet is None:
         warnings.append(
             "Correction logged without conversation_snippet. Set to the relevant "
@@ -149,7 +150,7 @@ async def log_annotation(
             "protocol violation per spec §3.4.1."
         )
 
-    # FM26: Gotcha with corrects_event_ids suggests reclassification
+    # Gotcha with corrects_event_ids suggests reclassification
     if category == "gotcha" and effective_corrects:
         warnings.append(
             "Gotcha logged with corrects_event_ids — consider whether this "
@@ -196,7 +197,7 @@ async def log_contribution(
     warnings: list[str] = []
     effective_decision_ids = related_decision_ids or []
 
-    # FM5: Missing conversation_snippet (v0.4.1 sharpened).
+    # Missing conversation_snippet (v0.4.1 sharpened).
     if conversation_snippet is None:
         warnings.append(
             "Contribution logged without conversation_snippet. Set to the relevant "
@@ -205,7 +206,7 @@ async def log_contribution(
             "protocol violation per spec §3.4.1."
         )
 
-    # FM3 (partial): No related_decision_ids.
+    # No related_decision_ids.
     # v0.4.1: demoted to fire only when the session actually has decisions.
     # If the session has zero decisions, "consider linking" is noise that
     # trains controllers to ignore the whole warning block.

--- a/src/trace_mcp/tools/query_tools.py
+++ b/src/trace_mcp/tools/query_tools.py
@@ -176,10 +176,11 @@ def _compute_knowledge_metrics(project: str) -> dict[str, Any]:
     Returns total learnings, category breakdown, most-surfaced learnings,
     never-surfaced count, and average recall count.
 
-    Core/extension boundary (governance: TRACE decision evt_002): the
-    trace-learn extension is OPTIONAL. When it is absent, this fails open
-    with the zero sentinel so the core tool `trace_project_summary` stays
-    functional — `import` must never break a core tool.
+    Core/extension boundary (see docs/adr/003-core-extension-boundary.md):
+    the optional trace-learn extension must never be a hard dependency of a
+    core tool. When it is absent, this fails open with the zero sentinel so
+    the core tool `trace_project_summary` stays functional — `import` must
+    never break a core tool.
     """
     try:
         from trace_mcp.extensions.learn.store import load_store
@@ -389,8 +390,8 @@ async def health_check(
 
     # Knowledge dir is reported for diagnostics only. Compute it from the env
     # WITHOUT importing the trace-learn extension — core must not depend on the
-    # extension (HARD CONSTRAINT #1 / governance evt_002). This mirrors the
-    # extension's own default resolution.
+    # extension (HARD CONSTRAINT #1; see docs/adr/003-core-extension-boundary.md).
+    # This mirrors the extension's own default resolution.
     knowledge_dir = str(Path(os.environ.get("TRACE_KNOWLEDGE_DIR", "~/.trace/knowledge")).expanduser())
     knowledge_dir_exists = Path(knowledge_dir).is_dir()
 

--- a/src/trace_mcp/tools/session_tools.py
+++ b/src/trace_mcp/tools/session_tools.py
@@ -66,7 +66,7 @@ def _is_explicit_absence(s: str | None) -> bool:
 
 
 # v0.4.1: phrase list for orphan-discovery hint detector (spec §3.7 + §8.1).
-# Tightened in the v0.4.1 remediation (P4 / A8): dropped the over-broad
+# Tightened in the v0.4.1 remediation: dropped the over-broad
 # "turned out" (false-positive on routine prose like "turned out cleaner").
 # The remaining phrases are technical-discovery markers that strongly
 # suggest a load-bearing finding that should have been its own
@@ -97,8 +97,9 @@ class AttributionAudit(BaseModel):
     unlinked_correction_count: int = 0
     warnings: list[str] = Field(default_factory=list)
 
-    # v0.4.1: extended audit fields surfacing the silent-warning failures
-    # from the waggle audit. Default 0 keeps the model backward-compatible.
+    # v0.4.1: extended audit fields surfacing silent-warning failures (warnings
+    # that were computed but never reported). Default 0 keeps the model
+    # backward-compatible.
     missing_snippet_contribution_count: int = 0
     missing_snippet_correction_count: int = 0
     explicit_absence_snippet_count: int = 0
@@ -223,7 +224,8 @@ def _build_attribution_audit(session: Session) -> AttributionAudit:
 
     v0.4.1: extended with snippet coverage counts, structural attribution
     warning, orphan-discovery hint, and dispatch-visibility hint. All new
-    metrics surface the silent-warning failures the waggle audit identified.
+    metrics surface silent-warning failures (warnings computed but never
+    reported) that a production-session audit identified.
     """
     from datetime import timedelta
 
@@ -276,7 +278,7 @@ def _build_attribution_audit(session: Session) -> AttributionAudit:
                 description_preview=desc,
             ))
 
-            # v0.4.1 L5.3: count contributions missing conversation_snippet.
+            # v0.4.1: count contributions missing conversation_snippet.
             # explicit_absence markers count separately so honest absences
             # (no user message during autonomous stretch) aren't penalized.
             snip = e.context.conversation_snippet
@@ -285,7 +287,7 @@ def _build_attribution_audit(session: Session) -> AttributionAudit:
             elif _is_explicit_absence(snip):
                 explicit_absence_snippet += 1
 
-            # v0.4.1 L5.5: orphan-discovery hint. If this contribution's
+            # v0.4.1: orphan-discovery hint. If this contribution's
             # description contains a discovery phrase but no
             # discovery/correction/gotcha annotation exists within 30 min
             # before this contribution, the discovery was likely logged
@@ -315,7 +317,7 @@ def _build_attribution_audit(session: Session) -> AttributionAudit:
             elif d.disposition == "revised":
                 revised.append(e)
 
-            # FM1/FM9: Track unresolved and (ai-only) self-resolved decisions
+            # Track unresolved and (ai-only) self-resolved decisions
             if d.disposition == "proposed":
                 unresolved_ids.append(e.id)
             elif d.resolved_by:
@@ -323,15 +325,17 @@ def _build_attribution_audit(session: Session) -> AttributionAudit:
                 if d.proposed_by.type == d.resolved_by.type == "ai":
                     self_resolved_ids.append(e.id)
 
-                # v0.4.1 L5.4 + Round-3 A1 / evt_016: STRUCTURAL
+                # v0.4.1 multi-actor refinement (see
+                # docs/adr/002-v041-protocol-additions.md): STRUCTURAL
                 # attribution-warning detector. Same-instance self-resolution
                 # (type AND id), gated to MULTI-ACTOR sessions (≥2 actor
-                # types). Catches the evt_025 pattern (human-proposes plan,
-                # human-accepts) in a real multi-actor workflow, while not
-                # false-firing on single-actor sessions (solo human, ai→ai
-                # solo, system→system) — the false positive A1 named with
-                # production data. ai→ai is still surfaced separately and
-                # unconditionally via self_resolved_ids above.
+                # types). Catches the pattern where one actor both proposes a
+                # plan and accepts it (e.g. human-proposes, human-accepts) in a
+                # real multi-actor workflow, while not false-firing on
+                # single-actor sessions (solo human, ai→ai solo, system→system)
+                # — the false positive the gating addresses. ai→ai is still
+                # surfaced separately and unconditionally via self_resolved_ids
+                # above.
                 if (
                     d.proposed_by.type == d.resolved_by.type
                     and d.proposed_by.id == d.resolved_by.id
@@ -341,11 +345,11 @@ def _build_attribution_audit(session: Session) -> AttributionAudit:
 
         elif e.type == "annotation" and e.annotation and e.annotation.category == "correction":
             corrections.append(e)
-            # FM17: Correction without corrects_event_ids
+            # Correction without corrects_event_ids
             if not e.annotation.corrects_event_ids:
                 unlinked_correction_count += 1
 
-            # v0.4.1 L5.3: count corrections missing conversation_snippet.
+            # v0.4.1: count corrections missing conversation_snippet.
             snip = e.context.conversation_snippet
             if snip is None:
                 missing_snippet_correction += 1
@@ -381,10 +385,10 @@ def _build_attribution_audit(session: Session) -> AttributionAudit:
             f"{unlinked_correction_count} correction(s) lack corrects_event_ids — "
             "link them for full provenance."
         )
-    # P4 / A8: orphan-discovery is surfaced ONLY as the low-severity
+    # Orphan-discovery is surfaced ONLY as the low-severity
     # `orphan_discovery_hint_count` (rendered separately). It is deliberately
     # NOT pushed into `audit_warnings` — duplicating a heuristic signal at
-    # warning severity over-weighted it (Round-1/2/3 finding).
+    # warning severity over-weighted it.
     if missing_snippet_contribution or missing_snippet_correction:
         parts3: list[str] = []
         if missing_snippet_contribution:
@@ -396,8 +400,8 @@ def _build_attribution_audit(session: Session) -> AttributionAudit:
             "Set to the user message or use '<autonomous-stretch>' to mark explicit absence."
         )
 
-    # v0.4.1 L5.6: dispatch-visibility hint (advisory only, no counter).
-    # Raised threshold per Round 3 amendment A3 — production sessions
+    # v0.4.1: dispatch-visibility hint (advisory only, no counter).
+    # Threshold raised by a later refinement — production sessions
     # routinely have 0 tool_call events, so a low threshold would generate
     # permanent noise. Guard against missing environment for legacy sessions.
     env = session.metadata.environment
@@ -573,7 +577,8 @@ async def start_session(
 
     path = storage._session_path(session.id) if hasattr(storage, "_session_path") else "disk"  # type: ignore[attr-defined]
     # Core-level, fail-safe probe of the OPTIONAL trace-learn extension
-    # (keeps the core/extension boundary intact — governance evt_002).
+    # (keeps the core/extension boundary intact — see
+    # docs/adr/003-core-extension-boundary.md).
     from trace_mcp.extension_status import get_extension_status
 
     return (
@@ -699,7 +704,7 @@ def _check_referential_integrity(
     # v0.4.1: parent_event_id on tool_call must point to a real event in the
     # session (the controller-side event that motivated the dispatch). Without
     # this check, PROV-LD's wasInformedBy edges could silently point at
-    # nonexistent events — Verifier C correctly flagged this gap.
+    # nonexistent events.
     if event.tool_call and event.tool_call.parent_event_id:
         ids_to_check.append((event.tool_call.parent_event_id, "parent_event_id"))
 
@@ -732,7 +737,8 @@ async def append_event(
     without a ``lock`` degrade to a no-op context (no behaviour change).
 
     Raises ValueError if the session is already completed (immutability guard)
-    or if event references point to nonexistent events (FM13/FM16/FM17).
+    or if event references point to nonexistent events (referential-integrity
+    check).
     """
     # Fast-path guard on the in-memory view.
     if session.status == "completed":
@@ -772,7 +778,7 @@ async def append_event(
                 f"file rather than appending."
             )
 
-        # FM13/FM16/FM17: validate referential integrity against the merged state.
+        # Validate referential integrity against the merged state.
         ref_errors = _check_referential_integrity(session, event)
         if ref_errors:
             raise ValueError(


### PR DESCRIPTION
## What

Reword pre-existing code comments, docstrings, and architecture-decision-record prose that cited internal development shorthand a fresh reader cannot resolve — bare decision-event ids, review-round and amendment codes, failure-mode index numbers, work-package labels, an internal cross-project session nickname, a review-agent reference, and pointers to local-only working files. Each now states its rule or rationale in durable terms.

This completes the self-contained-writing pass: an earlier pass cleaned the files it changed but deliberately left these pre-existing comments untouched.

## Scope

- 11 source files under `src/trace_mcp/` plus two ADRs (`docs/adr/002-v041-protocol-additions.md`, `docs/adr/003-core-extension-boundary.md`).
- In-repo references kept or strengthened: spec section ids, the ADR files (re-pointed where an ADR documents the rule), version tags, and real code identifiers.
- Intentionally excluded: `docs/specification.md` and `docs/examples.md`, whose example event ids are legitimate illustrations of the protocol's own id format, not internal citations.

## No behavior change

Comment, docstring, and markdown text only. Executable code — including the `decision-audit.sh` predicate and the `project_lock` calls whose trailing comments changed — is untouched.

## Verification

- `ruff check src/` — clean
- `pyright src/` — 0 errors
- `pytest` — 952 passed, 11 skipped
- An exhaustive label sweep over the affected sources and ADRs confirms no unresolvable internal label remains. The one retained event-id reference points at the spec's Appendix A worked example, which resolves in-repo.