### PR TITLE
feat(selfcost): offline self-cost report + telemetry-sidecar ADR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Diagnostics
+
+- **Offline self-cost report (`python -m trace_mcp.selfcost`).** A standalone,
+  read-only analyzer that estimates TRACE's own token footprint without adding
+  any MCP tool (so running it does not enlarge the tool-schema surface it
+  measures) and without touching any session record. It reports the tool-schema
+  surface under cold-write/warm-read prompt-caching regimes — so the
+  always-loaded cost is presented as a write-once/cache-read amount, not
+  mis-stated as a full per-turn tax — a per-session estimate of the tokens spent
+  authoring `trace_*` calls (scoped to `host="mcp"` events, since
+  `host="internal"/"external"` calls are logged by reference and not sizeable
+  from the server side), and a trace-learn reuse signal carrying a data-quality
+  flag (`recall_count` tracks surfacing, not use, so it is never converted to
+  "tokens saved"). Every figure is a labeled `chars/4` estimate, and the report
+  points at the host's OpenTelemetry `claude_code.token.usage` metric for the
+  authoritative measured number. The carbon/token telemetry direction is
+  recorded in [docs/adr/004-telemetry-sidecar.md](docs/adr/004-telemetry-sidecar.md):
+  carbon and self-cost are one optional, estimate-provenanced sidecar concern,
+  never core.
+
 ### Integrity hardening
 
 - **The per-session lock now fails closed.** On lock-acquisition timeout,

--- a/docs/adr/004-telemetry-sidecar.md
+++ b/docs/adr/004-telemetry-sidecar.md
@@ -1,0 +1,151 @@
+# ADR 004: Telemetry sidecar — carbon & token-cost as an optional, estimate-provenanced layer
+
+**Status:** accepted · **Date:** 2026-06-18
+
+## Context
+
+TRACE records decision provenance at the tool-call and decision level. Two
+adjacent measurements are frequently requested:
+
+1. **Environmental footprint** — the energy/carbon attributable to a tool call
+   or AI decision.
+2. **Self-cost** — how much of the host's token/credit budget TRACE itself
+   consumes (its always-loaded tool schemas plus the arguments/results that flow
+   through each `trace_*` call), and how that compares to the rework it avoids
+   via `trace-learn`.
+
+Both are structurally identical: attach an *estimated numeric measure* to an
+event and roll it up. Both also collide with hard facts about where TRACE sits:
+
+- **An MCP server is blind to host token accounting.** Tool handlers receive
+  only the tool name and arguments; the host model's total context, per-turn
+  token usage, cache behaviour, and credit burn never cross the JSON-RPC
+  boundary. Carbon and self-cost therefore cannot be *measured* from inside a
+  tool handler — at best they are *estimated* from the bytes TRACE can see.
+- **The standing schema cost is small and cache-amortized, not a per-turn tax.**
+  Tool/system definitions occupy the cached prompt prefix: under prompt caching
+  they are written once per session and read at a fraction of input price
+  thereafter — they are not re-billed in full every turn. A naive
+  `schema_chars × turns` figure overstates the real cost by roughly an order of
+  magnitude and in the wrong shape.
+- **Adding MCP tools is self-defeating for a cost measurement.** Every
+  registered tool enlarges the cached prefix and, if the tool set varies across
+  turns, invalidates that cache. A tool whose purpose is to measure context cost
+  must not itself grow it.
+- **`recall_count` is a surfacing signal, not a savings signal.** It increments
+  when a learning is returned, not when it is used; dedup hits are transactional
+  and not persistently counted. There is no measured "rework avoided".
+- **The governance boundary (ADR 003) is binding.** Core is provenance-only and
+  must not depend on any extension.
+
+A bespoke "carbon feature" plus a bespoke "cost feature", each baking numbers
+into core event models, would duplicate estimate-provenance logic, bloat the
+audit trail, and drift TRACE toward being a metrics dashboard — the opposite of
+its identity.
+
+## Decision
+
+1. **One optional telemetry layer, never core.** Carbon and self-cost are served
+   by a single optional concern (a future `trace-telemetry` extension and the
+   offline analyzer described below), not two features and not core fields.
+   Removing it leaves a fully functional provenance system. Core MUST NOT import
+   it (ADR 003 holds).
+
+2. **Canonical store is a separate sidecar, not the provenance record.**
+   Telemetry is derived diagnostics, not provenance, so it does not mutate event
+   data. It lives in its own sidecar file written with the existing atomic
+   temp-file + `os.replace` pattern (as `trace-learn` writes its knowledge
+   store), independent of the session lock. An on-event namespaced
+   `x_trace_telemetry` extra is reserved **only** for genuinely host-reported
+   usage captured at event-creation time; it rides the existing `extra="allow"`
+   and needs no wire-version bump. Any write into the canonical session record
+   (e.g. a rollup under `Session.metadata.custom`) MUST route through
+   `locked_disk_session` and be registered as an INV-1 writer.
+
+3. **Every number carries estimate provenance.** A measure records its
+   `value_kind` (`measured` / `host_reported` / `estimated` / `proxy_estimated`
+   / `modeled`), `method_id`, a versioned + hashed factor set, per-input source,
+   and an uncertainty **range** — never a bare point value. A missing input
+   yields **no estimate plus a skip reason**, never a silent default. Measured
+   and modeled values are never merged into one total. This makes a flagged
+   estimate honest and an unflagged one a protocol violation.
+
+4. **Self-cost is proxy by default, measured via host telemetry.** The honest
+   offline estimate is the schema-surface size plus per-call argument/result
+   sizes that TRACE can see, labeled as a `chars/4` proxy and reported under a
+   caching regime (cold write / warm read), never multiplied by turn count. The
+   authoritative number comes from the host's own telemetry: Claude Code emits a
+   `claude_code.token.usage` OpenTelemetry metric attributed by `mcp_server.name`
+   / `mcp_tool.name`, `type` (input/output/cacheRead/cacheCreation), `model`, and
+   correlated by `session.id`. Ingesting that stream yields measured, per-tool,
+   per-session cost. The offline proxy is the no-setup approximation of it.
+
+5. **Carbon estimates require explicit inputs and only attach to sizeable
+   events.** Carbon is `tokens × energy-per-token × PUE × grid-intensity`; the
+   inputs (model, token counts, region, factors) are not visible to an MCP
+   server and must be user-supplied, host-reported, or labeled proxy. Estimation
+   runs only on `host="mcp"` events whose payload TRACE actually marshalled;
+   `host="internal"`/`"external"` events are logged by reference and get a skip
+   reason, never a guessed size. A decision's footprint is a derived rollup over
+   its linked tool calls, never invented from the decision alone. Factor sets
+   ship as cited templates, never as authoritative silent defaults.
+
+6. **ROI is reuse-counts-with-a-flag, not measured savings.** The honest benefit
+   signal is raw reuse counts carrying a data-quality flag (recall counts track
+   surfacing, not use, and have known gaps). "Tokens saved" is only ever a
+   `modeled` figure derived from an explicit human attestation that a recall
+   prevented specific rework, with a zero floor for unconfirmed cases, labeled a
+   counterfactual scenario — never a measured benefit and never auto-derived
+   from `recall_count`.
+
+7. **Delivery is offline-CLI-first; the NOW increment adds zero MCP tools.**
+   Because an occasional, retrospective analysis must not enlarge the
+   always-loaded tool surface it measures, the first increment is an offline
+   analyzer (`trace_mcp.selfcost`, `python -m trace_mcp.selfcost`) that reads
+   stored session JSON read-only and introspects the registered tool schemas via
+   the FastMCP tool manager. It adds no MCP tool, no schema field, no wire
+   change, and no core dependency. Any future telemetry MCP tool must keep the
+   tool set static and deterministically ordered (cache-stable) and document the
+   cache cost it adds.
+
+## Implementation tiers
+
+- **NOW** (shipped with this ADR): the offline `trace_mcp.selfcost` report —
+  schema-surface estimate under cold/warm caching regimes, per-session authored
+  token estimate (`host="mcp"` coverage), and flagged reuse signal — plus this
+  ADR and its test (`tests/test_selfcost.py`). Additive, read-only, deletable.
+- **SOON** (not built here): a `trace-telemetry` sidecar extension (ledger
+  writer + derive-on-read summary); the OpenTelemetry host-usage importer (the
+  measured self-cost path); an optional fail-open observe-event hook if
+  auto-capture is needed; a human-attestation tool for defensible ROI. All
+  optional, no schema bump.
+- **NOT-NOW / NEVER**: core token/cost/energy/carbon fields; any wire/schema
+  version bump for telemetry; live carbon-intensity APIs or real-time power
+  metering; dashboards, offsets, or "green scores"; auto-attribution of host
+  credit burn without host telemetry; auto ROI from `recall_count`; external
+  ESG-disclosure positioning while compounded end-to-end uncertainty spans an
+  order of magnitude (kept behind the project's compliance kill-gates); any
+  publish coupling while naming/trademark is on hold.
+
+## Consequences
+
+- The schema is untouched and the governance boundary is preserved; carbon and
+  cost can never silently become part of the provenance semantics.
+- Users get an immediate, honest answer to "what does TRACE cost me" without any
+  host configuration, and a documented upgrade path to a measured number.
+- Honesty is enforceable rather than aspirational: a deterministic gate can
+  assert that every estimate carries method + factors + uncertainty, that
+  missing inputs are skipped not guessed, that measured and modeled totals stay
+  separate, and that the telemetry ledger schema holds no free-text payload
+  fields (a privacy guard, since size estimation reads argument/result content
+  and must persist only derived scalars).
+- The carbon ambition is explicitly parked behind an uncertainty check rather
+  than abandoned, keeping a credible-but-gated path without overclaiming.
+
+## References
+
+- ADR 003 — core/extension boundary (the binding governance constraint).
+- `docs/INVARIANTS.md` INV-1 — the single locked session-write path.
+- `src/trace_mcp/selfcost.py` — the NOW offline analyzer.
+- `docs/specification.md` §7.3 — custom-extension rule (extensions must not
+  redefine the semantics of defined fields).

--- a/src/trace_mcp/selfcost.py
+++ b/src/trace_mcp/selfcost.py
@@ -1,0 +1,353 @@
+"""Offline self-cost report for TRACE — estimate TRACE's own token footprint.
+
+This is a STANDALONE, read-only diagnostic. It adds ZERO MCP tools (so running
+it does not enlarge the very tool-schema surface it measures) and never mutates
+any session record. It answers "how much context does TRACE itself cost me?"
+with deliberately-labeled ESTIMATES, at the only granularity an offline analyzer
+can honestly speak to.
+
+What it can and cannot see (verified against the MCP/FastMCP runtime):
+
+  * Schema-surface — the JSON tool definitions TRACE injects into context. These
+    sit at prompt prefix position 0 and, under Anthropic prompt caching, are
+    written once (~1.25x input price) on the first turn of a session and then
+    served from cache (~0.1x) thereafter — they are NOT re-billed in full every
+    turn. So the steady-state cost is far below a naive ``chars/4 * turns``
+    figure. We report a cold-write and a warm-read regime instead of one number.
+
+  * Authored event content — for every TRACE event in a session, the model spent
+    OUTPUT tokens authoring that call's arguments. We estimate that from the
+    stored event payload. We do NOT see the result text TRACE returned (it is
+    not stored in the session) nor the host's true tokenizer, so this is a
+    labeled UNDERCOUNT of interaction cost, not a bill.
+
+  * Reuse signals (trace-learn) — recall counts, as a WEAK benefit proxy.
+    ``recall_count`` tracks SURFACING, not use, and has known tracking gaps, so
+    it ships with a data-quality flag and is NEVER converted to "tokens saved".
+
+For the authoritative, MEASURED per-tool / per-session number, ingest Claude
+Code's OpenTelemetry ``claude_code.token.usage`` metric filtered to
+``mcp_tool.name`` (see ``docs/adr/004-telemetry-sidecar.md``, the SOON "OTEL
+importer" tier). This offline report is the no-setup approximation of that.
+
+All token figures use a transparent ``ceil(chars / 4)`` proxy — NOT the host's
+real tokenizer. Treat every number as an order-of-magnitude estimate.
+
+Public functions: ``chars_to_tokens``, ``estimate_schema_surface``,
+``estimate_session_cost``, ``estimate_reuse_signal``, ``build_report``,
+``format_report``, ``main``.
+
+Side effects: reads the local filesystem (session JSON, knowledge store) and
+imports ``trace_mcp.server`` to introspect registered tool schemas (no server is
+started). Nothing is written.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from trace_mcp.schema import Session
+
+# Prompt-caching regime multipliers applied to the raw schema-surface token
+# estimate. Anthropic caches the tools+system prefix: the first turn pays a
+# cache-write premium, later turns pay a cache-read fraction. These are
+# documented public multipliers, recorded so the report's assumptions are
+# inspectable rather than hidden.
+CACHE_WRITE_MULTIPLIER = 1.25
+CACHE_READ_MULTIPLIER = 0.10
+
+CHARS_PER_TOKEN = 4
+
+
+def chars_to_tokens(chars: int) -> int:
+    """Estimate tokens from character count via a transparent ceil(chars/4) proxy.
+
+    This is NOT the host's tokenizer; it is a deterministic, auditable
+    approximation. Pure function.
+    """
+    if chars <= 0:
+        return 0
+    return (chars + CHARS_PER_TOKEN - 1) // CHARS_PER_TOKEN
+
+
+class SchemaSurface(BaseModel):
+    """Estimated cost of the TRACE tool-schema surface injected into context."""
+
+    tool_count: int = Field(..., description="Number of registered MCP tools introspected.")
+    schema_chars: int = Field(..., description="Total characters of name+description+inputSchema JSON across tools.")
+    tokens_est: int = Field(..., description="Raw chars/4 token estimate of the schema surface (uncached).")
+    cold_write_tokens_est: int = Field(..., description="First-turn cache-write estimate (tokens_est * write multiplier).")
+    warm_read_tokens_est: int = Field(..., description="Per-later-turn cache-read estimate (tokens_est * read multiplier).")
+    included_extensions: bool = Field(..., description="Whether extension tools were included in the surface.")
+    note: str = Field(..., description="Honesty caveat for this measurement.")
+
+
+class SessionCost(BaseModel):
+    """Estimated tokens the model spent AUTHORING TRACE calls in one session."""
+
+    session_id: str
+    project: str | None = None
+    event_count: int
+    authored_tokens_est: int = Field(..., description="chars/4 estimate of authored event payloads (model output side).")
+    by_event_type: dict[str, int] = Field(default_factory=dict, description="authored_tokens_est broken down by event type.")
+    tool_call_host_breakdown: dict[str, int] = Field(
+        default_factory=dict,
+        description="Counts of logged tool_call events by host (mcp/internal/external). internal/external are logged "
+        "by reference — TRACE never marshalled their payload, so they are not sizeable from this side.",
+    )
+    note: str = Field(..., description="Honesty caveat: excludes TRACE's returned-result tokens; chars/4 proxy.")
+
+
+class ReuseSignal(BaseModel):
+    """Weak benefit proxy from trace-learn. NOT a savings figure."""
+
+    project: str
+    total_learnings: int
+    total_recall_count: int = Field(..., description="Sum of recall_count across learnings (SURFACING, not proven use).")
+    never_surfaced: int
+    avg_recall_count: float
+    data_quality_flag: str = Field(..., description="Why these counts are a weak, possibly-undercounted signal.")
+
+
+class SelfCostReport(BaseModel):
+    """Top-level offline self-cost report."""
+
+    schema_surface: SchemaSurface
+    session: SessionCost | None = None
+    reuse: ReuseSignal | None = None
+    measured_path_pointer: str = Field(
+        default=(
+            "For a MEASURED per-tool/per-session number, ingest Claude Code's OpenTelemetry "
+            "'claude_code.token.usage' metric filtered to mcp_tool.name (see docs/adr/004-telemetry-sidecar.md). "
+            "This offline report is the no-setup approximation."
+        ),
+        description="Where to get the authoritative measured number.",
+    )
+
+
+def _list_registered_tools(include_extensions: bool) -> list[tuple[str, str, dict[str, Any]]]:
+    """Return (name, description, input_schema) for every registered MCP tool.
+
+    Side effect: imports trace_mcp.server (which constructs the FastMCP instance
+    and registers core tools at import time) and, when include_extensions is
+    True, calls its extension loader. No server is started. Returns [] if the
+    runtime introspection API is unavailable.
+    """
+    import trace_mcp.server as srv
+
+    if include_extensions:
+        try:
+            srv._load_extensions()
+        except Exception:  # noqa: BLE001 - extension loading is best-effort here
+            pass
+
+    tool_manager = getattr(srv.mcp, "_tool_manager", None)
+    if tool_manager is not None and hasattr(tool_manager, "list_tools"):
+        try:
+            tools = list(tool_manager.list_tools())
+            return [
+                (
+                    getattr(t, "name", "") or "",
+                    getattr(t, "description", "") or "",
+                    getattr(t, "parameters", {}) or {},
+                )
+                for t in tools
+            ]
+        except Exception:  # noqa: BLE001 - fall through to async fallback
+            pass
+
+    # Async fallback via the public list_tools() coroutine (MCPTool objects).
+    try:
+        import asyncio
+
+        mcp_tools = asyncio.run(srv.mcp.list_tools())
+        return [
+            (
+                getattr(t, "name", "") or "",
+                getattr(t, "description", "") or "",
+                getattr(t, "inputSchema", {}) or {},
+            )
+            for t in mcp_tools
+        ]
+    except Exception:  # noqa: BLE001 - introspection genuinely unavailable
+        return []
+
+
+def estimate_schema_surface(include_extensions: bool = True) -> SchemaSurface:
+    """Estimate the token cost of the TRACE tool-schema surface (see module docstring)."""
+    tools = _list_registered_tools(include_extensions)
+    total_chars = 0
+    for name, description, schema in tools:
+        payload = {"name": name, "description": description, "parameters": schema}
+        total_chars += len(json.dumps(payload, default=str))
+    tokens_est = chars_to_tokens(total_chars)
+    return SchemaSurface(
+        tool_count=len(tools),
+        schema_chars=total_chars,
+        tokens_est=tokens_est,
+        cold_write_tokens_est=round(tokens_est * CACHE_WRITE_MULTIPLIER),
+        warm_read_tokens_est=round(tokens_est * CACHE_READ_MULTIPLIER),
+        included_extensions=include_extensions,
+        note=(
+            "chars/4 proxy, not the host tokenizer. Under Anthropic prompt caching the schema surface is "
+            "written once per session (~cold) and read from cache thereafter (~warm) — it is NOT re-billed in "
+            "full every turn. Do not multiply tokens_est by turn count."
+        ),
+    )
+
+
+def estimate_session_cost(session: Session) -> SessionCost:
+    """Estimate the tokens the model spent authoring TRACE calls in this session.
+
+    Pure with respect to the filesystem (operates on an in-memory Session).
+    Sums a chars/4 estimate of each event's authored data payload. Excludes the
+    result text TRACE returned (not stored), so it is a labeled undercount.
+    """
+    by_type: dict[str, int] = {}
+    host_breakdown: dict[str, int] = {}
+    total = 0
+    for event in session.events:
+        data = getattr(event, event.type, None)
+        if data is not None and hasattr(data, "model_dump"):
+            payload = data.model_dump(mode="json", exclude_none=True)
+            chars = len(json.dumps(payload, default=str))
+            tokens = chars_to_tokens(chars)
+            total += tokens
+            by_type[event.type] = by_type.get(event.type, 0) + tokens
+        if event.type == "tool_call" and event.tool_call is not None:
+            host = event.tool_call.host or "mcp"
+            host_breakdown[host] = host_breakdown.get(host, 0) + 1
+    return SessionCost(
+        session_id=session.id,
+        project=session.metadata.project,
+        event_count=len(session.events),
+        authored_tokens_est=total,
+        by_event_type=by_type,
+        tool_call_host_breakdown=host_breakdown,
+        note=(
+            "Authored (model-output) side only, chars/4 proxy. Excludes TRACE's returned-result tokens "
+            "(not stored in the session) and the host's true tokenization — treat as a lower bound."
+        ),
+    )
+
+
+def estimate_reuse_signal(project: str) -> ReuseSignal | None:
+    """Summarize trace-learn reuse as a WEAK benefit proxy, or None if unavailable.
+
+    Side effect: reads the project's knowledge store from disk. Returns None when
+    the trace-learn extension or the store is absent (honest absence, not a zero
+    masquerading as a measurement).
+    """
+    try:
+        from trace_mcp.extensions.learn.store import load_store
+    except ImportError:
+        return None
+    try:
+        store = load_store(project)
+    except Exception:  # noqa: BLE001 - no store / unreadable store is honest absence
+        return None
+    learnings = list(getattr(store, "learnings", []))
+    if not learnings:
+        return None
+    recall_counts = [int(getattr(lrn, "recall_count", 0) or 0) for lrn in learnings]
+    total_recall = sum(recall_counts)
+    never = sum(1 for c in recall_counts if c == 0)
+    return ReuseSignal(
+        project=project,
+        total_learnings=len(learnings),
+        total_recall_count=total_recall,
+        never_surfaced=never,
+        avg_recall_count=round(total_recall / len(learnings), 2),
+        data_quality_flag=(
+            "recall_count counts SURFACING, not proven use, and trace-learn recall tracking has known gaps. "
+            "This is a weak, possibly-undercounted signal — never convert it to 'tokens saved'."
+        ),
+    )
+
+
+def build_report(session_path: str | None = None, include_extensions: bool = True) -> SelfCostReport:
+    """Assemble the offline self-cost report.
+
+    Side effect: reads the session JSON at session_path (if given) and the
+    matching project's knowledge store; imports the server for schema surface.
+    """
+    surface = estimate_schema_surface(include_extensions=include_extensions)
+    session_cost: SessionCost | None = None
+    reuse: ReuseSignal | None = None
+    if session_path:
+        with open(session_path, encoding="utf-8") as fh:
+            session = Session.model_validate(json.load(fh))
+        session_cost = estimate_session_cost(session)
+        if session.metadata.project:
+            reuse = estimate_reuse_signal(session.metadata.project)
+    return SelfCostReport(schema_surface=surface, session=session_cost, reuse=reuse)
+
+
+def format_report(report: SelfCostReport) -> str:
+    """Render a human-readable text report. Pure function."""
+    s = report.schema_surface
+    lines: list[str] = []
+    lines.append("TRACE self-cost report (offline estimate — NOT a bill)")
+    lines.append("=" * 60)
+    lines.append("")
+    lines.append(f"Schema surface ({s.tool_count} tools, extensions={s.included_extensions}):")
+    lines.append(f"  raw estimate      ~{s.tokens_est:,} tokens  ({s.schema_chars:,} chars / 4)")
+    lines.append(f"  cold (turn 1)     ~{s.cold_write_tokens_est:,} tokens  (cache write)")
+    lines.append(f"  warm (later turns)~{s.warm_read_tokens_est:,} tokens  (cache read)")
+    lines.append(f"  note: {s.note}")
+    lines.append("")
+    if report.session is not None:
+        c = report.session
+        lines.append(f"Session {c.session_id} (project={c.project}, {c.event_count} events):")
+        lines.append(f"  authored TRACE-call tokens ~{c.authored_tokens_est:,} (estimate)")
+        if c.by_event_type:
+            parts = ", ".join(f"{k}={v:,}" for k, v in sorted(c.by_event_type.items()))
+            lines.append(f"  by event type: {parts}")
+        if c.tool_call_host_breakdown:
+            parts = ", ".join(f"{k}={v}" for k, v in sorted(c.tool_call_host_breakdown.items()))
+            lines.append(f"  logged tool_call events by host: {parts}")
+        lines.append(f"  note: {c.note}")
+        lines.append("")
+    if report.reuse is not None:
+        r = report.reuse
+        lines.append(f"Reuse signal (trace-learn, project={r.project}) — WEAK benefit proxy:")
+        lines.append(
+            f"  {r.total_learnings} learnings, total recall_count={r.total_recall_count}, "
+            f"never_surfaced={r.never_surfaced}, avg_recall={r.avg_recall_count}"
+        )
+        lines.append(f"  flag: {r.data_quality_flag}")
+        lines.append("")
+    lines.append(report.measured_path_pointer)
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point. Usage: python -m trace_mcp.selfcost [SESSION_JSON] [--no-extensions] [--json]."""
+    parser = argparse.ArgumentParser(
+        prog="trace-selfcost",
+        description="Estimate TRACE's own token footprint (offline, read-only). Not a bill — labeled estimates only.",
+    )
+    parser.add_argument("session", nargs="?", default=None, help="Path to a session JSON file (optional).")
+    parser.add_argument(
+        "--no-extensions",
+        action="store_true",
+        help="Measure only the core tool-schema surface (exclude extension tools).",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit the report as JSON instead of text.")
+    args = parser.parse_args(argv)
+
+    report = build_report(session_path=args.session, include_extensions=not args.no_extensions)
+    if args.json:
+        print(json.dumps(report.model_dump(), indent=2))
+    else:
+        print(format_report(report))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_selfcost.py
+++ b/tests/test_selfcost.py
@@ -1,0 +1,118 @@
+"""E2E tests for the offline self-cost report (trace_mcp.selfcost).
+
+Uses real schema models and a real Session round-trip through disk — no mocks.
+Schema-surface assertions use inequalities (>=) so they are robust to the
+FastMCP singleton retaining extension tools once loaded in-process.
+"""
+
+from __future__ import annotations
+
+import json
+
+from trace_mcp import selfcost
+from trace_mcp.schema import (
+    Actor,
+    AnnotationData,
+    DecisionData,
+    Session,
+    SessionMetadata,
+    ToolCallData,
+    TraceEvent,
+)
+
+AI = Actor(type="ai", id="claude")
+
+
+def _make_session() -> Session:
+    sid = "trace_selfcost_test"
+    events = [
+        TraceEvent(
+            session_id=sid,
+            type="decision",
+            actor=AI,
+            decision=DecisionData(description="Use approach X for the thing", proposed_by=AI),
+        ),
+        TraceEvent(
+            session_id=sid,
+            type="tool_call",
+            actor=AI,
+            tool_call=ToolCallData(server="domain", name="run_query", input={"q": "select 1"}, host="mcp"),
+        ),
+        TraceEvent(
+            session_id=sid,
+            type="tool_call",
+            actor=AI,
+            tool_call=ToolCallData(server="claude-code", name="dispatch", input={}, host="internal"),
+        ),
+        TraceEvent(
+            session_id=sid,
+            type="annotation",
+            actor=AI,
+            annotation=AnnotationData(category="discovery", content="A non-trivial finding worth recording."),
+        ),
+    ]
+    return Session(id=sid, metadata=SessionMetadata(project="selfcost-test"), events=events)
+
+
+def test_chars_to_tokens() -> None:
+    assert selfcost.chars_to_tokens(0) == 0
+    assert selfcost.chars_to_tokens(4) == 1
+    assert selfcost.chars_to_tokens(5) == 2  # ceil
+    assert selfcost.chars_to_tokens(-3) == 0
+
+
+def test_estimate_schema_surface_core() -> None:
+    surface = selfcost.estimate_schema_surface(include_extensions=False)
+    assert surface.tool_count >= 17  # core registers 17 MCP tools
+    assert surface.schema_chars > 0
+    assert surface.tokens_est > 0
+    # Caching regimes: warm cache read must be cheaper than cold cache write.
+    assert surface.warm_read_tokens_est < surface.cold_write_tokens_est
+    assert surface.included_extensions is False
+
+
+def test_estimate_schema_surface_with_extensions_is_superset() -> None:
+    core = selfcost.estimate_schema_surface(include_extensions=False)
+    full = selfcost.estimate_schema_surface(include_extensions=True)
+    assert full.tool_count >= core.tool_count
+    assert full.included_extensions is True
+
+
+def test_estimate_session_cost() -> None:
+    cost = selfcost.estimate_session_cost(_make_session())
+    assert cost.event_count == 4
+    assert cost.authored_tokens_est > 0
+    assert "decision" in cost.by_event_type
+    assert "annotation" in cost.by_event_type
+    # Both tool_call events counted, separated by host.
+    assert cost.tool_call_host_breakdown.get("mcp") == 1
+    assert cost.tool_call_host_breakdown.get("internal") == 1
+
+
+def test_build_and_format_report(tmp_path) -> None:
+    session = _make_session()
+    p = tmp_path / "session.json"
+    p.write_text(json.dumps(session.model_dump(mode="json")), encoding="utf-8")
+    report = selfcost.build_report(session_path=str(p), include_extensions=False)
+    assert report.session is not None
+    assert report.session.event_count == 4
+    text = selfcost.format_report(report).lower()
+    # Honesty caveats must be present in the rendered report.
+    assert "estimate" in text
+    assert "cache" in text
+    assert "opentelemetry" in text or "otel" in text
+    assert "self-cost" in text
+
+
+def test_main_smoke(capsys, tmp_path) -> None:
+    session = _make_session()
+    p = tmp_path / "session.json"
+    p.write_text(json.dumps(session.model_dump(mode="json")), encoding="utf-8")
+    rc = selfcost.main([str(p), "--no-extensions"])
+    assert rc == 0
+    assert "Schema surface" in capsys.readouterr().out
+
+
+def test_estimate_reuse_signal_absent() -> None:
+    # A project with no knowledge store returns None (honest absence), not a crash.
+    assert selfcost.estimate_reuse_signal("nonexistent-project-xyz-selfcost") is None


### PR DESCRIPTION
## Summary

Adds an offline, read-only diagnostic that estimates TRACE's own token footprint, plus an ADR recording the carbon/token telemetry direction.

`python -m trace_mcp.selfcost [SESSION_JSON]` reports:

- **Schema surface** under cold-write / warm-read prompt-caching regimes — the always-loaded tool-schema cost is a write-once + cache-read amount, **not** a full per-turn tax. (For the current 22-tool surface: ~4,911 raw → ~6,139 cold write → **~491 warm read** tokens, the real steady-state cost.)
- **Per-session authored cost** — tokens the model spent authoring `trace_*` calls, scoped to `host="mcp"` events (`internal`/`external` calls are logged by reference and are not sizeable from the server side).
- **Reuse signal** — trace-learn recall counts with a data-quality flag; never converted to "tokens saved" (`recall_count` tracks *surfacing*, not use).
- A pointer to the host's OpenTelemetry `claude_code.token.usage` metric (`mcp_tool.name` attribution) for the authoritative *measured* number.

Every figure is a labeled `chars/4` estimate, not the host tokenizer.

## Why

An MCP server is blind to host token accounting (only tool name + arguments cross the JSON-RPC boundary), so TRACE's own cost can only be *estimated* offline — but the estimate is useful and was previously unavailable. Two facts shape the design: (1) tool schemas sit in the cached prompt prefix, so the standing cost is write-once + cache-read, not a per-turn multiple; and (2) a measurement delivered as an MCP tool would enlarge the very prefix it measures. Hence an offline CLI that adds zero tools.

## Design / ADR

`docs/adr/004-telemetry-sidecar.md` records the architecture: carbon and token-cost are a single **optional, estimate-provenanced** concern stored in a **sidecar, never core**; every number carries `value_kind` + method + versioned/hashed factors + an uncertainty range; missing inputs are skipped, never guessed; ROI stays reuse-counts-with-a-flag, never auto-derived "tokens saved"; carbon is parked behind an uncertainty check. The measured self-cost path (OpenTelemetry import) and a future `trace-telemetry` sidecar extension are scoped as SOON, not built here.

## Guarantees

- **No new MCP tool** — running the diagnostic does not enlarge the tool-schema surface it measures.
- **No schema field, no wire-version change** — additive `chars/4` estimation only.
- **No core dependency on any extension** (ADR 003 boundary preserved); read-only on session JSON; no write path added, so INV-1 is unaffected.

## Tests

`tests/test_selfcost.py` — 7 tests, real schema models and a real session round-trip through disk (no mocks). `ruff` + `pyright` clean; invariant guard (`tests/test_invariants.py`) green.
