### PR TITLE
ci: align lint/type/format gate scope with docs and reality

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,41 @@
+<!--
+Keep this body self-contained: a reader with no access to the authoring context
+must understand it. No conversational narrative, AI-attribution footers, internal
+plan labels, agent/review counts, or bare finding codes. See CONTRIBUTING.md →
+"Commit and PR messages". Keep it proportional — a tiny PR may use only Summary
+and Verification.
+-->
+
+## Summary
+
+- <what this PR does, in durable terms>
+
+## Why
+
+<the problem / failure mode / need this addresses>
+
+## Verification
+
+- [ ] `uv run ruff check .` and `uv run ruff format --check .`
+- [ ] `uv run pyright`
+- [ ] `uv run pytest`
+- [ ] Built & verified the shipped artifact, if packaging/release changed
+      (`uv build && uv run pytest tests/test_packaging_artifacts.py`)
+- [ ] Ran the invariant guard, if a write/read path or invariant changed
+      (`uv run pytest tests/test_invariants.py`)
+- [ ] Regenerated the JSON Schema, if schema models changed
+      (`python scripts/generate_schema.py`)
+
+<!-- Optional sections — include only when relevant:
+
+## Design / ADR
+<link or summarize the decision; reference docs/adr/NNN>
+
+## Risks / rollback
+<compatibility / data / migration risk, or why risk is low; how to roll back>
+
+## References
+- path/to/file.py
+- docs/adr/NNN-title.md
+- Closes #NNN
+-->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,11 +36,17 @@ jobs:
       - name: Sync dependencies
         run: uv sync --all-extras
 
+      # All three static gates run on the FULL tree (src + tests + scripts) —
+      # matching CONTRIBUTING and pyrightconfig.json — and the tree is clean
+      # under each, so a gate cannot silently diverge from the documented command.
       - name: Lint (ruff)
-        run: uv run ruff check src/
+        run: uv run ruff check .
+
+      - name: Format check (ruff)
+        run: uv run ruff format --check .
 
       - name: Type check (pyright)
-        run: uv run pyright src/
+        run: uv run pyright
 
       - name: Core/extension boundary invariant (governance ADR 003)
         run: uv run pytest tests/test_v041_core_extension_boundary.py -q -p no:cov

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,11 +32,15 @@ jobs:
       - name: Sync dependencies
         run: uv sync --all-extras
 
+      # Full-tree static gates, identical to ci.yml and CONTRIBUTING.
       - name: Lint (ruff)
-        run: uv run ruff check src/
+        run: uv run ruff check .
+
+      - name: Format check (ruff)
+        run: uv run ruff format --check .
 
       - name: Type check (pyright)
-        run: uv run pyright src/
+        run: uv run pyright
 
       - name: Tests
         run: uv run pytest -q -k "not uvx and not Uvx"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,9 +20,9 @@ All async tests use `asyncio_mode = "auto"` — no `@pytest.mark.asyncio` needed
 
 ### What the test suite covers
 
-The authoritative count is `uv run pytest` (**889 tests** — 887 passing + 2
-environment-gated skips as of v0.4.2). The table below highlights the main
-areas; it is representative, not an exhaustive per-file tally.
+The authoritative count is `uv run pytest` (**970 tests** — 959 passing + 11
+environment-gated skips). The table below highlights the main areas; it is
+representative, not an exhaustive per-file tally.
 
 | Area | Tests | What's verified |
 |------|------:|-----------------|
@@ -55,8 +55,14 @@ areas; it is representative, not an exhaustive per-file tally.
 
 ## Code style
 
-- **Formatter / linter**: ruff — `uv run ruff check src/` and `uv run ruff format src/`
-- **Type checker**: pyright — `uv run pyright src/`
+- **Linter**: ruff — `uv run ruff check .` lints the full tree (`src/`, `tests/`,
+  `scripts/`) and is CI-gated.
+- **Formatter**: ruff — `uv run ruff format` formats the full tree, and
+  `uv run ruff format --check .` is CI-gated. Run `uv run ruff format` before
+  committing.
+- **Type checker**: pyright — `uv run pyright` type-checks the full tree
+  (`pyrightconfig.json` includes `src/`, `tests/`, `scripts/`) and is CI-gated,
+  clean at 0 errors / 0 warnings.
 - **Line length**: 120
 - **Target**: Python 3.11+
 - Use `from datetime import UTC` (not `timezone.utc`) per ruff UP017
@@ -88,10 +94,30 @@ Host adapters (`src/trace_mcp/adapters/<host>/`) install hook scripts and config
 
 1. **Never push directly to `main`** — always work on a feature branch and open a PR.
 2. All tests must pass (`uv run pytest`).
-3. No new ruff or pyright errors (`uv run ruff check .` and `uv run pyright` — both cover `src/`, `tests/`, and `scripts/`).
+3. No new lint, format, or type errors — all CI-gated on the full tree:
+   `uv run ruff check .`, `uv run ruff format --check .`, and `uv run pyright`.
 4. Add tests for new functionality.
 5. Keep PRs focused — one feature or fix per PR.
 6. If modifying schema models, regenerate the JSON Schema (`python scripts/generate_schema.py`).
+7. Write self-contained commit and PR messages — see *Commit and PR messages* below.
+
+## Commit and PR messages
+
+Write every commit message and PR title/body **self-contained**: a reader with no
+access to the change's authoring context must understand it from the text alone.
+State what changed and the durable rationale (name the failure mode). Do not
+include conversational narrative, AI-generated attribution footers, internal plan
+labels (e.g. "PR B"), review-process or agent counts, or bare finding codes that
+are not defined in the repository.
+
+- **Subject** (commit and PR title): prefer `type(scope): summary` — one type from
+  `feat fix docs test refactor perf build ci chore revert security`, an imperative
+  summary, no trailing period. Use a component scope, not a version or phase. This
+  is a preference, not a hard gate.
+- **Body**: explain the change and the failure mode it addresses, and reference
+  durable anchors — file paths, `docs/adr/NNN`, `docs/INVARIANTS.md`, issue/PR
+  numbers. A PR body should cover **Summary**, **Why**, and **Verification**; see
+  [`.github/pull_request_template.md`](.github/pull_request_template.md).
 
 ## Development roadmap
 

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -1,0 +1,55 @@
+# Maintenance & conventions
+
+Durable conventions for the static quality gates, commit/PR messages, and
+releases, plus the maintenance backlog. Process companion to
+[CONTRIBUTING.md](../CONTRIBUTING.md) (contributor how-to) and
+[docs/INVARIANTS.md](INVARIANTS.md) (correctness invariants).
+
+## Static quality gates
+
+All three gates run on the **full tree** (`src/`, `tests/`, `scripts/`), are
+CI-gated on every PR (`.github/workflows/ci.yml`) and at release
+(`.github/workflows/release.yml`), and use the **same commands** documented in
+CONTRIBUTING and configured in `pyrightconfig.json`:
+
+| Gate | Command | State |
+|------|---------|-------|
+| Lint | `uv run ruff check .` | clean |
+| Format | `uv run ruff format --check .` | clean |
+| Types | `uv run pyright` | 0 errors / 0 warnings |
+
+Run all three plus `uv run pytest` before pushing. The gate commands are kept
+**identical** across CI, the release workflow, and the docs so they cannot
+silently diverge — documented-but-unenforced drift is the failure mode this
+convention exists to prevent. When a gate command changes in CI, change it in
+the other two places in the same commit.
+
+## Commit & PR messages
+
+See [CONTRIBUTING.md → "Commit and PR messages"](../CONTRIBUTING.md#commit-and-pr-messages).
+In short: self-contained, durable prose; preferred subject shape
+`type(scope): summary`; PR bodies follow
+[`.github/pull_request_template.md`](../.github/pull_request_template.md).
+
+## Tagging & releases
+
+- **One annotated tag per release**, `vMAJOR.MINOR.PATCH`, matching the
+  `pyproject.toml` version and the `CHANGELOG.md` section, created on the
+  release commit at release time (not retroactively).
+- Versioning follows [SemVer](https://semver.org); the changelog follows
+  [Keep a Changelog](https://keepachangelog.com).
+- `release.yml` builds and verifies the shipped distribution. **PyPI
+  publication is paused** pending finalization of the published distribution
+  name, so a release is currently "tagged + built + verified", not "published".
+  Because a pushed `vX.Y.Z` tag currently triggers the publish job, version
+  tags are not pushed to the remote while the publication pause is in effect;
+  the tag/publish coupling will be made safe (publish gated to a deliberate
+  action) before remote tagging resumes.
+
+## Maintenance backlog
+
+- Keep the CONTRIBUTING test-count headline current as the suite grows (the
+  authoritative number is the `uv run pytest` total); the per-area table is
+  representative, not exhaustive.
+- Periodically confirm each documented gate command still matches CI exactly —
+  the recurring drift this file guards against.

--- a/src/trace_mcp/extension_status.py
+++ b/src/trace_mcp/extension_status.py
@@ -34,8 +34,7 @@ def get_extension_status() -> str:
         from trace_mcp.extensions.learn.embeddings import get_embedding_provider
     except Exception:
         return (
-            f"{_BANNER} — no learning extension. "
-            "Enable the trace-learn extension for cross-session knowledge recall."
+            f"{_BANNER} — no learning extension. Enable the trace-learn extension for cross-session knowledge recall."
         )
 
     try:

--- a/src/trace_mcp/extensions/learn/__init__.py
+++ b/src/trace_mcp/extensions/learn/__init__.py
@@ -88,7 +88,8 @@ def register(mcp: FastMCP, storage: TraceStorage) -> None:
         if _embedding_provider is None:
             return []
         return [
-            lrn for lrn in ks.learnings
+            lrn
+            for lrn in ks.learnings
             if lrn.embedding is None or lrn.embedding_model != _embedding_provider.model_name
         ]
 
@@ -183,11 +184,13 @@ def register(mcp: FastMCP, storage: TraceStorage) -> None:
 
             if isinstance(exc, LLMFallbackError):
                 logger.error("Strict LLM mode blocked fallback in trace_learn_recall: %s", exc)
-                return json.dumps({
-                    "error": "LLM strict mode: fallback blocked",
-                    "detail": str(exc),
-                    "project": project,
-                })
+                return json.dumps(
+                    {
+                        "error": "LLM strict mode: fallback blocked",
+                        "detail": str(exc),
+                        "project": project,
+                    }
+                )
             logger.exception("Error recalling learnings")
             return json.dumps({"error": "Failed to recall learnings", "project": project})
 
@@ -207,9 +210,11 @@ def register(mcp: FastMCP, storage: TraceStorage) -> None:
         """
         try:
             if category not in _VALID_CATEGORIES:
-                return json.dumps({
-                    "error": f"Invalid category '{category}'. Must be one of: {_VALID_CATEGORIES}",
-                })
+                return json.dumps(
+                    {
+                        "error": f"Invalid category '{category}'. Must be one of: {_VALID_CATEGORIES}",
+                    }
+                )
             # Lock the full load->mutate->save span so concurrent
             # multi-session adds to the same project don't lose updates
             # (last-writer-wins on the shared store).
@@ -226,11 +231,13 @@ def register(mcp: FastMCP, storage: TraceStorage) -> None:
                         dedup_threshold=_config.dedup_threshold,
                     )
                     if result.is_duplicate:
-                        return json.dumps({
-                            "duplicate": True,
-                            "similar_to": result.duplicate_of,
-                            "existing": store.learning_to_dict(result.learning),
-                        })
+                        return json.dumps(
+                            {
+                                "duplicate": True,
+                                "similar_to": result.duplicate_of,
+                                "existing": store.learning_to_dict(result.learning),
+                            }
+                        )
                     lrn = result.learning
                 else:
                     lrn = store.add_learning(
@@ -249,11 +256,13 @@ def register(mcp: FastMCP, storage: TraceStorage) -> None:
 
             if isinstance(exc, LLMFallbackError):
                 logger.error("Strict LLM mode blocked fallback in trace_learn_add: %s", exc)
-                return json.dumps({
-                    "error": "LLM strict mode: fallback blocked",
-                    "detail": str(exc),
-                    "project": project,
-                })
+                return json.dumps(
+                    {
+                        "error": "LLM strict mode: fallback blocked",
+                        "detail": str(exc),
+                        "project": project,
+                    }
+                )
             logger.exception("Error adding learning")
             return json.dumps({"error": "Failed to add learning", "project": project})
 
@@ -351,10 +360,12 @@ def register(mcp: FastMCP, storage: TraceStorage) -> None:
 
             if isinstance(exc, LLMFallbackError):
                 logger.error("Strict LLM mode blocked fallback in trace_learn_extract: %s", exc)
-                return json.dumps({
-                    "error": "LLM strict mode: fallback blocked",
-                    "detail": str(exc),
-                    "project": project,
-                })
+                return json.dumps(
+                    {
+                        "error": "LLM strict mode: fallback blocked",
+                        "detail": str(exc),
+                        "project": project,
+                    }
+                )
             logger.exception("Error extracting learnings")
             return json.dumps({"error": "Failed to extract learnings", "project": project})

--- a/src/trace_mcp/extensions/learn/embeddings.py
+++ b/src/trace_mcp/extensions/learn/embeddings.py
@@ -27,21 +27,21 @@ logger = logging.getLogger(__name__)
 # targets the provider unit tests mock, so they must exist as module attributes.
 
 try:
-    import numpy as _np  # noqa: F401 (runtime probe)
+    import numpy as _np  # noqa: F401  # pyright: ignore[reportUnusedImport]  (runtime probe)
 
     _HAS_NUMPY = True
 except ImportError:  # pragma: no cover
     _HAS_NUMPY = False
 
 try:
-    from openai import AsyncOpenAI  # noqa: F401
+    from openai import AsyncOpenAI  # noqa: F401  # pyright: ignore[reportUnusedImport]
 
     _HAS_OPENAI = True
 except ImportError:  # pragma: no cover
     _HAS_OPENAI = False
 
 try:
-    from model2vec import StaticModel  # noqa: F401
+    from model2vec import StaticModel  # noqa: F401  # pyright: ignore[reportUnusedImport]
 
     _HAS_MODEL2VEC = True
 except ImportError:  # pragma: no cover
@@ -187,10 +187,7 @@ def get_embedding_provider(config: LearnConfig | None = None) -> EmbeddingProvid
         msg = "model2vec embeddings requested but package not installed"
         if config.strict_llm:
             logger.error("%s. Refusing to fall back.", msg)
-            raise LLMFallbackError(
-                f"{msg}. Install with: pip install model2vec. "
-                f"Or set TRACE_EMBEDDING_BACKEND=auto."
-            )
+            raise LLMFallbackError(f"{msg}. Install with: pip install model2vec. Or set TRACE_EMBEDDING_BACKEND=auto.")
         logger.warning("%s. Falling back.", msg)
 
     # auto mode fell through — no embeddings available.
@@ -201,8 +198,7 @@ def get_embedding_provider(config: LearnConfig | None = None) -> EmbeddingProvid
             "Refusing to fall through silently to BM25."
         )
         raise LLMFallbackError(
-            "Strict LLM mode: 'openai' package required but not installed. "
-            "Install with: pip install 'trace-mcp[llm]'."
+            "Strict LLM mode: 'openai' package required but not installed. Install with: pip install 'trace-mcp[llm]'."
         )
 
     logger.info("No embedding provider available — falling through to BM25 matching")

--- a/src/trace_mcp/extensions/learn/extraction.py
+++ b/src/trace_mcp/extensions/learn/extraction.py
@@ -29,11 +29,24 @@ logger = logging.getLogger(__name__)
 _EXTRACTABLE_CATEGORIES = {"learning", "correction", "gotcha"}
 
 # Keywords that signal a decision is about prompt strategy (for auto-categorization)
-_PROMPT_KEYWORDS = frozenset({
-    "prompt", "few-shot", "zero-shot", "chain-of-thought", "system prompt",
-    "instruction", "few shot", "zero shot", "chain of thought", "cot",
-    "prompting", "prompt engineering", "prompt template", "in-context",
-})
+_PROMPT_KEYWORDS = frozenset(
+    {
+        "prompt",
+        "few-shot",
+        "zero-shot",
+        "chain-of-thought",
+        "system prompt",
+        "instruction",
+        "few shot",
+        "zero shot",
+        "chain of thought",
+        "cot",
+        "prompting",
+        "prompt engineering",
+        "prompt template",
+        "in-context",
+    }
+)
 
 try:
     from openai import AsyncOpenAI
@@ -48,10 +61,7 @@ except ImportError:
 
 def _already_extracted(store: KnowledgeStore, session_id: str, event_id: str) -> bool:
     """Check if a learning from this session+event already exists."""
-    return any(
-        lrn.source_session == session_id and lrn.source_event == event_id
-        for lrn in store.learnings
-    )
+    return any(lrn.source_session == session_id and lrn.source_event == event_id for lrn in store.learnings)
 
 
 def _add_with_optional_dedup(
@@ -295,8 +305,8 @@ async def extract_from_session_llm(
         '- "tags": 2-5 relevant tags for future retrieval\n'
         '- "source_event": the event ID this learning primarily comes from\n'
         '- "corrects_event_ids": list of event IDs being corrected (for corrections only)\n\n'
-        "Return a JSON object with key \"learnings\" containing an array of objects.\n"
-        "If no new learnings exist, return {\"learnings\": []}."
+        'Return a JSON object with key "learnings" containing an array of objects.\n'
+        'If no new learnings exist, return {"learnings": []}.'
     )
 
     try:
@@ -364,8 +374,7 @@ async def extract_from_session_llm(
                 f"rule-based fallback."
             ) from exc
         logger.warning(
-            "LLM extraction failed (model=%s) — falling back to rule-based. "
-            "Strict mode is OFF.",
+            "LLM extraction failed (model=%s) — falling back to rule-based. Strict mode is OFF.",
             config.llm_extraction_model,
             exc_info=True,
         )
@@ -389,7 +398,5 @@ async def extract_from_session_auto(
     dedup_threshold = config.dedup_threshold if config.dedup_enabled else None
 
     if config.llm_enabled and config.openai_api_key and _HAS_OPENAI:
-        return await extract_from_session_llm(
-            store, session, config, dedup_threshold=dedup_threshold
-        )
+        return await extract_from_session_llm(store, session, config, dedup_threshold=dedup_threshold)
     return extract_from_session(store, session, dedup_threshold=dedup_threshold)

--- a/src/trace_mcp/extensions/learn/matching.py
+++ b/src/trace_mcp/extensions/learn/matching.py
@@ -171,10 +171,7 @@ class JaccardBackend:
         context: str,
         context_tags: list[str] | None = None,
     ) -> list[tuple[int, float]]:
-        return [
-            (i, score_learning(lrn, context, context_tags, self.tag_weight))
-            for i, lrn in enumerate(learnings)
-        ]
+        return [(i, score_learning(lrn, context, context_tags, self.tag_weight)) for i, lrn in enumerate(learnings)]
 
 
 # ── BM25 backend ─────────────────────────────────────────────────────────
@@ -289,8 +286,7 @@ class LLMBackend:
     def __init__(self, config: LearnConfig) -> None:
         if not _HAS_OPENAI:
             raise RuntimeError(
-                "The 'openai' package is required for LLM matching. "
-                "Install it with: pip install 'trace-mcp[llm]'"
+                "The 'openai' package is required for LLM matching. Install it with: pip install 'trace-mcp[llm]'"
             )
         self._client = AsyncOpenAI(api_key=config.openai_api_key)
         self._model = config.llm_model
@@ -315,9 +311,7 @@ class LLMBackend:
         index_map: dict[int, int] = {}  # local idx → original idx
         candidates = learnings
         if len(learnings) > self.MAX_DIRECT_CANDIDATES:
-            bm25_scores = await self._bm25_fallback.score_batch(
-                learnings, context, context_tags
-            )
+            bm25_scores = await self._bm25_fallback.score_batch(learnings, context, context_tags)
             bm25_scores.sort(key=lambda x: x[1], reverse=True)
             top_indices = [idx for idx, _ in bm25_scores[: self.MAX_DIRECT_CANDIDATES]]
             candidates = [learnings[i] for i in top_indices]
@@ -343,14 +337,11 @@ class LLMBackend:
                     f"allow silent fallback to BM25."
                 ) from exc
             logger.warning(
-                "LLM scoring failed (model=%s) — falling back to BM25. "
-                "Strict mode is OFF.",
+                "LLM scoring failed (model=%s) — falling back to BM25. Strict mode is OFF.",
                 self._model,
                 exc_info=True,
             )
-            return await self._bm25_fallback.score_batch(
-                learnings, context, context_tags
-            )
+            return await self._bm25_fallback.score_batch(learnings, context, context_tags)
 
         return [(index_map[local], score) for local, score in enumerate(scores)]
 
@@ -426,7 +417,9 @@ class EmbeddingBackend:
         self._provider = provider
         self._tag_weight = tag_weight
         self._bm25_fallback = BM25Backend(
-            k1=bm25_fallback_k1, b=bm25_fallback_b, tag_weight=tag_weight,
+            k1=bm25_fallback_k1,
+            b=bm25_fallback_b,
+            tag_weight=tag_weight,
         )
 
     async def score_batch(
@@ -459,7 +452,8 @@ class EmbeddingBackend:
             query_vec = query_vecs[0]
 
             matrix = np.array(
-                [lrn.embedding for _, lrn in with_emb], dtype=np.float32,
+                [lrn.embedding for _, lrn in with_emb],
+                dtype=np.float32,
             )
             similarities = cosine_similarity_matrix(query_vec, matrix)
 
@@ -473,7 +467,9 @@ class EmbeddingBackend:
         if without_emb:
             bm25_learnings = [lrn for _, lrn in without_emb]
             bm25_scores = await self._bm25_fallback.score_batch(
-                bm25_learnings, context, context_tags,
+                bm25_learnings,
+                context,
+                context_tags,
             )
             for bm25_local_idx, score in bm25_scores:
                 orig_idx = without_emb[bm25_local_idx][0]
@@ -533,7 +529,8 @@ def get_default_backend(config: LearnConfig | None = None) -> MatchingBackend:
 
     logger.warning(
         "Using BM25 matching backend (k1=%s, b=%s) — no LLM or embedding provider available",
-        config.bm25_k1, config.bm25_b,
+        config.bm25_k1,
+        config.bm25_b,
     )
     return BM25Backend(
         k1=config.bm25_k1,
@@ -657,10 +654,13 @@ async def recall_learnings(
     for idx, score in surfaced:
         learnings[idx].recall_count += 1
         learnings[idx].last_surfaced = now
-        results.append({
-            "learning": learnings[idx].model_dump(
-                mode="json", exclude={"embedding", "embedding_model"},
-            ),
-            "score": round(score, 4),
-        })
+        results.append(
+            {
+                "learning": learnings[idx].model_dump(
+                    mode="json",
+                    exclude={"embedding", "embedding_model"},
+                ),
+                "score": round(score, 4),
+            }
+        )
     return results

--- a/src/trace_mcp/init_project.py
+++ b/src/trace_mcp/init_project.py
@@ -81,8 +81,7 @@ def _pick_adapter(project_dir: Path, explicit: str | None) -> Adapter | None:
     detected = detect_adapter(project_dir)
     if detected is None:
         print(
-            "No host adapter auto-detected. Pass --client="
-            f"{{{','.join(list_adapters())},none}} to pick one explicitly."
+            f"No host adapter auto-detected. Pass --client={{{','.join(list_adapters())},none}} to pick one explicitly."
         )
     return detected
 

--- a/src/trace_mcp/scratchpad.py
+++ b/src/trace_mcp/scratchpad.py
@@ -78,10 +78,7 @@ def _build_session_section(session: Session) -> str:
         lines.append(session.summary)
 
     # ── Contributions ────────────────────────────────────────────────
-    contributions = [
-        e for e in session.events
-        if e.type == "contribution" and e.contribution
-    ]
+    contributions = [e for e in session.events if e.type == "contribution" and e.contribution]
     if contributions:
         lines.append("")
         lines.append("### What Was Accomplished")
@@ -90,16 +87,10 @@ def _build_session_section(session: Session) -> str:
             c = e.contribution
             assert c is not None
             artifact = f" (`{c.artifact}`)" if c.artifact else ""
-            lines.append(
-                f"- {c.description}{artifact} "
-                f"— direction={c.direction}, execution={c.execution}"
-            )
+            lines.append(f"- {c.description}{artifact} — direction={c.direction}, execution={c.execution}")
 
     # ── Decisions ────────────────────────────────────────────────────
-    decisions = [
-        e for e in session.events
-        if e.type == "decision" and e.decision
-    ]
+    decisions = [e for e in session.events if e.type == "decision" and e.decision]
     if decisions:
         lines.append("")
         lines.append("### Decisions")
@@ -109,16 +100,10 @@ def _build_session_section(session: Session) -> str:
             assert d is not None
             stype = f", suggestion={d.suggestion_type}" if d.suggestion_type else ""
             note = f" — {d.revision_note}" if d.revision_note else ""
-            lines.append(
-                f"- **[{d.disposition}]** {d.description} "
-                f"(proposed_by={d.proposed_by.type}{stype}){note}"
-            )
+            lines.append(f"- **[{d.disposition}]** {d.description} (proposed_by={d.proposed_by.type}{stype}){note}")
 
     # ── Open items (unresolved decisions) ────────────────────────────
-    unresolved = [
-        e for e in decisions
-        if e.decision and e.decision.disposition == "proposed"
-    ]
+    unresolved = [e for e in decisions if e.decision and e.decision.disposition == "proposed"]
     if unresolved:
         lines.append("")
         lines.append("### Open Items")
@@ -130,9 +115,9 @@ def _build_session_section(session: Session) -> str:
 
     # ── Gotchas & Corrections ────────────────────────────────────────
     gotchas = [
-        e for e in session.events
-        if e.type == "annotation" and e.annotation
-        and e.annotation.category in ("gotcha", "correction")
+        e
+        for e in session.events
+        if e.type == "annotation" and e.annotation and e.annotation.category in ("gotcha", "correction")
     ]
     if gotchas:
         lines.append("")
@@ -147,9 +132,7 @@ def _build_session_section(session: Session) -> str:
 
     # ── Learnings ────────────────────────────────────────────────────
     learnings = [
-        e for e in session.events
-        if e.type == "annotation" and e.annotation
-        and e.annotation.category == "learning"
+        e for e in session.events if e.type == "annotation" and e.annotation and e.annotation.category == "learning"
     ]
     if learnings:
         lines.append("")
@@ -161,11 +144,7 @@ def _build_session_section(session: Session) -> str:
             lines.append(f"- {a.content}")
 
     # ── TODOs ────────────────────────────────────────────────────────
-    todos = [
-        e for e in session.events
-        if e.type == "annotation" and e.annotation
-        and e.annotation.category == "todo"
-    ]
+    todos = [e for e in session.events if e.type == "annotation" and e.annotation and e.annotation.category == "todo"]
     if todos:
         lines.append("")
         lines.append("### TODOs")
@@ -198,9 +177,7 @@ def _build_session_section(session: Session) -> str:
 def _atomic_write(path: Path, content: str) -> None:
     """Write content atomically using temp file + rename."""
     path.parent.mkdir(parents=True, exist_ok=True)
-    fd, tmp_path = tempfile.mkstemp(
-        dir=str(path.parent), suffix=".tmp", prefix=".scratchpad_"
-    )
+    fd, tmp_path = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp", prefix=".scratchpad_")
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             f.write(content)

--- a/src/trace_mcp/selfcost.py
+++ b/src/trace_mcp/selfcost.py
@@ -81,8 +81,12 @@ class SchemaSurface(BaseModel):
     tool_count: int = Field(..., description="Number of registered MCP tools introspected.")
     schema_chars: int = Field(..., description="Total characters of name+description+inputSchema JSON across tools.")
     tokens_est: int = Field(..., description="Raw chars/4 token estimate of the schema surface (uncached).")
-    cold_write_tokens_est: int = Field(..., description="First-turn cache-write estimate (tokens_est * write multiplier).")
-    warm_read_tokens_est: int = Field(..., description="Per-later-turn cache-read estimate (tokens_est * read multiplier).")
+    cold_write_tokens_est: int = Field(
+        ..., description="First-turn cache-write estimate (tokens_est * write multiplier)."
+    )
+    warm_read_tokens_est: int = Field(
+        ..., description="Per-later-turn cache-read estimate (tokens_est * read multiplier)."
+    )
     included_extensions: bool = Field(..., description="Whether extension tools were included in the surface.")
     note: str = Field(..., description="Honesty caveat for this measurement.")
 
@@ -93,8 +97,12 @@ class SessionCost(BaseModel):
     session_id: str
     project: str | None = None
     event_count: int
-    authored_tokens_est: int = Field(..., description="chars/4 estimate of authored event payloads (model output side).")
-    by_event_type: dict[str, int] = Field(default_factory=dict, description="authored_tokens_est broken down by event type.")
+    authored_tokens_est: int = Field(
+        ..., description="chars/4 estimate of authored event payloads (model output side)."
+    )
+    by_event_type: dict[str, int] = Field(
+        default_factory=dict, description="authored_tokens_est broken down by event type."
+    )
     tool_call_host_breakdown: dict[str, int] = Field(
         default_factory=dict,
         description="Counts of logged tool_call events by host (mcp/internal/external). internal/external are logged "
@@ -108,7 +116,9 @@ class ReuseSignal(BaseModel):
 
     project: str
     total_learnings: int
-    total_recall_count: int = Field(..., description="Sum of recall_count across learnings (SURFACING, not proven use).")
+    total_recall_count: int = Field(
+        ..., description="Sum of recall_count across learnings (SURFACING, not proven use)."
+    )
     never_surfaced: int
     avg_recall_count: float
     data_quality_flag: str = Field(..., description="Why these counts are a weak, possibly-undercounted signal.")

--- a/src/trace_mcp/server.py
+++ b/src/trace_mcp/server.py
@@ -92,9 +92,7 @@ async def _ensure_session(session_id: str | None) -> tuple[Session, str]:
 
     # 1. Explicit session_id provided — look it up (may raise)
     if session_id:
-        session = await session_tools.get_or_load_session(
-            storage, active_sessions, session_id
-        )
+        session = await session_tools.get_or_load_session(storage, active_sessions, session_id)
         # Only an ACTIVE session may become the new current session. An
         # explicit session_id targeting a completed session (e.g. resolving
         # a decision proposed in a prior, now-closed session) must not move
@@ -115,9 +113,7 @@ async def _ensure_session(session_id: str | None) -> tuple[Session, str]:
     # 2. Re-use the current session from earlier in this server process
     if _current_session_id:
         try:
-            session = await session_tools.get_or_load_session(
-                storage, active_sessions, _current_session_id
-            )
+            session = await session_tools.get_or_load_session(storage, active_sessions, _current_session_id)
             if session.status == "active":
                 return session, ""
             # The current session was completed/abandoned (e.g. ended from
@@ -202,9 +198,7 @@ async def trace_start_session(
         # Recall is OFF by default (v0.4.2): opt-in only, rendered once.
         recalled_block = ""
         if recall_learnings and description:
-            recalled = await hooks.recall_if_available(
-                project, description, tags, recall_limit
-            )
+            recalled = await hooks.recall_if_available(project, description, tags, recall_limit)
             if recalled:
                 recalled_block = hooks.format_recalled_learnings(recalled)
 
@@ -246,9 +240,7 @@ async def trace_end_session(
         project: str | None = None
         if extract_learnings:
             try:
-                session = await session_tools.get_or_load_session(
-                    storage, active_sessions, session_id
-                )
+                session = await session_tools.get_or_load_session(storage, active_sessions, session_id)
                 project = session.metadata.project
             except FileNotFoundError:
                 pass
@@ -550,9 +542,7 @@ async def trace_propose_decision(
 
         # Layer 3: Auto-recall related learnings for this decision
         project = session.metadata.project
-        related = await hooks.recall_if_available(
-            project, description, tags, limit=3
-        )
+        related = await hooks.recall_if_available(project, description, tags, limit=3)
         if related:
             result += hooks.format_decision_warnings(related)
 
@@ -688,13 +678,15 @@ async def trace_search(
     all_results = query_tools.search_events(session, query=query)
     cap = max(1, min(limit, query_tools.MAX_SEARCH_LIMIT))
     returned = all_results[:cap]
-    return _compact({
-        "query": query,
-        "total_matched": len(all_results),
-        "returned": len(returned),
-        "truncated": len(all_results) > len(returned),
-        "results": returned,
-    })
+    return _compact(
+        {
+            "query": query,
+            "total_matched": len(all_results),
+            "returned": len(returned),
+            "truncated": len(all_results) > len(returned),
+            "results": returned,
+        }
+    )
 
 
 @mcp.tool()
@@ -726,9 +718,7 @@ async def trace_health_check(
     (total, by type, by actor type). Optionally scoped to a project or session.
     """
     try:
-        result = await query_tools.health_check(
-            storage, project=project, session_id=session_id
-        )
+        result = await query_tools.health_check(storage, project=project, session_id=session_id)
         return _compact(result)
     except Exception as e:
         logger.exception("Error running health check")

--- a/src/trace_mcp/tools/decision_tools.py
+++ b/src/trace_mcp/tools/decision_tools.py
@@ -124,10 +124,7 @@ async def resolve_decision(
         # id) proposes and resolves. The ai→ai case warns unconditionally; the
         # generalized non-ai case is gated to multi-actor sessions (see below).
         proposer = target.decision.proposed_by
-        is_self_resolution = (
-            proposer.type == resolved_by_type
-            and proposer.id == resolved_by_id
-        )
+        is_self_resolution = proposer.type == resolved_by_type and proposer.id == resolved_by_id
 
         if is_self_resolution and not suppress:
             if resolved_by_type == "ai":
@@ -135,8 +132,7 @@ async def resolve_decision(
                 # case). Fires unconditionally — AI must not resolve its own
                 # proposal regardless of how many actor types the session has.
                 guard_warnings.append(
-                    "AI resolved its own proposal. Decisions proposed by AI "
-                    "should normally be resolved by a human."
+                    "AI resolved its own proposal. Decisions proposed by AI should normally be resolved by a human."
                 )
             elif write_session.is_multi_actor():
                 # v0.4.1: human→human (or system→system) same-instance

--- a/src/trace_mcp/tools/logging_tools.py
+++ b/src/trace_mcp/tools/logging_tools.py
@@ -51,8 +51,7 @@ async def log_tool_call(
     tool_lower = tool_name.lower()
     if "trace" in server_lower or tool_lower.startswith("trace_"):
         warnings.append(
-            "TRACE protocol says to never log TRACE's own tool calls. "
-            "This event was logged but should be avoided."
+            "TRACE protocol says to never log TRACE's own tool calls. This event was logged but should be avoided."
         )
 
     # Hint about exploratory tool calls
@@ -129,11 +128,7 @@ async def log_annotation(
     # is likely being used as a workaround for the correction relationship.
     # This is the anti-pattern of a correction with no corrects_event_ids and
     # no anchor, where related_event_ids stands in for the correction link.
-    if (
-        category == "correction"
-        and not effective_corrects
-        and effective_related
-    ):
+    if category == "correction" and not effective_corrects and effective_related:
         warnings.append(
             "Correction has empty corrects_event_ids but non-empty related_event_ids. "
             "If related_event_ids contains the corrected item's anchor, move it to "

--- a/src/trace_mcp/tools/session_tools.py
+++ b/src/trace_mcp/tools/session_tools.py
@@ -41,10 +41,12 @@ class DecisionSummary(BaseModel):
 # v0.4.1: explicit absence markers for conversation_snippet per spec §3.4.1.
 # Documented allow-list; producers MAY define additional markers using the
 # `<...>` convention but these are the canonical ones surfaced in the audit.
-_EXPLICIT_ABSENCE_MARKERS = frozenset({
-    "<autonomous-stretch>",
-    "<no recent user message>",
-})
+_EXPLICIT_ABSENCE_MARKERS = frozenset(
+    {
+        "<autonomous-stretch>",
+        "<no recent user message>",
+    }
+)
 
 
 def _is_explicit_absence(s: str | None) -> bool:
@@ -118,7 +120,7 @@ class AttributionAudit(BaseModel):
                 artifact = f", artifact={c.artifact}" if c.artifact else ""
                 lines.append(
                     f"  {c.event_id}: direction={c.direction}, "
-                    f"execution={c.execution}{artifact} — \"{c.description_preview}\""
+                    f'execution={c.execution}{artifact} — "{c.description_preview}"'
                 )
 
         if self.decisions:
@@ -127,7 +129,7 @@ class AttributionAudit(BaseModel):
                 stype = f", suggestion={d.suggestion_type}" if d.suggestion_type else ""
                 lines.append(
                     f"  {d.event_id}: proposed_by={d.proposed_by_type}{stype}, "
-                    f"disposition={d.disposition} — \"{d.description_preview}\""
+                    f'disposition={d.disposition} — "{d.description_preview}"'
                 )
 
         if self.correction_count:
@@ -147,15 +149,11 @@ class AttributionAudit(BaseModel):
         # Guard rail warnings
         if self.unresolved_decision_count:
             ids = ", ".join(self.unresolved_decision_ids)
-            lines.append(
-                f"Unresolved decisions: {self.unresolved_decision_count} ({ids})"
-            )
+            lines.append(f"Unresolved decisions: {self.unresolved_decision_count} ({ids})")
 
         if self.self_resolution_count:
             ids = ", ".join(self.self_resolution_ids)
-            lines.append(
-                f"AI self-resolutions: {self.self_resolution_count} ({ids})"
-            )
+            lines.append(f"AI self-resolutions: {self.self_resolution_count} ({ids})")
 
         # v0.4.1: generalized same-instance self-resolution count (any actor
         # type, per spec §3.6 Proposer Identity Rule). May overlap with
@@ -169,10 +167,7 @@ class AttributionAudit(BaseModel):
             )
 
         if self.unlinked_correction_count:
-            lines.append(
-                f"Unlinked corrections: {self.unlinked_correction_count} "
-                "(missing corrects_event_ids)"
-            )
+            lines.append(f"Unlinked corrections: {self.unlinked_correction_count} (missing corrects_event_ids)")
 
         if self.orphan_discovery_hint_count:
             ids = ", ".join(self.orphan_discovery_event_ids)
@@ -183,10 +178,7 @@ class AttributionAudit(BaseModel):
                 "consider logging at the moment of discovery per spec §8.1"
             )
 
-        if (
-            self.missing_snippet_contribution_count
-            or self.missing_snippet_correction_count
-        ):
+        if self.missing_snippet_contribution_count or self.missing_snippet_correction_count:
             parts2: list[str] = []
             if self.missing_snippet_contribution_count:
                 parts2.append(f"{self.missing_snippet_contribution_count} contribution(s)")
@@ -208,12 +200,7 @@ class AttributionAudit(BaseModel):
             for w in self.warnings:
                 lines.append(f"  \u26a0\ufe0f {w}")
 
-        if (
-            not self.contributions
-            and not self.decisions
-            and not self.correction_count
-            and not self.warnings
-        ):
+        if not self.contributions and not self.decisions and not self.correction_count and not self.warnings:
             lines.append("No contributions, decisions, or corrections to review.")
 
         return "\n".join(lines)
@@ -254,10 +241,15 @@ def _build_attribution_audit(session: Session) -> AttributionAudit:
     # 30-minute pre-window in O(K) rather than O(N²).
     discovery_anchors: list[tuple[str, datetime]] = []  # (event_id, timestamp)
     for e in session.events:
-        if e.type == "annotation" and e.annotation and e.annotation.category in (
-            "discovery",
-            "correction",
-            "gotcha",
+        if (
+            e.type == "annotation"
+            and e.annotation
+            and e.annotation.category
+            in (
+                "discovery",
+                "correction",
+                "gotcha",
+            )
         ):
             discovery_anchors.append((e.id, e.timestamp))
 
@@ -270,13 +262,15 @@ def _build_attribution_audit(session: Session) -> AttributionAudit:
             contribution_count += 1
             c = e.contribution
             desc = c.description[:80] + ("..." if len(c.description) > 80 else "")
-            contribs.append(ContributionSummary(
-                event_id=e.id,
-                direction=c.direction,
-                execution=c.execution,
-                artifact=c.artifact,
-                description_preview=desc,
-            ))
+            contribs.append(
+                ContributionSummary(
+                    event_id=e.id,
+                    direction=c.direction,
+                    execution=c.execution,
+                    artifact=c.artifact,
+                    description_preview=desc,
+                )
+            )
 
             # v0.4.1: count contributions missing conversation_snippet.
             # explicit_absence markers count separately so honest absences
@@ -295,23 +289,22 @@ def _build_attribution_audit(session: Session) -> AttributionAudit:
             desc_lower = c.description.lower()
             if any(phrase in desc_lower for phrase in _DISCOVERY_PHRASES):
                 window_start = e.timestamp - discovery_window
-                has_anchor = any(
-                    window_start <= ts <= e.timestamp
-                    for _, ts in discovery_anchors
-                )
+                has_anchor = any(window_start <= ts <= e.timestamp for _, ts in discovery_anchors)
                 if not has_anchor:
                     orphan_discovery_ids.append(e.id)
 
         elif e.type == "decision" and e.decision:
             d = e.decision
             desc = d.description[:80] + ("..." if len(d.description) > 80 else "")
-            decs.append(DecisionSummary(
-                event_id=e.id,
-                proposed_by_type=d.proposed_by.type,
-                suggestion_type=d.suggestion_type,
-                disposition=d.disposition,
-                description_preview=desc,
-            ))
+            decs.append(
+                DecisionSummary(
+                    event_id=e.id,
+                    proposed_by_type=d.proposed_by.type,
+                    suggestion_type=d.suggestion_type,
+                    disposition=d.disposition,
+                    description_preview=desc,
+                )
+            )
             if d.disposition == "rejected":
                 rejected.append(e)
             elif d.disposition == "revised":
@@ -366,13 +359,11 @@ def _build_attribution_audit(session: Session) -> AttributionAudit:
     # Build aggregate warnings (severity-ordered to match render())
     if unresolved_ids:
         audit_warnings.append(
-            f"{len(unresolved_ids)} decision(s) still in 'proposed' state — "
-            "were they reviewed by the human?"
+            f"{len(unresolved_ids)} decision(s) still in 'proposed' state — were they reviewed by the human?"
         )
     if self_resolved_ids:
         audit_warnings.append(
-            f"{len(self_resolved_ids)} decision(s) were proposed and resolved by AI — "
-            "verify human was consulted."
+            f"{len(self_resolved_ids)} decision(s) were proposed and resolved by AI — verify human was consulted."
         )
     if attribution_warning_ids:
         audit_warnings.append(
@@ -382,8 +373,7 @@ def _build_attribution_audit(session: Session) -> AttributionAudit:
         )
     if unlinked_correction_count:
         audit_warnings.append(
-            f"{unlinked_correction_count} correction(s) lack corrects_event_ids — "
-            "link them for full provenance."
+            f"{unlinked_correction_count} correction(s) lack corrects_event_ids — link them for full provenance."
         )
     # Orphan-discovery is surfaced ONLY as the low-severity
     # `orphan_discovery_hint_count` (rendered separately). It is deliberately
@@ -405,12 +395,7 @@ def _build_attribution_audit(session: Session) -> AttributionAudit:
     # routinely have 0 tool_call events, so a low threshold would generate
     # permanent noise. Guard against missing environment for legacy sessions.
     env = session.metadata.environment
-    if (
-        contribution_count >= 10
-        and tool_call_count == 0
-        and env is not None
-        and env.client == "Claude Code"
-    ):
+    if contribution_count >= 10 and tool_call_count == 0 and env is not None and env.client == "Claude Code":
         audit_warnings.append(
             f"[hint] Session has {contribution_count} contributions and 0 tool_call "
             "events. If subagent dispatches occurred, consider logging them as "
@@ -715,8 +700,7 @@ def _check_referential_integrity(
     for ref_id, field_name in ids_to_check:
         if ref_id not in existing_ids:
             warnings.append(
-                f"Dangling reference: {field_name} contains '{ref_id}' "
-                f"which does not exist in this session."
+                f"Dangling reference: {field_name} contains '{ref_id}' which does not exist in this session."
             )
 
     return warnings
@@ -781,10 +765,7 @@ async def append_event(
         # Validate referential integrity against the merged state.
         ref_errors = _check_referential_integrity(session, event)
         if ref_errors:
-            raise ValueError(
-                f"Invalid event references in {event.id}:\n"
-                + "\n".join(f"  - {e}" for e in ref_errors)
-            )
+            raise ValueError(f"Invalid event references in {event.id}:\n" + "\n".join(f"  - {e}" for e in ref_errors))
 
         session.events.append(event)
         await storage.update_session(session)

--- a/tests/test_adapter_hooks.py
+++ b/tests/test_adapter_hooks.py
@@ -193,9 +193,7 @@ class TestPromptReminder:
         project_dir, sessions, runtime = self._setup(tmp_path)
         _make_session(sessions, session_id=f"trace_{_today()}_aaaaaa", project="my-proj", status="active")
 
-        result = _run_hook(
-            PROMPT_REMINDER, project_dir=project_dir, sessions_dir=sessions, runtime_dir=runtime
-        )
+        result = _run_hook(PROMPT_REMINDER, project_dir=project_dir, sessions_dir=sessions, runtime_dir=runtime)
         assert result.returncode == 0
         assert result.stdout.strip() == ""
 
@@ -203,9 +201,7 @@ class TestPromptReminder:
         project_dir, sessions, runtime = self._setup(tmp_path)
         # Default MIN_TURNS=3 → turns 1 and 2 should be silent
         for _ in range(2):
-            result = _run_hook(
-                PROMPT_REMINDER, project_dir=project_dir, sessions_dir=sessions, runtime_dir=runtime
-            )
+            result = _run_hook(PROMPT_REMINDER, project_dir=project_dir, sessions_dir=sessions, runtime_dir=runtime)
             assert result.stdout.strip() == "", f"unexpected nudge: {result.stdout!r}"
 
     def test_nudges_on_third_turn_without_session(self, tmp_path: Path) -> None:
@@ -213,9 +209,7 @@ class TestPromptReminder:
         for _ in range(2):
             _run_hook(PROMPT_REMINDER, project_dir=project_dir, sessions_dir=sessions, runtime_dir=runtime)
 
-        result = _run_hook(
-            PROMPT_REMINDER, project_dir=project_dir, sessions_dir=sessions, runtime_dir=runtime
-        )
+        result = _run_hook(PROMPT_REMINDER, project_dir=project_dir, sessions_dir=sessions, runtime_dir=runtime)
         assert "TRACE:" in result.stdout
         assert "my-proj" in result.stdout
 
@@ -226,9 +220,7 @@ class TestPromptReminder:
             _run_hook(PROMPT_REMINDER, project_dir=project_dir, sessions_dir=sessions, runtime_dir=runtime)
 
         # 4th turn within cooldown should be silent (cooldown default 300s)
-        result = _run_hook(
-            PROMPT_REMINDER, project_dir=project_dir, sessions_dir=sessions, runtime_dir=runtime
-        )
+        result = _run_hook(PROMPT_REMINDER, project_dir=project_dir, sessions_dir=sessions, runtime_dir=runtime)
         assert result.stdout.strip() == ""
 
     def test_re_nudges_after_cooldown_expires(self, tmp_path: Path) -> None:

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -262,9 +262,7 @@ class TestResolveTraceSource:
         monkeypatch.setenv("TRACE_SOURCE_PATH", "/explicit/path")
         assert _resolve_trace_source() == "/explicit/path"
 
-    def test_env_override_wins_even_inside_site_packages(
-        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-    ) -> None:
+    def test_env_override_wins_even_inside_site_packages(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
         from trace_mcp import init_project as ip
 
         fake = tmp_path / "lib" / "python3.13" / "site-packages" / "trace_mcp" / "init_project.py"
@@ -288,9 +286,7 @@ class TestResolveTraceSource:
 
         assert ip._resolve_trace_source() == "trace-mcp"
 
-    def test_uses_repo_root_for_editable_install(
-        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-    ) -> None:
+    def test_uses_repo_root_for_editable_install(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
         from trace_mcp import init_project as ip
 
         repo = tmp_path / "TRACE-checkout"

--- a/tests/test_decision_guards.py
+++ b/tests/test_decision_guards.py
@@ -31,9 +31,7 @@ async def _make_session(
     project: str = "guard-test",
 ) -> Session:
     """Helper to create a session and return the Session object."""
-    result = await session_tools.start_session(
-        storage, active, project=project, description="Guard rail test session"
-    )
+    result = await session_tools.start_session(storage, active, project=project, description="Guard rail test session")
     session_id = result.split("Session: ")[1].split("\n")[0]
     return active[session_id]
 
@@ -44,46 +42,50 @@ async def _make_session(
 class TestSameActorWarning:
     """FM1: AI should not resolve its own proposals."""
 
-    async def test_ai_self_resolves_gets_warning(
-        self, storage: JsonFileStorage, active: dict[str, Session]
-    ) -> None:
+    async def test_ai_self_resolves_gets_warning(self, storage: JsonFileStorage, active: dict[str, Session]) -> None:
         """AI proposes + AI resolves -> warning in result."""
         session = await _make_session(storage, active)
         evt_id = await decision_tools.propose_decision(
-            storage, session,
+            storage,
+            session,
             description="Use method X",
-            proposed_by_type="ai", proposed_by_id="claude",
+            proposed_by_type="ai",
+            proposed_by_id="claude",
         )
         # Extract clean event ID (strip any referential integrity warnings)
         evt_id = evt_id.split("\n")[0]
         result = await decision_tools.resolve_decision(
-            storage, session,
-            event_id=evt_id, disposition="accepted",
-            resolved_by_type="ai", resolved_by_id="claude",
+            storage,
+            session,
+            event_id=evt_id,
+            disposition="accepted",
+            resolved_by_type="ai",
+            resolved_by_id="claude",
         )
         assert "AI resolved its own proposal" in result
 
-    async def test_human_resolves_ai_proposal_clean(
-        self, storage: JsonFileStorage, active: dict[str, Session]
-    ) -> None:
+    async def test_human_resolves_ai_proposal_clean(self, storage: JsonFileStorage, active: dict[str, Session]) -> None:
         """AI proposes + human resolves -> no self-resolution warning."""
         session = await _make_session(storage, active)
         evt_id = await decision_tools.propose_decision(
-            storage, session,
+            storage,
+            session,
             description="Use method X",
-            proposed_by_type="ai", proposed_by_id="claude",
+            proposed_by_type="ai",
+            proposed_by_id="claude",
         )
         evt_id = evt_id.split("\n")[0]
         result = await decision_tools.resolve_decision(
-            storage, session,
-            event_id=evt_id, disposition="accepted",
-            resolved_by_type="human", resolved_by_id="researcher",
+            storage,
+            session,
+            event_id=evt_id,
+            disposition="accepted",
+            resolved_by_type="human",
+            resolved_by_id="researcher",
         )
         assert "AI resolved its own proposal" not in result
 
-    async def test_human_self_resolves_clean(
-        self, storage: JsonFileStorage, active: dict[str, Session]
-    ) -> None:
+    async def test_human_self_resolves_clean(self, storage: JsonFileStorage, active: dict[str, Session]) -> None:
         """Round-3 A1 / decision evt_016: human\u2192human same-instance
         self-resolution in a SINGLE-ACTOR session must NOT warn.
 
@@ -98,15 +100,20 @@ class TestSameActorWarning:
         """
         session = await _make_session(storage, active)
         evt_id = await decision_tools.propose_decision(
-            storage, session,
+            storage,
+            session,
             description="Use method X",
-            proposed_by_type="human", proposed_by_id="researcher",
+            proposed_by_type="human",
+            proposed_by_id="researcher",
         )
         evt_id = evt_id.split("\n")[0]
         result = await decision_tools.resolve_decision(
-            storage, session,
-            event_id=evt_id, disposition="accepted",
-            resolved_by_type="human", resolved_by_id="researcher",
+            storage,
+            session,
+            event_id=evt_id,
+            disposition="accepted",
+            resolved_by_type="human",
+            resolved_by_id="researcher",
         )
         # Single-actor session ({human} only) \u2192 NO general-case warning
         assert "Same actor instance proposed and resolved this decision" not in result
@@ -119,15 +126,20 @@ class TestSameActorWarning:
         (e.g. an automated pipeline) must NOT warn \u2014 {system} is one type."""
         session = await _make_session(storage, active)
         evt_id = await decision_tools.propose_decision(
-            storage, session,
+            storage,
+            session,
             description="auto-pick threshold",
-            proposed_by_type="system", proposed_by_id="pipeline",
+            proposed_by_type="system",
+            proposed_by_id="pipeline",
         )
         evt_id = evt_id.split("\n")[0]
         result = await decision_tools.resolve_decision(
-            storage, session,
-            event_id=evt_id, disposition="accepted",
-            resolved_by_type="system", resolved_by_id="pipeline",
+            storage,
+            session,
+            event_id=evt_id,
+            disposition="accepted",
+            resolved_by_type="system",
+            resolved_by_id="pipeline",
         )
         assert "Same actor instance proposed and resolved this decision" not in result
         assert "AI resolved its own proposal" not in result
@@ -142,15 +154,20 @@ class TestSameActorWarning:
         keep ai\u2192ai unconditional."""
         session = await _make_session(storage, active)
         evt_id = await decision_tools.propose_decision(
-            storage, session,
+            storage,
+            session,
             description="Use method X",
-            proposed_by_type="ai", proposed_by_id="claude",
+            proposed_by_type="ai",
+            proposed_by_id="claude",
         )
         evt_id = evt_id.split("\n")[0]
         result = await decision_tools.resolve_decision(
-            storage, session,
-            event_id=evt_id, disposition="accepted",
-            resolved_by_type="ai", resolved_by_id="claude",
+            storage,
+            session,
+            event_id=evt_id,
+            disposition="accepted",
+            resolved_by_type="ai",
+            resolved_by_id="claude",
         )
         # FM25 literal must be present for ai\u2192ai even in a single-actor session
         assert "Decision proposed and self-resolved in" in result
@@ -166,15 +183,20 @@ class TestSameActorWarning:
         # Make the session multi-actor by TYPE (human + ai participants).
         session.metadata.participants.append(Actor(type="ai", id="claude"))
         evt_id = await decision_tools.propose_decision(
-            storage, session,
+            storage,
+            session,
             description="Use threshold 0.80",
-            proposed_by_type="human", proposed_by_id="researcher-alice",
+            proposed_by_type="human",
+            proposed_by_id="researcher-alice",
         )
         evt_id = evt_id.split("\n")[0]
         result = await decision_tools.resolve_decision(
-            storage, session,
-            event_id=evt_id, disposition="accepted",
-            resolved_by_type="human", resolved_by_id="researcher-bob",
+            storage,
+            session,
+            event_id=evt_id,
+            disposition="accepted",
+            resolved_by_type="human",
+            resolved_by_id="researcher-bob",
         )
         # Multi-actor, but different instances \u2192 not same-instance \u2192 no warn
         assert "Same actor instance proposed and resolved this decision" not in result
@@ -190,35 +212,43 @@ class TestSameActorWarning:
         """
         session = await _make_session(storage, active)
         evt_id = await decision_tools.propose_decision(
-            storage, session,
+            storage,
+            session,
             description="Use method X",
-            proposed_by_type="human", proposed_by_id="researcher-alice",
+            proposed_by_type="human",
+            proposed_by_id="researcher-alice",
         )
         evt_id = evt_id.split("\n")[0]
         result = await decision_tools.resolve_decision(
-            storage, session,
-            event_id=evt_id, disposition="accepted",
-            resolved_by_type="human", resolved_by_id="researcher-bob",
+            storage,
+            session,
+            event_id=evt_id,
+            disposition="accepted",
+            resolved_by_type="human",
+            resolved_by_id="researcher-bob",
         )
         # Different ids \u2192 not same-instance \u2192 no self-resolution warning
         assert "Same actor instance" not in result
         assert "AI resolved its own proposal" not in result
 
-    async def test_ai_resolves_human_proposal_clean(
-        self, storage: JsonFileStorage, active: dict[str, Session]
-    ) -> None:
+    async def test_ai_resolves_human_proposal_clean(self, storage: JsonFileStorage, active: dict[str, Session]) -> None:
         """Human proposes + AI resolves -> no self-resolution warning (different actors)."""
         session = await _make_session(storage, active)
         evt_id = await decision_tools.propose_decision(
-            storage, session,
+            storage,
+            session,
             description="Use method X",
-            proposed_by_type="human", proposed_by_id="researcher",
+            proposed_by_type="human",
+            proposed_by_id="researcher",
         )
         evt_id = evt_id.split("\n")[0]
         result = await decision_tools.resolve_decision(
-            storage, session,
-            event_id=evt_id, disposition="accepted",
-            resolved_by_type="ai", resolved_by_id="claude",
+            storage,
+            session,
+            event_id=evt_id,
+            disposition="accepted",
+            resolved_by_type="ai",
+            resolved_by_id="claude",
         )
         assert "AI resolved its own proposal" not in result
 
@@ -229,33 +259,41 @@ class TestSameActorWarning:
         monkeypatch.setenv("TRACE_SUPPRESS_SELF_RESOLVE_WARNING", "true")
         session = await _make_session(storage, active)
         evt_id = await decision_tools.propose_decision(
-            storage, session,
+            storage,
+            session,
             description="Use method X",
-            proposed_by_type="ai", proposed_by_id="claude",
+            proposed_by_type="ai",
+            proposed_by_id="claude",
         )
         evt_id = evt_id.split("\n")[0]
         result = await decision_tools.resolve_decision(
-            storage, session,
-            event_id=evt_id, disposition="accepted",
-            resolved_by_type="ai", resolved_by_id="claude",
+            storage,
+            session,
+            event_id=evt_id,
+            disposition="accepted",
+            resolved_by_type="ai",
+            resolved_by_id="claude",
         )
         assert "AI resolved its own proposal" not in result
 
-    async def test_warning_persisted_on_decision(
-        self, storage: JsonFileStorage, active: dict[str, Session]
-    ) -> None:
+    async def test_warning_persisted_on_decision(self, storage: JsonFileStorage, active: dict[str, Session]) -> None:
         """Guard rail warnings are persisted in the DecisionData.warnings field."""
         session = await _make_session(storage, active)
         evt_id = await decision_tools.propose_decision(
-            storage, session,
+            storage,
+            session,
             description="Use method X",
-            proposed_by_type="ai", proposed_by_id="claude",
+            proposed_by_type="ai",
+            proposed_by_id="claude",
         )
         evt_id = evt_id.split("\n")[0]
         await decision_tools.resolve_decision(
-            storage, session,
-            event_id=evt_id, disposition="accepted",
-            resolved_by_type="ai", resolved_by_id="claude",
+            storage,
+            session,
+            event_id=evt_id,
+            disposition="accepted",
+            resolved_by_type="ai",
+            resolved_by_id="claude",
         )
         # Check the event in the session
         target = next(e for e in session.events if e.id == evt_id)
@@ -270,38 +308,44 @@ class TestSameActorWarning:
 class TestRejectionHint:
     """FM31: When a decision is rejected, suggest logging a correction."""
 
-    async def test_rejection_suggests_correction(
-        self, storage: JsonFileStorage, active: dict[str, Session]
-    ) -> None:
+    async def test_rejection_suggests_correction(self, storage: JsonFileStorage, active: dict[str, Session]) -> None:
         session = await _make_session(storage, active)
         evt_id = await decision_tools.propose_decision(
-            storage, session,
+            storage,
+            session,
             description="Use method X",
-            proposed_by_type="ai", proposed_by_id="claude",
+            proposed_by_type="ai",
+            proposed_by_id="claude",
         )
         evt_id = evt_id.split("\n")[0]
         result = await decision_tools.resolve_decision(
-            storage, session,
-            event_id=evt_id, disposition="rejected",
-            resolved_by_type="human", resolved_by_id="researcher",
+            storage,
+            session,
+            event_id=evt_id,
+            disposition="rejected",
+            resolved_by_type="human",
+            resolved_by_id="researcher",
             revision_note="Method X doesn't apply here",
         )
         assert "correction" in result.lower()
 
-    async def test_acceptance_no_correction_hint(
-        self, storage: JsonFileStorage, active: dict[str, Session]
-    ) -> None:
+    async def test_acceptance_no_correction_hint(self, storage: JsonFileStorage, active: dict[str, Session]) -> None:
         session = await _make_session(storage, active)
         evt_id = await decision_tools.propose_decision(
-            storage, session,
+            storage,
+            session,
             description="Use method X",
-            proposed_by_type="ai", proposed_by_id="claude",
+            proposed_by_type="ai",
+            proposed_by_id="claude",
         )
         evt_id = evt_id.split("\n")[0]
         result = await decision_tools.resolve_decision(
-            storage, session,
-            event_id=evt_id, disposition="accepted",
-            resolved_by_type="human", resolved_by_id="researcher",
+            storage,
+            session,
+            event_id=evt_id,
+            disposition="accepted",
+            resolved_by_type="human",
+            resolved_by_id="researcher",
         )
         assert "correction" not in result.lower() or "correction" in result.lower() and "rejected" in result.lower()
         # More precise: no correction suggestion for accepted decisions
@@ -314,30 +358,30 @@ class TestRejectionHint:
 class TestOrphanedCorrections:
     """FM17: Corrections should link to corrected events."""
 
-    async def test_correction_without_links_warns(
-        self, storage: JsonFileStorage, active: dict[str, Session]
-    ) -> None:
+    async def test_correction_without_links_warns(self, storage: JsonFileStorage, active: dict[str, Session]) -> None:
         session = await _make_session(storage, active)
         result = await logging_tools.log_annotation(
-            storage, session,
+            storage,
+            session,
             category="correction",
             content="The threshold should be 0.5 not 0.3",
         )
         assert "corrects_event_ids" in result
 
-    async def test_correction_with_links_clean(
-        self, storage: JsonFileStorage, active: dict[str, Session]
-    ) -> None:
+    async def test_correction_with_links_clean(self, storage: JsonFileStorage, active: dict[str, Session]) -> None:
         session = await _make_session(storage, active)
         # First create an event to correct
         evt_id = await decision_tools.propose_decision(
-            storage, session,
+            storage,
+            session,
             description="Use threshold 0.3",
-            proposed_by_type="ai", proposed_by_id="claude",
+            proposed_by_type="ai",
+            proposed_by_id="claude",
         )
         evt_id = evt_id.split("\n")[0]
         result = await logging_tools.log_annotation(
-            storage, session,
+            storage,
+            session,
             category="correction",
             content="The threshold should be 0.5 not 0.3",
             corrects_event_ids=[evt_id],
@@ -346,19 +390,20 @@ class TestOrphanedCorrections:
         # Should not have the orphaned correction warning
         assert "without corrects_event_ids" not in result
 
-    async def test_correction_missing_snippet_warns(
-        self, storage: JsonFileStorage, active: dict[str, Session]
-    ) -> None:
+    async def test_correction_missing_snippet_warns(self, storage: JsonFileStorage, active: dict[str, Session]) -> None:
         """FM5: Correction without conversation_snippet."""
         session = await _make_session(storage, active)
         evt_id = await decision_tools.propose_decision(
-            storage, session,
+            storage,
+            session,
             description="Use threshold 0.3",
-            proposed_by_type="ai", proposed_by_id="claude",
+            proposed_by_type="ai",
+            proposed_by_id="claude",
         )
         evt_id = evt_id.split("\n")[0]
         result = await logging_tools.log_annotation(
-            storage, session,
+            storage,
+            session,
             category="correction",
             content="Threshold should be 0.5",
             corrects_event_ids=[evt_id],
@@ -378,28 +423,32 @@ class TestMissingSnippet:
     ) -> None:
         session = await _make_session(storage, active)
         result = await logging_tools.log_contribution(
-            storage, session,
+            storage,
+            session,
             description="Implemented distance calc",
-            direction="human", execution="ai",
+            direction="human",
+            execution="ai",
             artifact="src/distances.py",
         )
         assert "conversation_snippet" in result
 
-    async def test_contribution_with_snippet_clean(
-        self, storage: JsonFileStorage, active: dict[str, Session]
-    ) -> None:
+    async def test_contribution_with_snippet_clean(self, storage: JsonFileStorage, active: dict[str, Session]) -> None:
         session = await _make_session(storage, active)
         # Create a real decision so related_decision_ids doesn't dangle
         eid = await decision_tools.propose_decision(
-            storage, session,
+            storage,
+            session,
             description="Use cosine distance",
-            proposed_by_type="ai", proposed_by_id="claude",
+            proposed_by_type="ai",
+            proposed_by_id="claude",
         )
         eid = eid.split("\n")[0]
         result = await logging_tools.log_contribution(
-            storage, session,
+            storage,
+            session,
             description="Implemented distance calc",
-            direction="human", execution="ai",
+            direction="human",
+            execution="ai",
             artifact="src/distances.py",
             conversation_snippet="implement the distance calculation using cosine",
             related_decision_ids=[eid],
@@ -419,25 +468,27 @@ class TestReferentialIntegrity:
         session = await _make_session(storage, active)
         with pytest.raises(ValueError, match="Dangling reference.*evt_nonexistent"):
             await logging_tools.log_annotation(
-                storage, session,
+                storage,
+                session,
                 category="correction",
                 content="Fix the threshold",
                 corrects_event_ids=["evt_nonexistent"],
                 conversation_snippet="that's wrong",
             )
 
-    async def test_valid_corrects_event_id_clean(
-        self, storage: JsonFileStorage, active: dict[str, Session]
-    ) -> None:
+    async def test_valid_corrects_event_id_clean(self, storage: JsonFileStorage, active: dict[str, Session]) -> None:
         session = await _make_session(storage, active)
         evt_id = await decision_tools.propose_decision(
-            storage, session,
+            storage,
+            session,
             description="Use threshold 0.3",
-            proposed_by_type="ai", proposed_by_id="claude",
+            proposed_by_type="ai",
+            proposed_by_id="claude",
         )
         evt_id = evt_id.split("\n")[0]
         result = await logging_tools.log_annotation(
-            storage, session,
+            storage,
+            session,
             category="correction",
             content="Use 0.5 instead",
             corrects_event_ids=[evt_id],
@@ -445,15 +496,15 @@ class TestReferentialIntegrity:
         )
         assert "Dangling reference" not in result
 
-    async def test_dangling_revises_event_id_raises(
-        self, storage: JsonFileStorage, active: dict[str, Session]
-    ) -> None:
+    async def test_dangling_revises_event_id_raises(self, storage: JsonFileStorage, active: dict[str, Session]) -> None:
         session = await _make_session(storage, active)
         with pytest.raises(ValueError, match="Dangling reference.*evt_ghost"):
             await decision_tools.propose_decision(
-                storage, session,
+                storage,
+                session,
                 description="Revised approach",
-                proposed_by_type="ai", proposed_by_id="claude",
+                proposed_by_type="ai",
+                proposed_by_id="claude",
                 revises_event_id="evt_ghost",
             )
 
@@ -463,9 +514,11 @@ class TestReferentialIntegrity:
         session = await _make_session(storage, active)
         with pytest.raises(ValueError, match="Dangling reference.*evt_nope"):
             await logging_tools.log_contribution(
-                storage, session,
+                storage,
+                session,
                 description="Built the thing",
-                direction="human", execution="ai",
+                direction="human",
+                execution="ai",
                 related_decision_ids=["evt_nope"],
                 conversation_snippet="build it",
             )
@@ -477,36 +530,33 @@ class TestReferentialIntegrity:
 class TestToolCallBlocklist:
     """FM22/FM23: Don't log TRACE's own calls or exploratory tools."""
 
-    async def test_trace_tool_call_warns(
-        self, storage: JsonFileStorage, active: dict[str, Session]
-    ) -> None:
+    async def test_trace_tool_call_warns(self, storage: JsonFileStorage, active: dict[str, Session]) -> None:
         session = await _make_session(storage, active)
         result = await logging_tools.log_tool_call(
-            storage, session,
+            storage,
+            session,
             server="trace",
             tool_name="trace_start_session",
             input={"project": "test"},
         )
         assert "never log TRACE" in result.lower() or "TRACE" in result
 
-    async def test_exploratory_tool_hint(
-        self, storage: JsonFileStorage, active: dict[str, Session]
-    ) -> None:
+    async def test_exploratory_tool_hint(self, storage: JsonFileStorage, active: dict[str, Session]) -> None:
         session = await _make_session(storage, active)
         result = await logging_tools.log_tool_call(
-            storage, session,
+            storage,
+            session,
             server="filesystem",
             tool_name="Read",
             input={"path": "/tmp/file.txt"},
         )
         assert "exploratory" in result.lower()
 
-    async def test_domain_tool_clean(
-        self, storage: JsonFileStorage, active: dict[str, Session]
-    ) -> None:
+    async def test_domain_tool_clean(self, storage: JsonFileStorage, active: dict[str, Session]) -> None:
         session = await _make_session(storage, active)
         result = await logging_tools.log_tool_call(
-            storage, session,
+            storage,
+            session,
             server="corpus-search",
             tool_name="search_papers",
             input={"query": "climate change"},
@@ -525,25 +575,27 @@ class TestGotchaReclassification:
     ) -> None:
         session = await _make_session(storage, active)
         evt_id = await decision_tools.propose_decision(
-            storage, session,
+            storage,
+            session,
             description="Use method X",
-            proposed_by_type="ai", proposed_by_id="claude",
+            proposed_by_type="ai",
+            proposed_by_id="claude",
         )
         evt_id = evt_id.split("\n")[0]
         result = await logging_tools.log_annotation(
-            storage, session,
+            storage,
+            session,
             category="gotcha",
             content="Method X doesn't work here",
             corrects_event_ids=[evt_id],
         )
         assert "correction" in result.lower()
 
-    async def test_gotcha_without_corrects_clean(
-        self, storage: JsonFileStorage, active: dict[str, Session]
-    ) -> None:
+    async def test_gotcha_without_corrects_clean(self, storage: JsonFileStorage, active: dict[str, Session]) -> None:
         session = await _make_session(storage, active)
         result = await logging_tools.log_annotation(
-            storage, session,
+            storage,
+            session,
             category="gotcha",
             content="Surprising API behavior",
         )
@@ -556,150 +608,164 @@ class TestGotchaReclassification:
 class TestAttributionAuditEnhanced:
     """Attribution audit at session end catches aggregate issues."""
 
-    async def test_audit_flags_unresolved(
-        self, storage: JsonFileStorage, active: dict[str, Session]
-    ) -> None:
+    async def test_audit_flags_unresolved(self, storage: JsonFileStorage, active: dict[str, Session]) -> None:
         """3 proposed, 1 resolved -> 2 unresolved."""
         session = await _make_session(storage, active)
         ids = []
         for i in range(3):
             eid = await decision_tools.propose_decision(
-                storage, session,
+                storage,
+                session,
                 description=f"Decision {i}",
-                proposed_by_type="ai", proposed_by_id="claude",
+                proposed_by_type="ai",
+                proposed_by_id="claude",
             )
             ids.append(eid.split("\n")[0])
         # Resolve only the first
         await decision_tools.resolve_decision(
-            storage, session,
-            event_id=ids[0], disposition="accepted",
-            resolved_by_type="human", resolved_by_id="researcher",
+            storage,
+            session,
+            event_id=ids[0],
+            disposition="accepted",
+            resolved_by_type="human",
+            resolved_by_id="researcher",
         )
-        result = await session_tools.end_session(
-            storage, active, session_id=session.id, summary="test"
-        )
+        result = await session_tools.end_session(storage, active, session_id=session.id, summary="test")
         assert "Unresolved decisions: 2" in result
 
-    async def test_audit_flags_self_resolutions(
-        self, storage: JsonFileStorage, active: dict[str, Session]
-    ) -> None:
+    async def test_audit_flags_self_resolutions(self, storage: JsonFileStorage, active: dict[str, Session]) -> None:
         """3 AI self-resolved -> count == 3."""
         session = await _make_session(storage, active)
         for i in range(3):
             eid = await decision_tools.propose_decision(
-                storage, session,
+                storage,
+                session,
                 description=f"Decision {i}",
-                proposed_by_type="ai", proposed_by_id="claude",
+                proposed_by_type="ai",
+                proposed_by_id="claude",
             )
             eid = eid.split("\n")[0]
             await decision_tools.resolve_decision(
-                storage, session,
-                event_id=eid, disposition="accepted",
-                resolved_by_type="ai", resolved_by_id="claude",
+                storage,
+                session,
+                event_id=eid,
+                disposition="accepted",
+                resolved_by_type="ai",
+                resolved_by_id="claude",
             )
-        result = await session_tools.end_session(
-            storage, active, session_id=session.id, summary="test"
-        )
+        result = await session_tools.end_session(storage, active, session_id=session.id, summary="test")
         assert "AI self-resolutions: 3" in result
 
-    async def test_audit_clean_session(
-        self, storage: JsonFileStorage, active: dict[str, Session]
-    ) -> None:
+    async def test_audit_clean_session(self, storage: JsonFileStorage, active: dict[str, Session]) -> None:
         """Properly attributed session -> no guard rail warnings."""
         session = await _make_session(storage, active)
         eid = await decision_tools.propose_decision(
-            storage, session,
+            storage,
+            session,
             description="Use cosine distance",
-            proposed_by_type="ai", proposed_by_id="claude",
+            proposed_by_type="ai",
+            proposed_by_id="claude",
         )
         eid = eid.split("\n")[0]
         await decision_tools.resolve_decision(
-            storage, session,
-            event_id=eid, disposition="accepted",
-            resolved_by_type="human", resolved_by_id="researcher",
+            storage,
+            session,
+            event_id=eid,
+            disposition="accepted",
+            resolved_by_type="human",
+            resolved_by_id="researcher",
         )
-        result = await session_tools.end_session(
-            storage, active, session_id=session.id, summary="test"
-        )
+        result = await session_tools.end_session(storage, active, session_id=session.id, summary="test")
         assert "Unresolved decisions" not in result
         assert "AI self-resolutions" not in result
         assert "Unlinked corrections" not in result
 
-    async def test_audit_mixed_session(
-        self, storage: JsonFileStorage, active: dict[str, Session]
-    ) -> None:
+    async def test_audit_mixed_session(self, storage: JsonFileStorage, active: dict[str, Session]) -> None:
         """2 proper + 1 self-resolve + 1 unresolved -> both counts."""
         session = await _make_session(storage, active)
         # 2 proper
         for i in range(2):
             eid = await decision_tools.propose_decision(
-                storage, session,
+                storage,
+                session,
                 description=f"Proper decision {i}",
-                proposed_by_type="ai", proposed_by_id="claude",
+                proposed_by_type="ai",
+                proposed_by_id="claude",
             )
             eid = eid.split("\n")[0]
             await decision_tools.resolve_decision(
-                storage, session,
-                event_id=eid, disposition="accepted",
-                resolved_by_type="human", resolved_by_id="researcher",
+                storage,
+                session,
+                event_id=eid,
+                disposition="accepted",
+                resolved_by_type="human",
+                resolved_by_id="researcher",
             )
         # 1 self-resolve
         eid = await decision_tools.propose_decision(
-            storage, session,
+            storage,
+            session,
             description="Self-resolved",
-            proposed_by_type="ai", proposed_by_id="claude",
+            proposed_by_type="ai",
+            proposed_by_id="claude",
         )
         eid = eid.split("\n")[0]
         await decision_tools.resolve_decision(
-            storage, session,
-            event_id=eid, disposition="accepted",
-            resolved_by_type="ai", resolved_by_id="claude",
+            storage,
+            session,
+            event_id=eid,
+            disposition="accepted",
+            resolved_by_type="ai",
+            resolved_by_id="claude",
         )
         # 1 unresolved
         await decision_tools.propose_decision(
-            storage, session,
+            storage,
+            session,
             description="Left hanging",
-            proposed_by_type="ai", proposed_by_id="claude",
+            proposed_by_type="ai",
+            proposed_by_id="claude",
         )
-        result = await session_tools.end_session(
-            storage, active, session_id=session.id, summary="test"
-        )
+        result = await session_tools.end_session(storage, active, session_id=session.id, summary="test")
         assert "Unresolved decisions: 1" in result
         assert "AI self-resolutions: 1" in result
 
-    async def test_audit_orphaned_corrections(
-        self, storage: JsonFileStorage, active: dict[str, Session]
-    ) -> None:
+    async def test_audit_orphaned_corrections(self, storage: JsonFileStorage, active: dict[str, Session]) -> None:
         """2 corrections without corrects_event_ids -> unlinked count."""
         session = await _make_session(storage, active)
         await logging_tools.log_annotation(
-            storage, session,
-            category="correction", content="Fix 1",
+            storage,
+            session,
+            category="correction",
+            content="Fix 1",
         )
         await logging_tools.log_annotation(
-            storage, session,
-            category="correction", content="Fix 2",
+            storage,
+            session,
+            category="correction",
+            content="Fix 2",
         )
-        result = await session_tools.end_session(
-            storage, active, session_id=session.id, summary="test"
-        )
+        result = await session_tools.end_session(storage, active, session_id=session.id, summary="test")
         assert "Unlinked corrections: 2" in result
 
-    async def test_audit_render_includes_warnings(
-        self, storage: JsonFileStorage, active: dict[str, Session]
-    ) -> None:
+    async def test_audit_render_includes_warnings(self, storage: JsonFileStorage, active: dict[str, Session]) -> None:
         """Audit warnings are included in the rendered text."""
         session = await _make_session(storage, active)
         eid = await decision_tools.propose_decision(
-            storage, session,
+            storage,
+            session,
             description="Self-resolved",
-            proposed_by_type="ai", proposed_by_id="claude",
+            proposed_by_type="ai",
+            proposed_by_id="claude",
         )
         eid = eid.split("\n")[0]
         await decision_tools.resolve_decision(
-            storage, session,
-            event_id=eid, disposition="accepted",
-            resolved_by_type="ai", resolved_by_id="claude",
+            storage,
+            session,
+            event_id=eid,
+            disposition="accepted",
+            resolved_by_type="ai",
+            resolved_by_id="claude",
         )
         audit = session_tools._build_attribution_audit(session)
         rendered = audit.render()
@@ -722,19 +788,24 @@ class TestFailureModeCoverage:
 
     # --- Attribution failures ---
 
-    async def test_fm1_ai_self_resolves_detected(
-        self, storage: JsonFileStorage, active: dict[str, Session]
-    ) -> None:
+    async def test_fm1_ai_self_resolves_detected(self, storage: JsonFileStorage, active: dict[str, Session]) -> None:
         """FM1: DETECTED — AI self-resolution triggers warning."""
         session = await _make_session(storage, active)
         eid = await decision_tools.propose_decision(
-            storage, session, description="X",
-            proposed_by_type="ai", proposed_by_id="claude",
+            storage,
+            session,
+            description="X",
+            proposed_by_type="ai",
+            proposed_by_id="claude",
         )
         eid = eid.split("\n")[0]
         result = await decision_tools.resolve_decision(
-            storage, session, event_id=eid, disposition="accepted",
-            resolved_by_type="ai", resolved_by_id="claude",
+            storage,
+            session,
+            event_id=eid,
+            disposition="accepted",
+            resolved_by_type="ai",
+            resolved_by_id="claude",
         )
         assert "AI resolved its own proposal" in result
 
@@ -746,23 +817,25 @@ class TestFailureModeCoverage:
         session = await _make_session(storage, active)
         # Even a wrong swap looks valid to the server
         result = await logging_tools.log_contribution(
-            storage, session,
+            storage,
+            session,
             description="Built widget",
-            direction="ai", execution="human",  # possibly swapped!
+            direction="ai",
+            execution="human",  # possibly swapped!
             conversation_snippet="build the widget please",
         )
         # No warning about direction/execution — server trusts it
         assert "evt_" in result
 
-    async def test_fm5_missing_snippet_detected(
-        self, storage: JsonFileStorage, active: dict[str, Session]
-    ) -> None:
+    async def test_fm5_missing_snippet_detected(self, storage: JsonFileStorage, active: dict[str, Session]) -> None:
         """FM5: DETECTED — missing conversation_snippet triggers warning."""
         session = await _make_session(storage, active)
         result = await logging_tools.log_contribution(
-            storage, session,
+            storage,
+            session,
             description="Built it",
-            direction="human", execution="ai",
+            direction="human",
+            execution="ai",
         )
         assert "conversation_snippet" in result
 
@@ -773,40 +846,41 @@ class TestFailureModeCoverage:
         session = await _make_session(storage, active)
         # Misclassified as "requested" when it was actually "proactive"
         eid = await decision_tools.propose_decision(
-            storage, session, description="X",
-            proposed_by_type="ai", proposed_by_id="claude",
+            storage,
+            session,
+            description="X",
+            proposed_by_type="ai",
+            proposed_by_id="claude",
             suggestion_type="requested",
         )
         # No warning — server trusts the classification
         assert "evt_" in eid
 
-    async def test_fm7_batch_logging_noted(
-        self, storage: JsonFileStorage, active: dict[str, Session]
-    ) -> None:
+    async def test_fm7_batch_logging_noted(self, storage: JsonFileStorage, active: dict[str, Session]) -> None:
         """FM7: NOTED — timestamp clustering detection deferred.
         Events logged rapidly are indistinguishable from legitimate rapid work."""
         session = await _make_session(storage, active)
         for i in range(5):
             await logging_tools.log_annotation(
-                storage, session,
-                category="learning", content=f"Learning {i}",
+                storage,
+                session,
+                category="learning",
+                content=f"Learning {i}",
             )
         # Currently no batch-logging detection — noted for future
-        result = await session_tools.end_session(
-            storage, active, session_id=session.id, summary="test"
-        )
+        result = await session_tools.end_session(storage, active, session_id=session.id, summary="test")
         assert "Session ended" in result
 
-    async def test_fm8_actor_type_default_noted(
-        self, storage: JsonFileStorage, active: dict[str, Session]
-    ) -> None:
+    async def test_fm8_actor_type_default_noted(self, storage: JsonFileStorage, active: dict[str, Session]) -> None:
         """FM8: NOTED — actor_type defaults to 'ai', which is usually correct
         but could mask human actions. Audit breakdown helps catch this."""
         session = await _make_session(storage, active)
         # Default actor_type="ai" is used
         await logging_tools.log_annotation(
-            storage, session,
-            category="learning", content="Something",
+            storage,
+            session,
+            category="learning",
+            content="Something",
         )
         evt = session.events[-1]
         assert evt.actor.type == "ai"  # Default — might be wrong but acceptable
@@ -817,13 +891,18 @@ class TestFailureModeCoverage:
         """FM26: DETECTED — gotcha + corrects_event_ids suggests correction."""
         session = await _make_session(storage, active)
         eid = await decision_tools.propose_decision(
-            storage, session, description="X",
-            proposed_by_type="ai", proposed_by_id="claude",
+            storage,
+            session,
+            description="X",
+            proposed_by_type="ai",
+            proposed_by_id="claude",
         )
         eid = eid.split("\n")[0]
         result = await logging_tools.log_annotation(
-            storage, session,
-            category="gotcha", content="Oops",
+            storage,
+            session,
+            category="gotcha",
+            content="Oops",
             corrects_event_ids=[eid],
         )
         assert "correction" in result.lower()
@@ -836,9 +915,11 @@ class TestFailureModeCoverage:
         session = await _make_session(storage, active)
         # One combined contribution where there should have been two
         await logging_tools.log_contribution(
-            storage, session,
+            storage,
+            session,
             description="Built widgets A and B",  # should be 2 separate
-            direction="collaborative", execution="collaborative",
+            direction="collaborative",
+            execution="collaborative",
             conversation_snippet="build A, then build B",
         )
         # Server can't detect this — it's a single valid contribution
@@ -846,16 +927,12 @@ class TestFailureModeCoverage:
 
     # --- Completeness failures ---
 
-    async def test_fm3_missed_logging_undetectable(
-        self, storage: JsonFileStorage, active: dict[str, Session]
-    ) -> None:
+    async def test_fm3_missed_logging_undetectable(self, storage: JsonFileStorage, active: dict[str, Session]) -> None:
         """FM3: UNDETECTABLE — server can't detect absence of events."""
         session = await _make_session(storage, active)
         # Human makes a decision verbally, AI doesn't log it
         # Server has no way to know
-        result = await session_tools.end_session(
-            storage, active, session_id=session.id, summary="test"
-        )
+        result = await session_tools.end_session(storage, active, session_id=session.id, summary="test")
         assert "Session ended" in result  # No warning about missing events
 
     async def test_fm9_abandoned_session_partially_detected(
@@ -865,51 +942,51 @@ class TestFailureModeCoverage:
         Truly abandoned sessions (never ended) need external reaper."""
         session = await _make_session(storage, active)
         await decision_tools.propose_decision(
-            storage, session, description="Never resolved",
-            proposed_by_type="ai", proposed_by_id="claude",
+            storage,
+            session,
+            description="Never resolved",
+            proposed_by_type="ai",
+            proposed_by_id="claude",
         )
-        result = await session_tools.end_session(
-            storage, active, session_id=session.id, summary="test"
-        )
+        result = await session_tools.end_session(storage, active, session_id=session.id, summary="test")
         assert "Unresolved decisions: 1" in result
 
-    async def test_fm10_late_start_noted(
-        self, storage: JsonFileStorage, active: dict[str, Session]
-    ) -> None:
+    async def test_fm10_late_start_noted(self, storage: JsonFileStorage, active: dict[str, Session]) -> None:
         """FM10: NOTED — late session start loses early decisions.
         Auto-session mitigates but can't retroactively capture."""
         # This is about the conversation starting before trace_start_session
         # Server can't detect it — it's a client-side timing issue
         pass  # Documented as known limitation
 
-    async def test_fm11_audit_not_reviewed_noted(
-        self, storage: JsonFileStorage, active: dict[str, Session]
-    ) -> None:
+    async def test_fm11_audit_not_reviewed_noted(self, storage: JsonFileStorage, active: dict[str, Session]) -> None:
         """FM11: NOTED — audit is emitted but we can't force the AI to review it.
         L2 hook (PostToolUse) helps on Claude Code."""
         pass  # Mitigated by L2 hook
 
-    async def test_fm12_post_compact_loss_noted(
-        self, storage: JsonFileStorage, active: dict[str, Session]
-    ) -> None:
+    async def test_fm12_post_compact_loss_noted(self, storage: JsonFileStorage, active: dict[str, Session]) -> None:
         """FM12: NOTED — post-compact context loss of session ID.
         Mitigated by compact-safe skill and server-side session persistence."""
         pass  # Mitigated by existing infrastructure
 
-    async def test_fm25_fast_resolution_detected(
-        self, storage: JsonFileStorage, active: dict[str, Session]
-    ) -> None:
+    async def test_fm25_fast_resolution_detected(self, storage: JsonFileStorage, active: dict[str, Session]) -> None:
         """FM25: DETECTED — propose + resolve <5s by AI -> timing warning."""
         session = await _make_session(storage, active)
         eid = await decision_tools.propose_decision(
-            storage, session, description="Quick decision",
-            proposed_by_type="ai", proposed_by_id="claude",
+            storage,
+            session,
+            description="Quick decision",
+            proposed_by_type="ai",
+            proposed_by_id="claude",
         )
         eid = eid.split("\n")[0]
         # Resolve immediately (< 5s)
         result = await decision_tools.resolve_decision(
-            storage, session, event_id=eid, disposition="accepted",
-            resolved_by_type="ai", resolved_by_id="claude",
+            storage,
+            session,
+            event_id=eid,
+            disposition="accepted",
+            resolved_by_type="ai",
+            resolved_by_id="claude",
         )
         assert "self-resolved" in result.lower() or "AI resolved" in result
 
@@ -919,60 +996,69 @@ class TestFailureModeCoverage:
         """FM31: DETECTED — rejection suggests correction annotation."""
         session = await _make_session(storage, active)
         eid = await decision_tools.propose_decision(
-            storage, session, description="Bad idea",
-            proposed_by_type="ai", proposed_by_id="claude",
+            storage,
+            session,
+            description="Bad idea",
+            proposed_by_type="ai",
+            proposed_by_id="claude",
         )
         eid = eid.split("\n")[0]
         result = await decision_tools.resolve_decision(
-            storage, session, event_id=eid, disposition="rejected",
-            resolved_by_type="human", resolved_by_id="researcher",
+            storage,
+            session,
+            event_id=eid,
+            disposition="rejected",
+            resolved_by_type="human",
+            resolved_by_id="researcher",
             revision_note="Doesn't apply",
         )
         assert "correction" in result.lower()
 
     # --- Structural failures ---
 
-    async def test_fm2_chain_collapse_undetectable(
-        self, storage: JsonFileStorage, active: dict[str, Session]
-    ) -> None:
+    async def test_fm2_chain_collapse_undetectable(self, storage: JsonFileStorage, active: dict[str, Session]) -> None:
         """FM2: UNDETECTABLE — server can't tell if a multi-step deliberation
         was collapsed into a single decision. Requires semantic understanding."""
         session = await _make_session(storage, active)
         # This looks like a single decision but was actually 3 iterations
         await decision_tools.propose_decision(
-            storage, session,
+            storage,
+            session,
             description="Final approach: use method Z after considering X, Y",
-            proposed_by_type="ai", proposed_by_id="claude",
+            proposed_by_type="ai",
+            proposed_by_id="claude",
         )
         # Server has no way to know there were intermediate steps
         assert len([e for e in session.events if e.type == "decision"]) == 1
 
-    async def test_fm13_dangling_refs_detected(
-        self, storage: JsonFileStorage, active: dict[str, Session]
-    ) -> None:
+    async def test_fm13_dangling_refs_detected(self, storage: JsonFileStorage, active: dict[str, Session]) -> None:
         """FM13: DETECTED — dangling event ID references raise ValueError."""
         session = await _make_session(storage, active)
         with pytest.raises(ValueError, match="Dangling reference.*evt_phantom"):
             await logging_tools.log_annotation(
-                storage, session,
-                category="correction", content="Fix",
+                storage,
+                session,
+                category="correction",
+                content="Fix",
                 corrects_event_ids=["evt_phantom"],
                 conversation_snippet="fix it",
             )
 
-    async def test_fm14_duplicate_events_noted(
-        self, storage: JsonFileStorage, active: dict[str, Session]
-    ) -> None:
+    async def test_fm14_duplicate_events_noted(self, storage: JsonFileStorage, active: dict[str, Session]) -> None:
         """FM14: NOTED — duplicate event detection deferred.
         Content dedup would need fuzzy matching."""
         session = await _make_session(storage, active)
         await logging_tools.log_annotation(
-            storage, session,
-            category="learning", content="Important finding",
+            storage,
+            session,
+            category="learning",
+            content="Important finding",
         )
         await logging_tools.log_annotation(
-            storage, session,
-            category="learning", content="Important finding",  # duplicate!
+            storage,
+            session,
+            category="learning",
+            content="Important finding",  # duplicate!
         )
         # Currently no dedup — both are logged
         assert len([e for e in session.events if e.type == "annotation"]) == 2
@@ -984,9 +1070,11 @@ class TestFailureModeCoverage:
         session = await _make_session(storage, active)
         with pytest.raises(ValueError, match="Dangling reference.*evt_wrong"):
             await decision_tools.propose_decision(
-                storage, session,
+                storage,
+                session,
                 description="Revision of phantom",
-                proposed_by_type="ai", proposed_by_id="claude",
+                proposed_by_type="ai",
+                proposed_by_id="claude",
                 revises_event_id="evt_wrong",
             )
 
@@ -996,54 +1084,45 @@ class TestFailureModeCoverage:
         """FM17: DETECTED — correction without corrects_event_ids warns."""
         session = await _make_session(storage, active)
         result = await logging_tools.log_annotation(
-            storage, session,
-            category="correction", content="Fixed the issue",
+            storage,
+            session,
+            category="correction",
+            content="Fixed the issue",
         )
         assert "corrects_event_ids" in result
 
     # --- Cross-session failures ---
 
-    async def test_fm18_wrong_project_noted(
-        self, storage: JsonFileStorage, active: dict[str, Session]
-    ) -> None:
+    async def test_fm18_wrong_project_noted(self, storage: JsonFileStorage, active: dict[str, Session]) -> None:
         """FM18: NOTED — project name consistency check deferred."""
         pass  # Would need cross-session analysis
 
-    async def test_fm19_bad_extraction_noted(
-        self, storage: JsonFileStorage, active: dict[str, Session]
-    ) -> None:
+    async def test_fm19_bad_extraction_noted(self, storage: JsonFileStorage, active: dict[str, Session]) -> None:
         """FM19: NOTED — knowledge extraction quality scoring deferred."""
         pass
 
-    async def test_fm20_stale_learnings_noted(
-        self, storage: JsonFileStorage, active: dict[str, Session]
-    ) -> None:
+    async def test_fm20_stale_learnings_noted(self, storage: JsonFileStorage, active: dict[str, Session]) -> None:
         """FM20: NOTED — stale learning detection handled by decay system."""
         pass
 
-    async def test_fm30_auto_project_name_noted(
-        self, storage: JsonFileStorage, active: dict[str, Session]
-    ) -> None:
+    async def test_fm30_auto_project_name_noted(self, storage: JsonFileStorage, active: dict[str, Session]) -> None:
         """FM30: NOTED — auto-session with 'auto' project name.
         Auto-session already warns about this."""
         pass
 
-    async def test_fm32_fragmented_sessions_noted(
-        self, storage: JsonFileStorage, active: dict[str, Session]
-    ) -> None:
+    async def test_fm32_fragmented_sessions_noted(self, storage: JsonFileStorage, active: dict[str, Session]) -> None:
         """FM32: NOTED — multiple sessions for one workflow. Would need
         session linking / workflow ID concept."""
         pass
 
     # --- Protocol violations ---
 
-    async def test_fm22_trace_self_logging_detected(
-        self, storage: JsonFileStorage, active: dict[str, Session]
-    ) -> None:
+    async def test_fm22_trace_self_logging_detected(self, storage: JsonFileStorage, active: dict[str, Session]) -> None:
         """FM22: DETECTED — logging TRACE tool calls triggers warning."""
         session = await _make_session(storage, active)
         result = await logging_tools.log_tool_call(
-            storage, session,
+            storage,
+            session,
             server="trace-mcp",
             tool_name="trace_propose_decision",
             input={"description": "test"},
@@ -1056,22 +1135,22 @@ class TestFailureModeCoverage:
         """FM23: DETECTED — logging exploratory tools triggers hint."""
         session = await _make_session(storage, active)
         result = await logging_tools.log_tool_call(
-            storage, session,
+            storage,
+            session,
             server="filesystem",
             tool_name="Grep",
             input={"pattern": "test"},
         )
         assert "exploratory" in result.lower()
 
-    async def test_fm24_fabrication_undetectable(
-        self, storage: JsonFileStorage, active: dict[str, Session]
-    ) -> None:
+    async def test_fm24_fabrication_undetectable(self, storage: JsonFileStorage, active: dict[str, Session]) -> None:
         """FM24: UNDETECTABLE — server can't distinguish real from fabricated.
         Only L3 absolute rule can address this."""
         session = await _make_session(storage, active)
         # A completely fabricated event looks valid
         await logging_tools.log_annotation(
-            storage, session,
+            storage,
+            session,
             category="learning",
             content="Discovered that X causes Y",  # might be fabricated
         )
@@ -1085,7 +1164,8 @@ class TestFailureModeCoverage:
         session = await _make_session(storage, active)
         # AI logs the success but not the 3 failures that preceded it
         await logging_tools.log_tool_call(
-            storage, session,
+            storage,
+            session,
             server="analysis",
             tool_name="run_model",
             input={"params": "final"},
@@ -1096,9 +1176,7 @@ class TestFailureModeCoverage:
 
     # --- Systemic ---
 
-    async def test_fm28_logging_overhead_noted(
-        self, storage: JsonFileStorage, active: dict[str, Session]
-    ) -> None:
+    async def test_fm28_logging_overhead_noted(self, storage: JsonFileStorage, active: dict[str, Session]) -> None:
         """FM28: NOTED — logging overhead is inherent.
         Mitigated by auto-tools and efficient implementation."""
         pass
@@ -1123,63 +1201,74 @@ class TestFailureModeCoverage:
 class TestScenarioSimulations:
     """End-to-end scenarios testing guard rail interactions."""
 
-    async def test_scenario_proper_workflow(
-        self, storage: JsonFileStorage, active: dict[str, Session]
-    ) -> None:
+    async def test_scenario_proper_workflow(self, storage: JsonFileStorage, active: dict[str, Session]) -> None:
         """Fully proper workflow: propose(ai) -> resolve(human) -> contribute -> end.
         Should produce zero warnings."""
         session = await _make_session(storage, active)
         eid = await decision_tools.propose_decision(
-            storage, session,
+            storage,
+            session,
             description="Use cosine distance for text similarity",
-            proposed_by_type="ai", proposed_by_id="claude",
+            proposed_by_type="ai",
+            proposed_by_id="claude",
             suggestion_type="proactive",
         )
         eid = eid.split("\n")[0]
         await decision_tools.resolve_decision(
-            storage, session,
-            event_id=eid, disposition="accepted",
-            resolved_by_type="human", resolved_by_id="researcher",
+            storage,
+            session,
+            event_id=eid,
+            disposition="accepted",
+            resolved_by_type="human",
+            resolved_by_id="researcher",
         )
         await logging_tools.log_contribution(
-            storage, session,
+            storage,
+            session,
             description="Implemented cosine distance calculation",
-            direction="human", execution="ai",
+            direction="human",
+            execution="ai",
             artifact="src/distances.py",
             related_decision_ids=[eid],
             conversation_snippet="implement the cosine distance function",
         )
         result = await session_tools.end_session(
-            storage, active, session_id=session.id,
+            storage,
+            active,
+            session_id=session.id,
             summary="Implemented distance calculation",
         )
         assert "Unresolved decisions" not in result
         assert "AI self-resolutions" not in result
         assert "Unlinked corrections" not in result
 
-    async def test_scenario_correction_chain(
-        self, storage: JsonFileStorage, active: dict[str, Session]
-    ) -> None:
+    async def test_scenario_correction_chain(self, storage: JsonFileStorage, active: dict[str, Session]) -> None:
         """Rejection + correction + retry: proper provenance chain."""
         session = await _make_session(storage, active)
         # AI proposes bad approach
         eid1 = await decision_tools.propose_decision(
-            storage, session,
+            storage,
+            session,
             description="Use Euclidean distance",
-            proposed_by_type="ai", proposed_by_id="claude",
+            proposed_by_type="ai",
+            proposed_by_id="claude",
         )
         eid1 = eid1.split("\n")[0]
         # Human rejects
         reject_result = await decision_tools.resolve_decision(
-            storage, session,
-            event_id=eid1, disposition="rejected",
-            resolved_by_type="human", resolved_by_id="researcher",
+            storage,
+            session,
+            event_id=eid1,
+            disposition="rejected",
+            resolved_by_type="human",
+            resolved_by_id="researcher",
             revision_note="Euclidean is wrong for text embeddings",
         )
         assert "correction" in reject_result.lower()  # FM31 hint
         # Human logs correction
         await logging_tools.log_annotation(
-            storage, session,
+            storage,
+            session,
             category="correction",
             content="Euclidean distance is inappropriate for high-dimensional text embeddings",
             corrects_event_ids=[eid1],
@@ -1187,56 +1276,76 @@ class TestScenarioSimulations:
         )
         # AI proposes revised approach
         eid2 = await decision_tools.propose_decision(
-            storage, session,
+            storage,
+            session,
             description="Use cosine distance instead",
-            proposed_by_type="ai", proposed_by_id="claude",
+            proposed_by_type="ai",
+            proposed_by_id="claude",
             revises_event_id=eid1,
         )
         eid2 = eid2.split("\n")[0]
         await decision_tools.resolve_decision(
-            storage, session,
-            event_id=eid2, disposition="accepted",
-            resolved_by_type="human", resolved_by_id="researcher",
+            storage,
+            session,
+            event_id=eid2,
+            disposition="accepted",
+            resolved_by_type="human",
+            resolved_by_id="researcher",
         )
         result = await session_tools.end_session(
-            storage, active, session_id=session.id, summary="Fixed distance metric",
+            storage,
+            active,
+            session_id=session.id,
+            summary="Fixed distance metric",
         )
         assert "1 rejection" in result
         assert "Corrections: 1" in result
 
-    async def test_scenario_rapid_fire_performance(
-        self, storage: JsonFileStorage, active: dict[str, Session]
-    ) -> None:
+    async def test_scenario_rapid_fire_performance(self, storage: JsonFileStorage, active: dict[str, Session]) -> None:
         """25 proper + 25 self-resolved decisions. Should complete quickly."""
         import time
+
         start = time.monotonic()
         session = await _make_session(storage, active)
         for i in range(25):
             eid = await decision_tools.propose_decision(
-                storage, session,
+                storage,
+                session,
                 description=f"Proper decision {i}",
-                proposed_by_type="ai", proposed_by_id="claude",
+                proposed_by_type="ai",
+                proposed_by_id="claude",
             )
             eid = eid.split("\n")[0]
             await decision_tools.resolve_decision(
-                storage, session,
-                event_id=eid, disposition="accepted",
-                resolved_by_type="human", resolved_by_id="researcher",
+                storage,
+                session,
+                event_id=eid,
+                disposition="accepted",
+                resolved_by_type="human",
+                resolved_by_id="researcher",
             )
         for i in range(25):
             eid = await decision_tools.propose_decision(
-                storage, session,
+                storage,
+                session,
                 description=f"Self-resolved {i}",
-                proposed_by_type="ai", proposed_by_id="claude",
+                proposed_by_type="ai",
+                proposed_by_id="claude",
             )
             eid = eid.split("\n")[0]
             await decision_tools.resolve_decision(
-                storage, session,
-                event_id=eid, disposition="accepted",
-                resolved_by_type="ai", resolved_by_id="claude",
+                storage,
+                session,
+                event_id=eid,
+                disposition="accepted",
+                resolved_by_type="ai",
+                resolved_by_id="claude",
             )
         result = await session_tools.end_session(
-            storage, active, session_id=session.id, summary="perf test",
+            storage,
+            active,
+            session_id=session.id,
+            summary="perf test",
         )
         elapsed = time.monotonic() - start
         assert "AI self-resolutions: 25" in result

--- a/tests/test_decision_guards_e2e.py
+++ b/tests/test_decision_guards_e2e.py
@@ -28,31 +28,46 @@ class TestDecisionGuardsE2E:
                 req_id = 2
 
                 # Start session
-                response = await _call_tool(proc, "trace_start_session", {
-                    "project": "guard-e2e",
-                    "description": "Guard rail E2E test",
-                }, request_id=req_id)
+                response = await _call_tool(
+                    proc,
+                    "trace_start_session",
+                    {
+                        "project": "guard-e2e",
+                        "description": "Guard rail E2E test",
+                    },
+                    request_id=req_id,
+                )
                 req_id += 1
                 result_text = response["result"]["content"][0]["text"]
                 session_id = result_text.split("Session: ")[1].split("\n")[0]
 
                 # Propose (AI)
-                response = await _call_tool(proc, "trace_propose_decision", {
-                    "session_id": session_id,
-                    "description": "Use method X",
-                    "proposed_by_type": "ai",
-                    "proposed_by_id": "test-ai",
-                }, request_id=req_id)
+                response = await _call_tool(
+                    proc,
+                    "trace_propose_decision",
+                    {
+                        "session_id": session_id,
+                        "description": "Use method X",
+                        "proposed_by_type": "ai",
+                        "proposed_by_id": "test-ai",
+                    },
+                    request_id=req_id,
+                )
                 req_id += 1
 
                 # Resolve (AI — self-resolution)
-                response = await _call_tool(proc, "trace_resolve_decision", {
-                    "event_id": "evt_001",
-                    "session_id": session_id,
-                    "disposition": "accepted",
-                    "resolved_by_type": "ai",
-                    "resolved_by_id": "test-ai",
-                }, request_id=req_id)
+                response = await _call_tool(
+                    proc,
+                    "trace_resolve_decision",
+                    {
+                        "event_id": "evt_001",
+                        "session_id": session_id,
+                        "disposition": "accepted",
+                        "resolved_by_type": "ai",
+                        "resolved_by_id": "test-ai",
+                    },
+                    request_id=req_id,
+                )
                 req_id += 1
                 result_text = response["result"]["content"][0]["text"]
                 assert "AI resolved its own proposal" in result_text
@@ -68,28 +83,43 @@ class TestDecisionGuardsE2E:
                 await _initialize_server(proc)
                 req_id = 2
 
-                response = await _call_tool(proc, "trace_start_session", {
-                    "project": "guard-e2e",
-                }, request_id=req_id)
+                response = await _call_tool(
+                    proc,
+                    "trace_start_session",
+                    {
+                        "project": "guard-e2e",
+                    },
+                    request_id=req_id,
+                )
                 req_id += 1
                 result_text = response["result"]["content"][0]["text"]
                 session_id = result_text.split("Session: ")[1].split("\n")[0]
 
                 # Propose 2 decisions, resolve none
                 for i in range(2):
-                    await _call_tool(proc, "trace_propose_decision", {
-                        "session_id": session_id,
-                        "description": f"Unresolved decision {i}",
-                        "proposed_by_type": "ai",
-                        "proposed_by_id": "test-ai",
-                    }, request_id=req_id)
+                    await _call_tool(
+                        proc,
+                        "trace_propose_decision",
+                        {
+                            "session_id": session_id,
+                            "description": f"Unresolved decision {i}",
+                            "proposed_by_type": "ai",
+                            "proposed_by_id": "test-ai",
+                        },
+                        request_id=req_id,
+                    )
                     req_id += 1
 
                 # End session
-                response = await _call_tool(proc, "trace_end_session", {
-                    "session_id": session_id,
-                    "summary": "test unresolved",
-                }, request_id=req_id)
+                response = await _call_tool(
+                    proc,
+                    "trace_end_session",
+                    {
+                        "session_id": session_id,
+                        "summary": "test unresolved",
+                    },
+                    request_id=req_id,
+                )
                 req_id += 1
                 result_text = response["result"]["content"][0]["text"]
                 assert "Unresolved decisions: 2" in result_text
@@ -105,35 +135,55 @@ class TestDecisionGuardsE2E:
                 await _initialize_server(proc)
                 req_id = 2
 
-                response = await _call_tool(proc, "trace_start_session", {
-                    "project": "guard-e2e",
-                }, request_id=req_id)
+                response = await _call_tool(
+                    proc,
+                    "trace_start_session",
+                    {
+                        "project": "guard-e2e",
+                    },
+                    request_id=req_id,
+                )
                 req_id += 1
                 result_text = response["result"]["content"][0]["text"]
                 session_id = result_text.split("Session: ")[1].split("\n")[0]
 
                 for i in range(3):
-                    await _call_tool(proc, "trace_propose_decision", {
-                        "session_id": session_id,
-                        "description": f"Self-resolved {i}",
-                        "proposed_by_type": "ai",
-                        "proposed_by_id": "test-ai",
-                    }, request_id=req_id)
+                    await _call_tool(
+                        proc,
+                        "trace_propose_decision",
+                        {
+                            "session_id": session_id,
+                            "description": f"Self-resolved {i}",
+                            "proposed_by_type": "ai",
+                            "proposed_by_id": "test-ai",
+                        },
+                        request_id=req_id,
+                    )
                     req_id += 1
 
-                    await _call_tool(proc, "trace_resolve_decision", {
-                        "event_id": f"evt_{i + 1:03d}",
-                        "session_id": session_id,
-                        "disposition": "accepted",
-                        "resolved_by_type": "ai",
-                        "resolved_by_id": "test-ai",
-                    }, request_id=req_id)
+                    await _call_tool(
+                        proc,
+                        "trace_resolve_decision",
+                        {
+                            "event_id": f"evt_{i + 1:03d}",
+                            "session_id": session_id,
+                            "disposition": "accepted",
+                            "resolved_by_type": "ai",
+                            "resolved_by_id": "test-ai",
+                        },
+                        request_id=req_id,
+                    )
                     req_id += 1
 
-                response = await _call_tool(proc, "trace_end_session", {
-                    "session_id": session_id,
-                    "summary": "self-resolution test",
-                }, request_id=req_id)
+                response = await _call_tool(
+                    proc,
+                    "trace_end_session",
+                    {
+                        "session_id": session_id,
+                        "summary": "self-resolution test",
+                    },
+                    request_id=req_id,
+                )
                 req_id += 1
                 result_text = response["result"]["content"][0]["text"]
                 assert "AI self-resolutions: 3" in result_text
@@ -149,35 +199,55 @@ class TestDecisionGuardsE2E:
                 await _initialize_server(proc)
                 req_id = 2
 
-                response = await _call_tool(proc, "trace_start_session", {
-                    "project": "guard-e2e",
-                }, request_id=req_id)
+                response = await _call_tool(
+                    proc,
+                    "trace_start_session",
+                    {
+                        "project": "guard-e2e",
+                    },
+                    request_id=req_id,
+                )
                 req_id += 1
                 result_text = response["result"]["content"][0]["text"]
                 session_id = result_text.split("Session: ")[1].split("\n")[0]
 
-                await _call_tool(proc, "trace_propose_decision", {
-                    "session_id": session_id,
-                    "description": "Use cosine distance",
-                    "proposed_by_type": "ai",
-                    "proposed_by_id": "test-ai",
-                    "suggestion_type": "proactive",
-                }, request_id=req_id)
+                await _call_tool(
+                    proc,
+                    "trace_propose_decision",
+                    {
+                        "session_id": session_id,
+                        "description": "Use cosine distance",
+                        "proposed_by_type": "ai",
+                        "proposed_by_id": "test-ai",
+                        "suggestion_type": "proactive",
+                    },
+                    request_id=req_id,
+                )
                 req_id += 1
 
-                await _call_tool(proc, "trace_resolve_decision", {
-                    "event_id": "evt_001",
-                    "session_id": session_id,
-                    "disposition": "accepted",
-                    "resolved_by_type": "human",
-                    "resolved_by_id": "researcher",
-                }, request_id=req_id)
+                await _call_tool(
+                    proc,
+                    "trace_resolve_decision",
+                    {
+                        "event_id": "evt_001",
+                        "session_id": session_id,
+                        "disposition": "accepted",
+                        "resolved_by_type": "human",
+                        "resolved_by_id": "researcher",
+                    },
+                    request_id=req_id,
+                )
                 req_id += 1
 
-                response = await _call_tool(proc, "trace_end_session", {
-                    "session_id": session_id,
-                    "summary": "clean workflow",
-                }, request_id=req_id)
+                response = await _call_tool(
+                    proc,
+                    "trace_end_session",
+                    {
+                        "session_id": session_id,
+                        "summary": "clean workflow",
+                    },
+                    request_id=req_id,
+                )
                 req_id += 1
                 result_text = response["result"]["content"][0]["text"]
                 assert "Unresolved decisions" not in result_text

--- a/tests/test_decision_integrity.py
+++ b/tests/test_decision_integrity.py
@@ -40,9 +40,7 @@ def active() -> dict[str, Session]:
     return {}
 
 
-async def _session_with_proposal(
-    storage: JsonFileStorage, active: dict[str, Session]
-) -> tuple[Session, str]:
+async def _session_with_proposal(storage: JsonFileStorage, active: dict[str, Session]) -> tuple[Session, str]:
     """Create a session containing one proposed decision; return (session, event_id)."""
     session = await session_tools.create_session(
         storage, active, project="integrity-test", description="decision integrity"
@@ -130,9 +128,7 @@ class TestH2ReResolution:
 
 
 class TestH1PostCompletionResolution:
-    async def test_resolve_proposed_in_completed_session_allowed_with_warning(
-        self, storage, active
-    ):
+    async def test_resolve_proposed_in_completed_session_allowed_with_warning(self, storage, active):
         """Cross-session resolution (the documented decision lifecycle) keeps working."""
         session, event_id = await _session_with_proposal(storage, active)
         await session_tools.end_session(storage, active, session_id=session.id)
@@ -156,9 +152,7 @@ class TestH1PostCompletionResolution:
         assert decision_evt.decision.disposition == "accepted"
         assert any("after session completion" in w for w in decision_evt.decision.warnings)
 
-    async def test_stale_in_memory_copy_cannot_resurrect_completed_session(
-        self, storage, active
-    ):
+    async def test_stale_in_memory_copy_cannot_resurrect_completed_session(self, storage, active):
         """The write must target the disk object, not the caller's stale copy."""
         session, event_id = await _session_with_proposal(storage, active)
         # Another process completes the session; our in-memory copy still says active.
@@ -205,9 +199,7 @@ class TestWarningsPreserved:
 
 
 class TestCurrentSessionPointerGuard:
-    async def test_completed_session_does_not_become_current(
-        self, storage, active, monkeypatch
-    ):
+    async def test_completed_session_does_not_become_current(self, storage, active, monkeypatch):
         """Explicit session_id to a completed session must not move the pointer."""
         from trace_mcp import server
 
@@ -235,9 +227,7 @@ class TestCurrentSessionPointerGuard:
         assert looked_up.id == session.id
         assert server._current_session_id == session.id
 
-    async def test_stale_cached_active_but_disk_completed_does_not_move_pointer(
-        self, storage, active, monkeypatch
-    ):
+    async def test_stale_cached_active_but_disk_completed_does_not_move_pointer(self, storage, active, monkeypatch):
         """Pointer guard must trust disk status, not the in-memory cache."""
         from trace_mcp import server
 
@@ -255,9 +245,7 @@ class TestCurrentSessionPointerGuard:
         assert looked_up.id == session.id
         assert server._current_session_id == "sentinel-current"
 
-    async def test_completed_current_session_falls_through_to_autocreate(
-        self, storage, active, monkeypatch
-    ):
+    async def test_completed_current_session_falls_through_to_autocreate(self, storage, active, monkeypatch):
         """A completed current session must not wedge pointer-less calls."""
         from trace_mcp import server
 
@@ -339,6 +327,5 @@ class TestLiteralSignatureSweep:
                     )
                     literal_values.update(typing.get_args(arg))
         assert literal_values == expected_values, (
-            f"{tool_name}.{param}: expected Literal{sorted(map(str, expected_values))}, "
-            f"got {hints[param]!r}"
+            f"{tool_name}.{param}: expected Literal{sorted(map(str, expected_values))}, got {hints[param]!r}"
         )

--- a/tests/test_e2e_server.py
+++ b/tests/test_e2e_server.py
@@ -23,7 +23,7 @@ import tempfile
 from pathlib import Path
 from typing import Any
 
-import pytest  # noqa: F401 (used by pytest-asyncio for test collection)
+import pytest  # noqa: F401  # pyright: ignore[reportUnusedImport]  (used by pytest-asyncio for test collection)
 
 import trace_mcp
 
@@ -96,9 +96,7 @@ async def _send_and_receive(
             return parsed
 
 
-async def _start_server(
-    sessions_dir: str, env_extra: dict[str, str] | None = None
-) -> asyncio.subprocess.Process:
+async def _start_server(sessions_dir: str, env_extra: dict[str, str] | None = None) -> asyncio.subprocess.Process:
     """Start the TRACE MCP server as a subprocess.
 
     env_extra, if given, overrides individual env vars after the deterministic
@@ -142,11 +140,14 @@ async def _start_server(
 async def _initialize_server(proc: asyncio.subprocess.Process) -> dict[str, Any]:
     """Perform the MCP initialization handshake."""
     # Send initialize request
-    init_request = _make_jsonrpc_request("initialize", {
-        "protocolVersion": "2024-11-05",
-        "capabilities": {},
-        "clientInfo": {"name": "trace-test", "version": "1.0.0"},
-    })
+    init_request = _make_jsonrpc_request(
+        "initialize",
+        {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": {"name": "trace-test", "version": "1.0.0"},
+        },
+    )
     response = await _send_and_receive(proc, init_request)
 
     # Send initialized notification
@@ -165,10 +166,14 @@ async def _call_tool(
     request_id: int = 1,
 ) -> dict[str, Any]:
     """Call an MCP tool and return the result."""
-    request = _make_jsonrpc_request("tools/call", {
-        "name": tool_name,
-        "arguments": arguments,
-    }, id=request_id)
+    request = _make_jsonrpc_request(
+        "tools/call",
+        {
+            "name": tool_name,
+            "arguments": arguments,
+        },
+        id=request_id,
+    )
     return await _send_and_receive(proc, request)
 
 
@@ -288,10 +293,15 @@ class TestSessionLifecycleE2E:
                 req_id = 2
 
                 # 1. Start a session
-                response = await _call_tool(proc, "trace_start_session", {
-                    "project": "e2e-test",
-                    "description": "End-to-end test session",
-                }, request_id=req_id)
+                response = await _call_tool(
+                    proc,
+                    "trace_start_session",
+                    {
+                        "project": "e2e-test",
+                        "description": "End-to-end test session",
+                    },
+                    request_id=req_id,
+                )
                 req_id += 1
 
                 assert "result" in response, f"start_session failed: {response}"
@@ -305,75 +315,105 @@ class TestSessionLifecycleE2E:
                 assert session_id.startswith("trace_")
 
                 # 2. Propose a decision
-                response = await _call_tool(proc, "trace_propose_decision", {
-                    "session_id": session_id,
-                    "description": "Use cosine distance metric",
-                    "proposed_by_type": "ai",
-                    "proposed_by_id": "test-ai",
-                    "rationale": "Standard for text embedding comparison",
-                    "suggestion_type": "proactive",
-                }, request_id=req_id)
+                response = await _call_tool(
+                    proc,
+                    "trace_propose_decision",
+                    {
+                        "session_id": session_id,
+                        "description": "Use cosine distance metric",
+                        "proposed_by_type": "ai",
+                        "proposed_by_id": "test-ai",
+                        "rationale": "Standard for text embedding comparison",
+                        "suggestion_type": "proactive",
+                    },
+                    request_id=req_id,
+                )
                 req_id += 1
 
                 result_text = response["result"]["content"][0]["text"]
                 assert "evt_001" in result_text
 
                 # 3. Resolve the decision
-                response = await _call_tool(proc, "trace_resolve_decision", {
-                    "event_id": "evt_001",
-                    "session_id": session_id,
-                    "disposition": "accepted",
-                    "resolved_by_type": "human",
-                    "resolved_by_id": "test-researcher",
-                }, request_id=req_id)
+                response = await _call_tool(
+                    proc,
+                    "trace_resolve_decision",
+                    {
+                        "event_id": "evt_001",
+                        "session_id": session_id,
+                        "disposition": "accepted",
+                        "resolved_by_type": "human",
+                        "resolved_by_id": "test-researcher",
+                    },
+                    request_id=req_id,
+                )
                 req_id += 1
 
                 result_text = response["result"]["content"][0]["text"]
                 assert "accepted" in result_text
 
                 # 4. Log a contribution
-                response = await _call_tool(proc, "trace_log_contribution", {
-                    "session_id": session_id,
-                    "description": "Implemented distance calculation",
-                    "direction": "human",
-                    "execution": "ai",
-                    "artifact": "src/distances.py",
-                    "related_decision_ids": ["evt_001"],
-                }, request_id=req_id)
+                response = await _call_tool(
+                    proc,
+                    "trace_log_contribution",
+                    {
+                        "session_id": session_id,
+                        "description": "Implemented distance calculation",
+                        "direction": "human",
+                        "execution": "ai",
+                        "artifact": "src/distances.py",
+                        "related_decision_ids": ["evt_001"],
+                    },
+                    request_id=req_id,
+                )
                 req_id += 1
 
                 result_text = response["result"]["content"][0]["text"]
                 assert "evt_002" in result_text
 
                 # 5. Log an annotation
-                response = await _call_tool(proc, "trace_log_annotation", {
-                    "session_id": session_id,
-                    "category": "learning",
-                    "content": "Cosine distance is invariant to vector magnitude",
-                    "tags": ["methodology", "distance"],
-                }, request_id=req_id)
+                response = await _call_tool(
+                    proc,
+                    "trace_log_annotation",
+                    {
+                        "session_id": session_id,
+                        "category": "learning",
+                        "content": "Cosine distance is invariant to vector magnitude",
+                        "tags": ["methodology", "distance"],
+                    },
+                    request_id=req_id,
+                )
                 req_id += 1
 
                 result_text = response["result"]["content"][0]["text"]
                 assert "evt_003" in result_text
 
                 # 6. Log a state change
-                response = await _call_tool(proc, "trace_log_state_change", {
-                    "session_id": session_id,
-                    "description": "Switched to GPU compute",
-                    "field": "environment.compute",
-                    "old_value": "cpu",
-                    "new_value": "gpu",
-                }, request_id=req_id)
+                response = await _call_tool(
+                    proc,
+                    "trace_log_state_change",
+                    {
+                        "session_id": session_id,
+                        "description": "Switched to GPU compute",
+                        "field": "environment.compute",
+                        "old_value": "cpu",
+                        "new_value": "gpu",
+                    },
+                    request_id=req_id,
+                )
                 req_id += 1
 
                 result_text = response["result"]["content"][0]["text"]
                 assert "evt_004" in result_text
 
                 # 7. Query decisions
-                response = await _call_tool(proc, "trace_get_decisions", {
-                    "session_id": session_id,
-                }, request_id=req_id)
+                response = await _call_tool(
+                    proc,
+                    "trace_get_decisions",
+                    {
+                        "session_id": session_id,
+                    },
+                    request_id=req_id,
+                )
                 req_id += 1
 
                 result_text = response["result"]["content"][0]["text"]
@@ -382,10 +422,15 @@ class TestSessionLifecycleE2E:
                 assert decisions[0]["decision"]["disposition"] == "accepted"
 
                 # 8. Search events
-                response = await _call_tool(proc, "trace_search", {
-                    "session_id": session_id,
-                    "query": "cosine",
-                }, request_id=req_id)
+                response = await _call_tool(
+                    proc,
+                    "trace_search",
+                    {
+                        "session_id": session_id,
+                        "query": "cosine",
+                    },
+                    request_id=req_id,
+                )
                 req_id += 1
 
                 result_text = response["result"]["content"][0]["text"]
@@ -396,9 +441,14 @@ class TestSessionLifecycleE2E:
                 assert search["truncated"] is False  # tiny session, nothing dropped
 
                 # 9. Get session summary
-                response = await _call_tool(proc, "trace_get_session", {
-                    "session_id": session_id,
-                }, request_id=req_id)
+                response = await _call_tool(
+                    proc,
+                    "trace_get_session",
+                    {
+                        "session_id": session_id,
+                    },
+                    request_id=req_id,
+                )
                 req_id += 1
 
                 result_text = response["result"]["content"][0]["text"]
@@ -407,9 +457,14 @@ class TestSessionLifecycleE2E:
                 assert summary["metadata"]["project"] == "e2e-test"
 
                 # 10. Health check
-                response = await _call_tool(proc, "trace_health_check", {
-                    "project": "e2e-test",
-                }, request_id=req_id)
+                response = await _call_tool(
+                    proc,
+                    "trace_health_check",
+                    {
+                        "project": "e2e-test",
+                    },
+                    request_id=req_id,
+                )
                 req_id += 1
 
                 result_text = response["result"]["content"][0]["text"]
@@ -418,10 +473,15 @@ class TestSessionLifecycleE2E:
                 assert health["session_count"] == 1
 
                 # 11. End session
-                response = await _call_tool(proc, "trace_end_session", {
-                    "session_id": session_id,
-                    "summary": "E2E test completed successfully",
-                }, request_id=req_id)
+                response = await _call_tool(
+                    proc,
+                    "trace_end_session",
+                    {
+                        "session_id": session_id,
+                        "summary": "E2E test completed successfully",
+                    },
+                    request_id=req_id,
+                )
                 req_id += 1
 
                 result_text = response["result"]["content"][0]["text"]
@@ -448,50 +508,80 @@ class TestSessionLifecycleE2E:
                 req_id = 2
 
                 # Create a session with one event
-                response = await _call_tool(proc, "trace_start_session", {
-                    "project": "export-test",
-                }, request_id=req_id)
+                response = await _call_tool(
+                    proc,
+                    "trace_start_session",
+                    {
+                        "project": "export-test",
+                    },
+                    request_id=req_id,
+                )
                 req_id += 1
 
                 result_text = response["result"]["content"][0]["text"]
                 session_id = result_text.split("Session: ")[1].split("\n")[0]
 
-                await _call_tool(proc, "trace_log_annotation", {
-                    "session_id": session_id,
-                    "category": "learning",
-                    "content": "Test annotation for export",
-                }, request_id=req_id)
+                await _call_tool(
+                    proc,
+                    "trace_log_annotation",
+                    {
+                        "session_id": session_id,
+                        "category": "learning",
+                        "content": "Test annotation for export",
+                    },
+                    request_id=req_id,
+                )
                 req_id += 1
 
-                await _call_tool(proc, "trace_end_session", {
-                    "session_id": session_id,
-                }, request_id=req_id)
+                await _call_tool(
+                    proc,
+                    "trace_end_session",
+                    {
+                        "session_id": session_id,
+                    },
+                    request_id=req_id,
+                )
                 req_id += 1
 
                 # Test JSON export
-                response = await _call_tool(proc, "trace_export", {
-                    "session_id": session_id,
-                    "format": "json",
-                }, request_id=req_id)
+                response = await _call_tool(
+                    proc,
+                    "trace_export",
+                    {
+                        "session_id": session_id,
+                        "format": "json",
+                    },
+                    request_id=req_id,
+                )
                 req_id += 1
                 json_export = response["result"]["content"][0]["text"]
                 parsed = json.loads(json_export)
                 assert parsed["id"] == session_id
 
                 # Test Markdown export
-                response = await _call_tool(proc, "trace_export", {
-                    "session_id": session_id,
-                    "format": "markdown",
-                }, request_id=req_id)
+                response = await _call_tool(
+                    proc,
+                    "trace_export",
+                    {
+                        "session_id": session_id,
+                        "format": "markdown",
+                    },
+                    request_id=req_id,
+                )
                 req_id += 1
                 md_export = response["result"]["content"][0]["text"]
                 assert "# TRACE Session:" in md_export
 
                 # Test PROV-JSONLD export
-                response = await _call_tool(proc, "trace_export", {
-                    "session_id": session_id,
-                    "format": "prov-jsonld",
-                }, request_id=req_id)
+                response = await _call_tool(
+                    proc,
+                    "trace_export",
+                    {
+                        "session_id": session_id,
+                        "format": "prov-jsonld",
+                    },
+                    request_id=req_id,
+                )
                 req_id += 1
                 prov_export = response["result"]["content"][0]["text"]
                 prov_data = json.loads(prov_export)
@@ -514,9 +604,14 @@ class TestErrorHandlingE2E:
             try:
                 await _initialize_server(proc)
 
-                response = await _call_tool(proc, "trace_get_session", {
-                    "session_id": "nonexistent_session_id",
-                }, request_id=2)
+                response = await _call_tool(
+                    proc,
+                    "trace_get_session",
+                    {
+                        "session_id": "nonexistent_session_id",
+                    },
+                    request_id=2,
+                )
 
                 result_text = response["result"]["content"][0]["text"]
                 assert "error" in result_text.lower() or "not found" in result_text.lower()
@@ -530,9 +625,14 @@ class TestErrorHandlingE2E:
             try:
                 await _initialize_server(proc)
 
-                response = await _call_tool(proc, "trace_end_session", {
-                    "session_id": "nonexistent",
-                }, request_id=2)
+                response = await _call_tool(
+                    proc,
+                    "trace_end_session",
+                    {
+                        "session_id": "nonexistent",
+                    },
+                    request_id=2,
+                )
 
                 result_text = response["result"]["content"][0]["text"]
                 assert "error" in result_text.lower() or "not found" in result_text.lower()
@@ -548,21 +648,31 @@ class TestErrorHandlingE2E:
                 req_id = 2
 
                 # Create a valid session first
-                response = await _call_tool(proc, "trace_start_session", {
-                    "project": "error-test",
-                }, request_id=req_id)
+                response = await _call_tool(
+                    proc,
+                    "trace_start_session",
+                    {
+                        "project": "error-test",
+                    },
+                    request_id=req_id,
+                )
                 req_id += 1
                 result_text = response["result"]["content"][0]["text"]
                 session_id = result_text.split("Session: ")[1].split("\n")[0]
 
                 # Try to resolve nonexistent decision
-                response = await _call_tool(proc, "trace_resolve_decision", {
-                    "event_id": "evt_999",
-                    "session_id": session_id,
-                    "disposition": "accepted",
-                    "resolved_by_type": "human",
-                    "resolved_by_id": "researcher",
-                }, request_id=req_id)
+                response = await _call_tool(
+                    proc,
+                    "trace_resolve_decision",
+                    {
+                        "event_id": "evt_999",
+                        "session_id": session_id,
+                        "disposition": "accepted",
+                        "resolved_by_type": "human",
+                        "resolved_by_id": "researcher",
+                    },
+                    request_id=req_id,
+                )
                 req_id += 1
 
                 result_text = response["result"]["content"][0]["text"]
@@ -586,25 +696,40 @@ class TestSessionPersistenceE2E:
                 await _initialize_server(proc1)
                 req_id = 2
 
-                response = await _call_tool(proc1, "trace_start_session", {
-                    "project": "persistence-test",
-                    "description": "Testing persistence",
-                }, request_id=req_id)
+                response = await _call_tool(
+                    proc1,
+                    "trace_start_session",
+                    {
+                        "project": "persistence-test",
+                        "description": "Testing persistence",
+                    },
+                    request_id=req_id,
+                )
                 req_id += 1
                 result_text = response["result"]["content"][0]["text"]
                 session_id = result_text.split("Session: ")[1].split("\n")[0]
 
-                await _call_tool(proc1, "trace_propose_decision", {
-                    "session_id": session_id,
-                    "description": "Test decision for persistence",
-                    "proposed_by_type": "ai",
-                    "proposed_by_id": "test",
-                }, request_id=req_id)
+                await _call_tool(
+                    proc1,
+                    "trace_propose_decision",
+                    {
+                        "session_id": session_id,
+                        "description": "Test decision for persistence",
+                        "proposed_by_type": "ai",
+                        "proposed_by_id": "test",
+                    },
+                    request_id=req_id,
+                )
                 req_id += 1
 
-                await _call_tool(proc1, "trace_end_session", {
-                    "session_id": session_id,
-                }, request_id=req_id)
+                await _call_tool(
+                    proc1,
+                    "trace_end_session",
+                    {
+                        "session_id": session_id,
+                    },
+                    request_id=req_id,
+                )
                 req_id += 1
 
             finally:
@@ -615,9 +740,14 @@ class TestSessionPersistenceE2E:
             try:
                 await _initialize_server(proc2)
 
-                response = await _call_tool(proc2, "trace_get_session", {
-                    "session_id": session_id,
-                }, request_id=2)
+                response = await _call_tool(
+                    proc2,
+                    "trace_get_session",
+                    {
+                        "session_id": session_id,
+                    },
+                    request_id=2,
+                )
 
                 result_text = response["result"]["content"][0]["text"]
                 session_data = json.loads(result_text)
@@ -626,9 +756,14 @@ class TestSessionPersistenceE2E:
                 assert session_data["event_count"] == 1
 
                 # Also verify list_sessions finds it
-                response = await _call_tool(proc2, "trace_list_sessions", {
-                    "project": "persistence-test",
-                }, request_id=3)
+                response = await _call_tool(
+                    proc2,
+                    "trace_list_sessions",
+                    {
+                        "project": "persistence-test",
+                    },
+                    request_id=3,
+                )
 
                 result_text = response["result"]["content"][0]["text"]
                 sessions = json.loads(result_text)
@@ -653,19 +788,21 @@ class TestUvxIntegration:
         result = subprocess.run(
             [
                 "uvx",
-                "--from", str(TRACE_ROOT),
-                "--refresh-package", "trace-mcp",
-                "--with", "trace-mcp",
-                "python", "-c",
+                "--from",
+                str(TRACE_ROOT),
+                "--refresh-package",
+                "trace-mcp",
+                "--with",
+                "trace-mcp",
+                "python",
+                "-c",
                 "import trace_mcp; print(trace_mcp.__version__)",
             ],
             capture_output=True,
             text=True,
             timeout=60,
         )
-        assert result.returncode == 0, (
-            f"uvx import failed.\nstdout: {result.stdout}\nstderr: {result.stderr}"
-        )
+        assert result.returncode == 0, f"uvx import failed.\nstdout: {result.stdout}\nstderr: {result.stderr}"
         assert "0." in result.stdout  # Version should start with 0.
 
     def test_uvx_entry_point_resolves(self) -> None:
@@ -673,10 +810,14 @@ class TestUvxIntegration:
         result = subprocess.run(
             [
                 "uvx",
-                "--from", str(TRACE_ROOT),
-                "--refresh-package", "trace-mcp",
-                "--with", "trace-mcp",
-                "python", "-c",
+                "--from",
+                str(TRACE_ROOT),
+                "--refresh-package",
+                "trace-mcp",
+                "--with",
+                "trace-mcp",
+                "python",
+                "-c",
                 "from trace_mcp.server import main; print('entry point OK')",
             ],
             capture_output=True,
@@ -684,7 +825,6 @@ class TestUvxIntegration:
             timeout=60,
         )
         assert result.returncode == 0, (
-            f"uvx entry point check failed.\n"
-            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+            f"uvx entry point check failed.\nstdout: {result.stdout}\nstderr: {result.stderr}"
         )
         assert "entry point OK" in result.stdout

--- a/tests/test_env_isolation.py
+++ b/tests/test_env_isolation.py
@@ -55,9 +55,7 @@ class TestSuiteEnvIsolation:
         context-restoration file) or falls back to ~/.trace/scratchpads."""
         isolated = _assert_isolated("TRACE_SCRATCHPAD_DIR")
         resolved = _scratchpad_path().resolve()
-        assert resolved.is_relative_to(isolated), (
-            f"scratchpad resolves to {resolved}, expected inside {isolated}"
-        )
+        assert resolved.is_relative_to(isolated), f"scratchpad resolves to {resolved}, expected inside {isolated}"
         assert not resolved.is_relative_to((Path.cwd() / ".claude").resolve()), (
             "scratchpad would overwrite the developer's real .claude/SCRATCHPAD.md"
         )

--- a/tests/test_failure_modes_e2e.py
+++ b/tests/test_failure_modes_e2e.py
@@ -28,17 +28,23 @@ from test_e2e_server import (
 
 async def _setup_session(proc, req_id: int = 2, project: str = "fm-test"):
     """Start a session and return (session_id, next_req_id)."""
-    response = await _call_tool(proc, "trace_start_session", {
-        "project": project,
-        "description": f"Failure mode test session ({project})",
-    }, request_id=req_id)
+    response = await _call_tool(
+        proc,
+        "trace_start_session",
+        {
+            "project": project,
+            "description": f"Failure mode test session ({project})",
+        },
+        request_id=req_id,
+    )
     text = response["result"]["content"][0]["text"]
     session_id = text.split("Session: ")[1].split("\n")[0]
     return session_id, req_id + 1
 
 
-async def _propose(proc, session_id, req_id, *, description="Test decision",
-                   proposed_by_type="ai", proposed_by_id="test-ai", **kwargs):
+async def _propose(
+    proc, session_id, req_id, *, description="Test decision", proposed_by_type="ai", proposed_by_id="test-ai", **kwargs
+):
     """Propose a decision and return (result_text, event_id, next_req_id)."""
     args = {
         "session_id": session_id,
@@ -56,9 +62,17 @@ async def _propose(proc, session_id, req_id, *, description="Test decision",
     return text, "evt_001", req_id + 1
 
 
-async def _resolve(proc, session_id, event_id, req_id, *,
-                   disposition="accepted", resolved_by_type="human",
-                   resolved_by_id="researcher", **kwargs):
+async def _resolve(
+    proc,
+    session_id,
+    event_id,
+    req_id,
+    *,
+    disposition="accepted",
+    resolved_by_type="human",
+    resolved_by_id="researcher",
+    **kwargs,
+):
     """Resolve a decision and return (result_text, next_req_id)."""
     args = {
         "event_id": event_id,
@@ -74,15 +88,19 @@ async def _resolve(proc, session_id, event_id, req_id, *,
 
 async def _end_session(proc, session_id, req_id, summary="test"):
     """End session and return (result_text, next_req_id)."""
-    response = await _call_tool(proc, "trace_end_session", {
-        "session_id": session_id,
-        "summary": summary,
-    }, request_id=req_id)
+    response = await _call_tool(
+        proc,
+        "trace_end_session",
+        {
+            "session_id": session_id,
+            "summary": summary,
+        },
+        request_id=req_id,
+    )
     return response["result"]["content"][0]["text"], req_id + 1
 
 
-async def _annotate(proc, session_id, req_id, *, category="learning",
-                    content="Test annotation", **kwargs):
+async def _annotate(proc, session_id, req_id, *, category="learning", content="Test annotation", **kwargs):
     """Log an annotation and return (result_text, next_req_id)."""
     args = {
         "category": category,
@@ -95,8 +113,9 @@ async def _annotate(proc, session_id, req_id, *, category="learning",
     return response["result"]["content"][0]["text"], req_id + 1
 
 
-async def _contribute(proc, session_id, req_id, *, description="Test contribution",
-                      direction="human", execution="ai", **kwargs):
+async def _contribute(
+    proc, session_id, req_id, *, description="Test contribution", direction="human", execution="ai", **kwargs
+):
     """Log a contribution and return (result_text, next_req_id)."""
     args = {
         "session_id": session_id,
@@ -109,8 +128,7 @@ async def _contribute(proc, session_id, req_id, *, description="Test contributio
     return response["result"]["content"][0]["text"], req_id + 1
 
 
-async def _log_tool_call(proc, session_id, req_id, *, server="domain-server",
-                         tool_name="do_work", **kwargs):
+async def _log_tool_call(proc, session_id, req_id, *, server="domain-server", tool_name="do_work", **kwargs):
     """Log a tool call and return (result_text, next_req_id)."""
     args = {
         "session_id": session_id,
@@ -144,8 +162,12 @@ class TestAttributionFailures:
                 sid, rid = await _setup_session(proc)
                 _, eid, rid = await _propose(proc, sid, rid)
                 text, rid = await _resolve(
-                    proc, sid, eid, rid,
-                    resolved_by_type="ai", resolved_by_id="test-ai",
+                    proc,
+                    sid,
+                    eid,
+                    rid,
+                    resolved_by_type="ai",
+                    resolved_by_id="test-ai",
                 )
                 assert "AI resolved its own proposal" in text
             finally:
@@ -174,8 +196,12 @@ class TestAttributionFailures:
                 for _ in range(3):
                     _, eid, rid = await _propose(proc, sid, rid)
                     _, rid = await _resolve(
-                        proc, sid, eid, rid,
-                        resolved_by_type="ai", resolved_by_id="test-ai",
+                        proc,
+                        sid,
+                        eid,
+                        rid,
+                        resolved_by_type="ai",
+                        resolved_by_id="test-ai",
                     )
                 text, rid = await _end_session(proc, sid, rid)
                 assert "AI self-resolutions: 3" in text
@@ -195,9 +221,12 @@ class TestAttributionFailures:
                 sid, rid = await _setup_session(proc)
                 # Direction=ai, execution=human — possibly swapped
                 text, rid = await _contribute(
-                    proc, sid, rid,
+                    proc,
+                    sid,
+                    rid,
                     description="Built the widget",
-                    direction="ai", execution="human",
+                    direction="ai",
+                    execution="human",
                     conversation_snippet="please build the widget",
                     related_decision_ids=[],
                 )
@@ -233,7 +262,9 @@ class TestAttributionFailures:
                 sid, rid = await _setup_session(proc)
                 _, eid, rid = await _propose(proc, sid, rid)
                 text, rid = await _annotate(
-                    proc, sid, rid,
+                    proc,
+                    sid,
+                    rid,
                     category="correction",
                     content="Wrong threshold",
                     corrects_event_ids=[eid],
@@ -251,7 +282,9 @@ class TestAttributionFailures:
                 sid, rid = await _setup_session(proc)
                 _, eid, rid = await _propose(proc, sid, rid)
                 text, rid = await _contribute(
-                    proc, sid, rid,
+                    proc,
+                    sid,
+                    rid,
                     conversation_snippet="user said to build it",
                     related_decision_ids=[eid],
                 )
@@ -271,8 +304,10 @@ class TestAttributionFailures:
                 await _initialize_server(proc)
                 sid, rid = await _setup_session(proc)
                 # Claiming "requested" when it was actually proactive
-                text, eid, rid = await _propose(
-                    proc, sid, rid,
+                text, _eid, rid = await _propose(
+                    proc,
+                    sid,
+                    rid,
                     suggestion_type="requested",
                 )
                 assert "Decision proposed" in text
@@ -295,7 +330,9 @@ class TestAttributionFailures:
                 # Log 8 events in rapid succession (simulating deferred logging)
                 for i in range(8):
                     _, rid = await _annotate(
-                        proc, sid, rid,
+                        proc,
+                        sid,
+                        rid,
                         content=f"Batch annotation {i}",
                     )
                 text, rid = await _end_session(proc, sid, rid)
@@ -318,7 +355,9 @@ class TestAttributionFailures:
                 sid, rid = await _setup_session(proc)
                 # Human logs annotation but actor_type defaults to "ai"
                 text, rid = await _annotate(
-                    proc, sid, rid,
+                    proc,
+                    sid,
+                    rid,
                     content="Human observation logged with default actor",
                     # actor_type not set — defaults to "ai"
                 )
@@ -341,7 +380,9 @@ class TestAttributionFailures:
                 sid, rid = await _setup_session(proc)
                 _, eid, rid = await _propose(proc, sid, rid)
                 text, rid = await _annotate(
-                    proc, sid, rid,
+                    proc,
+                    sid,
+                    rid,
                     category="gotcha",
                     content="Method X doesn't actually work here",
                     corrects_event_ids=[eid],
@@ -358,7 +399,9 @@ class TestAttributionFailures:
                 await _initialize_server(proc)
                 sid, rid = await _setup_session(proc)
                 text, rid = await _annotate(
-                    proc, sid, rid,
+                    proc,
+                    sid,
+                    rid,
                     category="gotcha",
                     content="Surprising API behavior",
                 )
@@ -379,7 +422,9 @@ class TestAttributionFailures:
                 sid, rid = await _setup_session(proc)
                 # One contribution that should have been two separate ones
                 text, rid = await _contribute(
-                    proc, sid, rid,
+                    proc,
+                    sid,
+                    rid,
                     description="Built features A and B (should be 2 contributions)",
                     direction="collaborative",
                     execution="collaborative",
@@ -413,8 +458,10 @@ class TestCompletenessFailures:
                 await _initialize_server(proc)
                 sid, rid = await _setup_session(proc)
                 # AI only logs a contribution, "forgetting" the decision
-                text, rid = await _contribute(
-                    proc, sid, rid,
+                _text, rid = await _contribute(
+                    proc,
+                    sid,
+                    rid,
                     description="Implemented feature",
                     conversation_snippet="let's use approach X (decision not logged!)",
                 )
@@ -476,7 +523,9 @@ class TestCompletenessFailures:
                 rid = 2
                 # Log event WITHOUT starting a session first → auto-session
                 text, rid = await _annotate(
-                    proc, None, rid,
+                    proc,
+                    None,
+                    rid,
                     content="This happened before any session was started",
                 )
                 # Auto-session warning appears, but no "late start" detection
@@ -500,8 +549,12 @@ class TestCompletenessFailures:
                 sid, rid = await _setup_session(proc)
                 _, eid, rid = await _propose(proc, sid, rid)
                 _, rid = await _resolve(
-                    proc, sid, eid, rid,
-                    resolved_by_type="ai", resolved_by_id="test-ai",
+                    proc,
+                    sid,
+                    eid,
+                    rid,
+                    resolved_by_type="ai",
+                    resolved_by_id="test-ai",
                 )
                 text, rid = await _end_session(proc, sid, rid)
                 # Audit IS emitted...
@@ -523,12 +576,17 @@ class TestCompletenessFailures:
             try:
                 await _initialize_server(proc)
                 sid, rid = await _setup_session(proc)
-                _, eid, rid = await _propose(proc, sid, rid)
+                _, _eid, rid = await _propose(proc, sid, rid)
                 # Simulate: AI "forgets" session_id after compact
                 # It can still load sessions via list_sessions
-                response = await _call_tool(proc, "trace_list_sessions", {
-                    "project": "fm-test",
-                }, request_id=rid)
+                response = await _call_tool(
+                    proc,
+                    "trace_list_sessions",
+                    {
+                        "project": "fm-test",
+                    },
+                    request_id=rid,
+                )
                 rid += 1
                 sessions = json.loads(response["result"]["content"][0]["text"])
                 assert len(sessions) >= 1
@@ -552,8 +610,12 @@ class TestCompletenessFailures:
                 _, eid, rid = await _propose(proc, sid, rid)
                 # Resolve immediately (well under 5s)
                 text, rid = await _resolve(
-                    proc, sid, eid, rid,
-                    resolved_by_type="ai", resolved_by_id="test-ai",
+                    proc,
+                    sid,
+                    eid,
+                    rid,
+                    resolved_by_type="ai",
+                    resolved_by_id="test-ai",
                 )
                 assert "self-resolved" in text.lower() or "AI resolved" in text
             finally:
@@ -585,7 +647,10 @@ class TestCompletenessFailures:
                 sid, rid = await _setup_session(proc)
                 _, eid, rid = await _propose(proc, sid, rid, description="Bad approach")
                 text, rid = await _resolve(
-                    proc, sid, eid, rid,
+                    proc,
+                    sid,
+                    eid,
+                    rid,
                     disposition="rejected",
                     revision_note="This approach is fundamentally wrong",
                 )
@@ -629,7 +694,9 @@ class TestStructuralFailures:
                 sid, rid = await _setup_session(proc)
                 # Should be 3 decisions (X → Y → Z) but logged as one
                 _, eid, rid = await _propose(
-                    proc, sid, rid,
+                    proc,
+                    sid,
+                    rid,
                     description="Use method Z (after considering X and Y)",
                 )
                 _, rid = await _resolve(proc, sid, eid, rid)
@@ -653,7 +720,9 @@ class TestStructuralFailures:
                 await _initialize_server(proc)
                 sid, rid = await _setup_session(proc)
                 text, rid = await _annotate(
-                    proc, sid, rid,
+                    proc,
+                    sid,
+                    rid,
                     category="correction",
                     content="Fixed the issue",
                     corrects_event_ids=["evt_999"],
@@ -673,7 +742,9 @@ class TestStructuralFailures:
                 sid, rid = await _setup_session(proc)
                 _, eid, rid = await _propose(proc, sid, rid)
                 text, rid = await _annotate(
-                    proc, sid, rid,
+                    proc,
+                    sid,
+                    rid,
                     category="correction",
                     content="Fixed threshold",
                     corrects_event_ids=[eid],
@@ -691,7 +762,9 @@ class TestStructuralFailures:
                 await _initialize_server(proc)
                 sid, rid = await _setup_session(proc)
                 text, rid = await _contribute(
-                    proc, sid, rid,
+                    proc,
+                    sid,
+                    rid,
                     related_decision_ids=["evt_phantom"],
                     conversation_snippet="build it",
                 )
@@ -712,11 +785,15 @@ class TestStructuralFailures:
                 await _initialize_server(proc)
                 sid, rid = await _setup_session(proc)
                 text1, rid = await _annotate(
-                    proc, sid, rid,
+                    proc,
+                    sid,
+                    rid,
                     content="Important discovery about the data",
                 )
                 text2, rid = await _annotate(
-                    proc, sid, rid,
+                    proc,
+                    sid,
+                    rid,
                     content="Important discovery about the data",  # exact duplicate
                 )
                 # Both logged, different event IDs
@@ -738,8 +815,10 @@ class TestStructuralFailures:
             try:
                 await _initialize_server(proc)
                 sid, rid = await _setup_session(proc)
-                text, eid, rid = await _propose(
-                    proc, sid, rid,
+                text, _eid, rid = await _propose(
+                    proc,
+                    sid,
+                    rid,
                     description="Revised approach",
                     revises_event_id="evt_wrong",
                 )
@@ -757,11 +836,17 @@ class TestStructuralFailures:
                 sid, rid = await _setup_session(proc)
                 _, eid1, rid = await _propose(proc, sid, rid, description="First approach")
                 _, rid = await _resolve(
-                    proc, sid, eid1, rid,
-                    disposition="rejected", revision_note="Doesn't work",
+                    proc,
+                    sid,
+                    eid1,
+                    rid,
+                    disposition="rejected",
+                    revision_note="Doesn't work",
                 )
-                text, eid2, rid = await _propose(
-                    proc, sid, rid,
+                text, _eid2, rid = await _propose(
+                    proc,
+                    sid,
+                    rid,
                     description="Better approach",
                     revises_event_id=eid1,
                 )
@@ -781,7 +866,9 @@ class TestStructuralFailures:
                 await _initialize_server(proc)
                 sid, rid = await _setup_session(proc)
                 text, rid = await _annotate(
-                    proc, sid, rid,
+                    proc,
+                    sid,
+                    rid,
                     category="correction",
                     content="The threshold should be 0.5 not 0.3",
                 )
@@ -798,7 +885,9 @@ class TestStructuralFailures:
                 sid, rid = await _setup_session(proc)
                 _, eid, rid = await _propose(proc, sid, rid)
                 text, rid = await _annotate(
-                    proc, sid, rid,
+                    proc,
+                    sid,
+                    rid,
                     category="correction",
                     content="Threshold should be 0.5",
                     corrects_event_ids=[eid],
@@ -817,7 +906,9 @@ class TestStructuralFailures:
                 sid, rid = await _setup_session(proc)
                 for i in range(3):
                     _, rid = await _annotate(
-                        proc, sid, rid,
+                        proc,
+                        sid,
+                        rid,
                         category="correction",
                         content=f"Orphaned fix {i}",
                     )
@@ -847,19 +938,29 @@ class TestCrossSessionFailures:
                 await _initialize_server(proc)
                 rid = 2
                 # Create sessions with different project names for same work
-                response = await _call_tool(proc, "trace_start_session", {
-                    "project": "demo-project",
-                    "description": "Analysis session",
-                }, request_id=rid)
+                response = await _call_tool(
+                    proc,
+                    "trace_start_session",
+                    {
+                        "project": "demo-project",
+                        "description": "Analysis session",
+                    },
+                    request_id=rid,
+                )
                 rid += 1
                 text1 = response["result"]["content"][0]["text"]
                 sid1 = text1.split("Session: ")[1].split("\n")[0]
                 _, rid = await _end_session(proc, sid1, rid)
 
-                response = await _call_tool(proc, "trace_start_session", {
-                    "project": "Demo-Project",  # different casing!
-                    "description": "Same project, different name",
-                }, request_id=rid)
+                response = await _call_tool(
+                    proc,
+                    "trace_start_session",
+                    {
+                        "project": "Demo-Project",  # different casing!
+                        "description": "Same project, different name",
+                    },
+                    request_id=rid,
+                )
                 rid += 1
                 text2 = response["result"]["content"][0]["text"]
                 # No warning about inconsistent project naming
@@ -914,19 +1015,29 @@ class TestCrossSessionFailures:
                 await _initialize_server(proc)
                 rid = 2
                 # Session 1 — part of same workflow
-                response = await _call_tool(proc, "trace_start_session", {
-                    "project": "fm-test",
-                    "description": "Part 1 of analysis",
-                }, request_id=rid)
+                response = await _call_tool(
+                    proc,
+                    "trace_start_session",
+                    {
+                        "project": "fm-test",
+                        "description": "Part 1 of analysis",
+                    },
+                    request_id=rid,
+                )
                 rid += 1
                 sid1 = response["result"]["content"][0]["text"].split("Session: ")[1].split("\n")[0]
                 _, rid = await _end_session(proc, sid1, rid, summary="Part 1 done")
 
                 # Session 2 — continuation, should be linked
-                response = await _call_tool(proc, "trace_start_session", {
-                    "project": "fm-test",
-                    "description": "Part 2 of analysis (continuation)",
-                }, request_id=rid)
+                response = await _call_tool(
+                    proc,
+                    "trace_start_session",
+                    {
+                        "project": "fm-test",
+                        "description": "Part 2 of analysis (continuation)",
+                    },
+                    request_id=rid,
+                )
                 rid += 1
                 text2 = response["result"]["content"][0]["text"]
                 # No warning about fragmentation
@@ -956,7 +1067,9 @@ class TestProtocolViolations:
                 await _initialize_server(proc)
                 sid, rid = await _setup_session(proc)
                 text, rid = await _log_tool_call(
-                    proc, sid, rid,
+                    proc,
+                    sid,
+                    rid,
                     server="trace",
                     tool_name="trace_propose_decision",
                     input={"description": "test"},
@@ -974,7 +1087,9 @@ class TestProtocolViolations:
                 await _initialize_server(proc)
                 sid, rid = await _setup_session(proc)
                 text, rid = await _log_tool_call(
-                    proc, sid, rid,
+                    proc,
+                    sid,
+                    rid,
                     server="mcp-server",
                     tool_name="trace_end_session",
                     input={},
@@ -996,7 +1111,9 @@ class TestProtocolViolations:
                 sid, rid = await _setup_session(proc)
                 for tool in ["Read", "Grep", "Glob", "Bash"]:
                     text, rid = await _log_tool_call(
-                        proc, sid, rid,
+                        proc,
+                        sid,
+                        rid,
                         server="filesystem",
                         tool_name=tool,
                         input={"path": "/tmp/test"},
@@ -1013,7 +1130,9 @@ class TestProtocolViolations:
                 await _initialize_server(proc)
                 sid, rid = await _setup_session(proc)
                 text, rid = await _log_tool_call(
-                    proc, sid, rid,
+                    proc,
+                    sid,
+                    rid,
                     server="corpus-search",
                     tool_name="search_papers",
                     input={"query": "climate change"},
@@ -1037,7 +1156,9 @@ class TestProtocolViolations:
                 sid, rid = await _setup_session(proc)
                 # Log a completely fabricated tool call
                 text, rid = await _log_tool_call(
-                    proc, sid, rid,
+                    proc,
+                    sid,
+                    rid,
                     server="analysis-pipeline",
                     tool_name="run_model",
                     input={"model": "gpt-5.4-mini", "data": "fabricated_dataset.csv"},
@@ -1064,7 +1185,9 @@ class TestProtocolViolations:
                 sid, rid = await _setup_session(proc)
                 # AI only logs the successful 4th attempt, hiding 3 failures
                 text, rid = await _log_tool_call(
-                    proc, sid, rid,
+                    proc,
+                    sid,
+                    rid,
                     server="analysis",
                     tool_name="run_model",
                     input={"attempt": 4},
@@ -1101,11 +1224,15 @@ class TestSystemicFailures:
                 # Log events — timestamps will be in order of logging,
                 # not necessarily in order of occurrence
                 _, rid = await _annotate(
-                    proc, sid, rid,
+                    proc,
+                    sid,
+                    rid,
                     content="Event B happened first but logged second",
                 )
                 _, rid = await _annotate(
-                    proc, sid, rid,
+                    proc,
+                    sid,
+                    rid,
                     content="Event A happened second but logged first",
                 )
                 # No timestamp ordering validation
@@ -1129,18 +1256,28 @@ class TestSystemicFailures:
                 rid = 2
                 # Two different projects with same name
                 for desc in ["Climate analysis", "Totally different project"]:
-                    response = await _call_tool(proc, "trace_start_session", {
-                        "project": "shared-name",
-                        "description": desc,
-                    }, request_id=rid)
+                    response = await _call_tool(
+                        proc,
+                        "trace_start_session",
+                        {
+                            "project": "shared-name",
+                            "description": desc,
+                        },
+                        request_id=rid,
+                    )
                     rid += 1
                     text = response["result"]["content"][0]["text"]
                     sid = text.split("Session: ")[1].split("\n")[0]
                     _, rid = await _end_session(proc, sid, rid)
                 # Both accepted under same project name
-                response = await _call_tool(proc, "trace_list_sessions", {
-                    "project": "shared-name",
-                }, request_id=rid)
+                response = await _call_tool(
+                    proc,
+                    "trace_list_sessions",
+                    {
+                        "project": "shared-name",
+                    },
+                    request_id=rid,
+                )
                 rid += 1
                 sessions = json.loads(response["result"]["content"][0]["text"])
                 assert len(sessions) == 2
@@ -1166,23 +1303,24 @@ class TestSystemicFailures:
                     _, rid = await _resolve(proc, sid, eid, rid)
                 for i in range(5):
                     _, rid = await _contribute(
-                        proc, sid, rid,
+                        proc,
+                        sid,
+                        rid,
                         description=f"Contribution {i}",
                         conversation_snippet=f"build feature {i}",
                     )
                 for i in range(5):
                     _, rid = await _log_tool_call(
-                        proc, sid, rid,
+                        proc,
+                        sid,
+                        rid,
                         tool_name=f"analyze_{i}",
                         input={"step": i},
                     )
                 _, rid = await _end_session(proc, sid, rid)
                 elapsed = time.monotonic() - start
                 # Should complete in reasonable time despite guard rails
-                assert elapsed < 15.0, (
-                    f"Session with 30 events + guard rails took {elapsed:.1f}s "
-                    f"(should be <15s)"
-                )
+                assert elapsed < 15.0, f"Session with 30 events + guard rails took {elapsed:.1f}s (should be <15s)"
             finally:
                 await _shutdown_server(proc)
 
@@ -1205,7 +1343,9 @@ class TestFullScenarios:
 
                 # AI proposes, human resolves
                 _, eid1, rid = await _propose(
-                    proc, sid, rid,
+                    proc,
+                    sid,
+                    rid,
                     description="Use cosine distance for similarity",
                     suggestion_type="proactive",
                 )
@@ -1213,7 +1353,9 @@ class TestFullScenarios:
 
                 # Contribution with all fields
                 _, rid = await _contribute(
-                    proc, sid, rid,
+                    proc,
+                    sid,
+                    rid,
                     description="Implemented cosine distance",
                     artifact="src/distances.py",
                     related_decision_ids=[eid1],
@@ -1222,7 +1364,9 @@ class TestFullScenarios:
 
                 # Domain tool call
                 _, rid = await _log_tool_call(
-                    proc, sid, rid,
+                    proc,
+                    sid,
+                    rid,
                     server="analysis",
                     tool_name="compute_similarity",
                     input={"method": "cosine"},
@@ -1230,7 +1374,9 @@ class TestFullScenarios:
 
                 # Learning annotation
                 _, rid = await _annotate(
-                    proc, sid, rid,
+                    proc,
+                    sid,
+                    rid,
                     content="Cosine distance is invariant to magnitude",
                     tags=["methodology"],
                 )
@@ -1255,25 +1401,35 @@ class TestFullScenarios:
                 # FM1 + FM25: AI self-resolves immediately
                 _, eid1, rid = await _propose(proc, sid, rid, description="Self-resolved A")
                 resolve_text, rid = await _resolve(
-                    proc, sid, eid1, rid,
-                    resolved_by_type="ai", resolved_by_id="test-ai",
+                    proc,
+                    sid,
+                    eid1,
+                    rid,
+                    resolved_by_type="ai",
+                    resolved_by_id="test-ai",
                 )
                 assert "AI resolved its own proposal" in resolve_text
 
                 # FM31: Human rejects
                 _, eid2, rid = await _propose(proc, sid, rid, description="Bad idea")
                 reject_text, rid = await _resolve(
-                    proc, sid, eid2, rid,
-                    disposition="rejected", revision_note="Wrong approach",
+                    proc,
+                    sid,
+                    eid2,
+                    rid,
+                    disposition="rejected",
+                    revision_note="Wrong approach",
                 )
                 assert "correction" in reject_text.lower()
 
                 # FM9: Unresolved decision
-                _, eid3, rid = await _propose(proc, sid, rid, description="Left hanging")
+                _, _eid3, rid = await _propose(proc, sid, rid, description="Left hanging")
 
                 # FM17: Orphaned correction
                 corr_text, rid = await _annotate(
-                    proc, sid, rid,
+                    proc,
+                    sid,
+                    rid,
                     category="correction",
                     content="Fixed the threshold",
                 )
@@ -1284,7 +1440,9 @@ class TestFullScenarios:
 
                 # FM13: Dangling reference
                 dangle_text, rid = await _annotate(
-                    proc, sid, rid,
+                    proc,
+                    sid,
+                    rid,
                     category="correction",
                     content="Another fix",
                     corrects_event_ids=["evt_phantom"],
@@ -1294,7 +1452,9 @@ class TestFullScenarios:
 
                 # FM22: Logging TRACE's own call
                 trace_text, rid = await _log_tool_call(
-                    proc, sid, rid,
+                    proc,
+                    sid,
+                    rid,
                     server="trace",
                     tool_name="trace_start_session",
                     input={"project": "oops"},
@@ -1303,7 +1463,9 @@ class TestFullScenarios:
 
                 # FM23: Logging exploratory call
                 read_text, rid = await _log_tool_call(
-                    proc, sid, rid,
+                    proc,
+                    sid,
+                    rid,
                     server="filesystem",
                     tool_name="Read",
                     input={"path": "/tmp/file"},
@@ -1312,7 +1474,9 @@ class TestFullScenarios:
 
                 # FM26: Gotcha with corrects_event_ids
                 gotcha_text, rid = await _annotate(
-                    proc, sid, rid,
+                    proc,
+                    sid,
+                    rid,
                     category="gotcha",
                     content="Actually this was wrong",
                     corrects_event_ids=[eid1],
@@ -1344,14 +1508,19 @@ class TestFullScenarios:
 
                 # Step 1: AI proposes (bad)
                 _, eid1, rid = await _propose(
-                    proc, sid, rid,
+                    proc,
+                    sid,
+                    rid,
                     description="Use Euclidean distance",
                     suggestion_type="proactive",
                 )
 
                 # Step 2: Human rejects
                 reject_text, rid = await _resolve(
-                    proc, sid, eid1, rid,
+                    proc,
+                    sid,
+                    eid1,
+                    rid,
                     disposition="rejected",
                     revision_note="Euclidean is inappropriate for high-dim text",
                 )
@@ -1359,7 +1528,9 @@ class TestFullScenarios:
 
                 # Step 3: Correction annotation
                 _, rid = await _annotate(
-                    proc, sid, rid,
+                    proc,
+                    sid,
+                    rid,
                     category="correction",
                     content="Euclidean distance is inappropriate for text embeddings",
                     corrects_event_ids=[eid1],
@@ -1368,7 +1539,9 @@ class TestFullScenarios:
 
                 # Step 4: AI proposes revision
                 _, eid2, rid = await _propose(
-                    proc, sid, rid,
+                    proc,
+                    sid,
+                    rid,
                     description="Use cosine distance instead",
                     revises_event_id=eid1,
                 )
@@ -1378,7 +1551,9 @@ class TestFullScenarios:
 
                 # Step 6: Contribution
                 _, rid = await _contribute(
-                    proc, sid, rid,
+                    proc,
+                    sid,
+                    rid,
                     description="Implemented cosine distance",
                     artifact="src/distances.py",
                     related_decision_ids=[eid2],

--- a/tests/test_hardening_e2e.py
+++ b/tests/test_hardening_e2e.py
@@ -78,7 +78,11 @@ async def _create_session(
     tags: list[str] | None = None,
 ) -> tuple[str, Session]:
     await session_tools.start_session(
-        storage, active, project=project, description=description, tags=tags,
+        storage,
+        active,
+        project=project,
+        description=description,
+        tags=tags,
     )
     session_id = list(active.keys())[-1]
     return session_id, active[session_id]
@@ -144,30 +148,43 @@ class TestSessionImmutability:
     """Sessions must be immutable once completed. No double-ending, no post-end logging."""
 
     async def test_double_end_returns_error(
-        self, storage: JsonFileStorage, active: dict[str, Session],
+        self,
+        storage: JsonFileStorage,
+        active: dict[str, Session],
     ) -> None:
         """Ending an already-completed session returns an error, not silent overwrite."""
         session_id, _ = await _create_session(storage, active)
         result1 = await session_tools.end_session(
-            storage, active, session_id=session_id, summary="done",
+            storage,
+            active,
+            session_id=session_id,
+            summary="done",
         )
         assert "Session ended" in result1
 
         # Second end attempt must fail
         result2 = await session_tools.end_session(
-            storage, active, session_id=session_id, summary="different",
+            storage,
+            active,
+            session_id=session_id,
+            summary="different",
         )
         assert "Error" in result2
         assert "already ended" in result2
         assert "immutable" in result2
 
     async def test_double_end_preserves_original_timestamp(
-        self, storage: JsonFileStorage, active: dict[str, Session],
+        self,
+        storage: JsonFileStorage,
+        active: dict[str, Session],
     ) -> None:
         """The original ended timestamp must not be overwritten."""
         session_id, _ = await _create_session(storage, active)
         await session_tools.end_session(
-            storage, active, session_id=session_id, summary="first",
+            storage,
+            active,
+            session_id=session_id,
+            summary="first",
         )
 
         # Load and record original timestamp
@@ -176,7 +193,10 @@ class TestSessionImmutability:
 
         # Try to end again
         await session_tools.end_session(
-            storage, active, session_id=session_id, summary="second",
+            storage,
+            active,
+            session_id=session_id,
+            summary="second",
         )
 
         # Verify timestamp unchanged
@@ -185,35 +205,51 @@ class TestSessionImmutability:
         assert reloaded.summary == "first"  # original summary preserved
 
     async def test_double_end_preserves_original_summary(
-        self, storage: JsonFileStorage, active: dict[str, Session],
+        self,
+        storage: JsonFileStorage,
+        active: dict[str, Session],
     ) -> None:
         """The original summary must not be overwritten by a second end call."""
         session_id, session = await _create_session(storage, active)
 
         # Log a real event so the session has content
         await logging_tools.log_annotation(
-            storage, session, category="observation", content="test observation",
+            storage,
+            session,
+            category="observation",
+            content="test observation",
         )
 
         await session_tools.end_session(
-            storage, active, session_id=session_id, summary="Original summary",
+            storage,
+            active,
+            session_id=session_id,
+            summary="Original summary",
         )
 
         # Attempt to end again with different summary
         await session_tools.end_session(
-            storage, active, session_id=session_id, summary="Altered summary",
+            storage,
+            active,
+            session_id=session_id,
+            summary="Altered summary",
         )
 
         reloaded = await storage.get_session(session_id)
         assert reloaded.summary == "Original summary"
 
     async def test_append_event_to_completed_session_raises(
-        self, storage: JsonFileStorage, active: dict[str, Session],
+        self,
+        storage: JsonFileStorage,
+        active: dict[str, Session],
     ) -> None:
         """Logging to a completed session must raise ValueError."""
-        session_id, session = await _create_session(storage, active)
+        session_id, _session = await _create_session(storage, active)
         await session_tools.end_session(
-            storage, active, session_id=session_id, summary="done",
+            storage,
+            active,
+            session_id=session_id,
+            summary="done",
         )
 
         # Re-load the completed session
@@ -228,15 +264,23 @@ class TestSessionImmutability:
             await session_tools.append_event(storage, completed, event)
 
     async def test_post_completion_event_not_persisted(
-        self, storage: JsonFileStorage, active: dict[str, Session],
+        self,
+        storage: JsonFileStorage,
+        active: dict[str, Session],
     ) -> None:
         """Events attempted after completion must not appear in the stored session."""
         session_id, session = await _create_session(storage, active)
         await logging_tools.log_annotation(
-            storage, session, category="observation", content="pre-end event",
+            storage,
+            session,
+            category="observation",
+            content="pre-end event",
         )
         await session_tools.end_session(
-            storage, active, session_id=session_id, summary="done",
+            storage,
+            active,
+            session_id=session_id,
+            summary="done",
         )
 
         completed = await storage.get_session(session_id)
@@ -245,7 +289,10 @@ class TestSessionImmutability:
         # Attempt post-end logging
         with pytest.raises(ValueError):
             await logging_tools.log_annotation(
-                storage, completed, category="observation", content="post-end",
+                storage,
+                completed,
+                category="observation",
+                content="post-end",
             )
 
         # Verify event count unchanged on disk
@@ -253,45 +300,65 @@ class TestSessionImmutability:
         assert len(reloaded.events) == 1
 
     async def test_all_logging_tools_reject_completed_session(
-        self, storage: JsonFileStorage, active: dict[str, Session],
+        self,
+        storage: JsonFileStorage,
+        active: dict[str, Session],
     ) -> None:
         """Every logging function must reject completed sessions."""
-        session_id, session = await _create_session(storage, active)
+        session_id, _session = await _create_session(storage, active)
         await session_tools.end_session(
-            storage, active, session_id=session_id, summary="done",
+            storage,
+            active,
+            session_id=session_id,
+            summary="done",
         )
         completed = await storage.get_session(session_id)
 
         # log_annotation
         with pytest.raises(ValueError, match="Cannot append"):
             await logging_tools.log_annotation(
-                storage, completed, category="learning", content="test",
+                storage,
+                completed,
+                category="learning",
+                content="test",
             )
 
         # log_contribution
         with pytest.raises(ValueError, match="Cannot append"):
             await logging_tools.log_contribution(
-                storage, completed, description="test",
-                direction="ai", execution="ai",
+                storage,
+                completed,
+                description="test",
+                direction="ai",
+                execution="ai",
             )
 
         # log_tool_call
         with pytest.raises(ValueError, match="Cannot append"):
             await logging_tools.log_tool_call(
-                storage, completed, server="test", tool_name="test", input={},
+                storage,
+                completed,
+                server="test",
+                tool_name="test",
+                input={},
             )
 
         # log_state_change
         with pytest.raises(ValueError, match="Cannot append"):
             await logging_tools.log_state_change(
-                storage, completed, description="test",
+                storage,
+                completed,
+                description="test",
             )
 
         # propose_decision
         with pytest.raises(ValueError, match="Cannot append"):
             await decision_tools.propose_decision(
-                storage, completed, description="test",
-                proposed_by_type="ai", proposed_by_id="claude",
+                storage,
+                completed,
+                description="test",
+                proposed_by_type="ai",
+                proposed_by_id="claude",
             )
 
 
@@ -299,73 +366,97 @@ class TestReferentialIntegrityEnforcement:
     """Invalid event references must be rejected, not just warned about."""
 
     async def test_invalid_corrects_event_ids_raises(
-        self, storage: JsonFileStorage, active: dict[str, Session],
+        self,
+        storage: JsonFileStorage,
+        active: dict[str, Session],
     ) -> None:
         """corrects_event_ids pointing to nonexistent events must raise ValueError."""
-        session_id, session = await _create_session(storage, active)
+        _session_id, session = await _create_session(storage, active)
         with pytest.raises(ValueError, match="Dangling reference.*corrects_event_ids"):
             await logging_tools.log_annotation(
-                storage, session,
-                category="correction", content="fix",
+                storage,
+                session,
+                category="correction",
+                content="fix",
                 corrects_event_ids=["evt_phantom"],
                 conversation_snippet="that was wrong",
             )
 
     async def test_invalid_retries_event_id_raises(
-        self, storage: JsonFileStorage, active: dict[str, Session],
+        self,
+        storage: JsonFileStorage,
+        active: dict[str, Session],
     ) -> None:
         """retries_event_id pointing to nonexistent event must raise ValueError."""
-        session_id, session = await _create_session(storage, active)
+        _session_id, session = await _create_session(storage, active)
         with pytest.raises(ValueError, match="Dangling reference.*retries_event_id"):
             await logging_tools.log_tool_call(
-                storage, session,
-                server="test", tool_name="test", input={},
+                storage,
+                session,
+                server="test",
+                tool_name="test",
+                input={},
                 retries_event_id="evt_nonexistent",
             )
 
     async def test_invalid_revises_event_id_raises(
-        self, storage: JsonFileStorage, active: dict[str, Session],
+        self,
+        storage: JsonFileStorage,
+        active: dict[str, Session],
     ) -> None:
         """revises_event_id pointing to nonexistent event must raise ValueError."""
-        session_id, session = await _create_session(storage, active)
+        _session_id, session = await _create_session(storage, active)
         with pytest.raises(ValueError, match="Dangling reference.*revises_event_id"):
             await decision_tools.propose_decision(
-                storage, session,
+                storage,
+                session,
                 description="revised decision",
-                proposed_by_type="ai", proposed_by_id="claude",
+                proposed_by_type="ai",
+                proposed_by_id="claude",
                 revises_event_id="evt_ghost",
             )
 
     async def test_invalid_related_decision_ids_raises(
-        self, storage: JsonFileStorage, active: dict[str, Session],
+        self,
+        storage: JsonFileStorage,
+        active: dict[str, Session],
     ) -> None:
         """related_decision_ids pointing to nonexistent events must raise ValueError."""
-        session_id, session = await _create_session(storage, active)
+        _session_id, session = await _create_session(storage, active)
         with pytest.raises(ValueError, match="Dangling reference.*related_decision_ids"):
             await logging_tools.log_contribution(
-                storage, session,
-                description="test contribution", direction="ai", execution="ai",
+                storage,
+                session,
+                description="test contribution",
+                direction="ai",
+                execution="ai",
                 related_decision_ids=["evt_missing"],
                 conversation_snippet="do the thing",
             )
 
     async def test_valid_references_accepted(
-        self, storage: JsonFileStorage, active: dict[str, Session],
+        self,
+        storage: JsonFileStorage,
+        active: dict[str, Session],
     ) -> None:
         """Valid references to existing events must be accepted without error."""
-        session_id, session = await _create_session(storage, active)
+        _session_id, session = await _create_session(storage, active)
 
         # Create events to reference
         dec_id = await decision_tools.propose_decision(
-            storage, session,
+            storage,
+            session,
             description="Use method A",
-            proposed_by_type="ai", proposed_by_id="claude",
+            proposed_by_type="ai",
+            proposed_by_id="claude",
         )
 
         # Valid correction referencing the decision
         ann_id = await logging_tools.log_annotation(
-            storage, session,
-            category="correction", content="Actually use method B",
+            storage,
+            session,
+            category="correction",
+            content="Actually use method B",
             corrects_event_ids=[dec_id],
             conversation_snippet="no, use method B instead",
         )
@@ -373,16 +464,20 @@ class TestReferentialIntegrityEnforcement:
 
         # Valid contribution referencing the decision
         contrib_id = await logging_tools.log_contribution(
-            storage, session,
+            storage,
+            session,
             description="Implemented method B",
-            direction="human", execution="ai",
+            direction="human",
+            execution="ai",
             related_decision_ids=[dec_id],
             conversation_snippet="implement method B",
         )
         assert contrib_id.startswith("evt_")
 
     async def test_event_not_persisted_on_invalid_reference(
-        self, storage: JsonFileStorage, active: dict[str, Session],
+        self,
+        storage: JsonFileStorage,
+        active: dict[str, Session],
     ) -> None:
         """Failed reference validation must not leave the event in the session."""
         session_id, session = await _create_session(storage, active)
@@ -390,8 +485,10 @@ class TestReferentialIntegrityEnforcement:
 
         with pytest.raises(ValueError):
             await logging_tools.log_annotation(
-                storage, session,
-                category="correction", content="fix",
+                storage,
+                session,
+                category="correction",
+                content="fix",
                 corrects_event_ids=["evt_bad"],
             )
 
@@ -446,7 +543,9 @@ class TestScratchpadGeneration:
         # Add events like the real narrative-analysis session
         session.events = [
             TraceEvent(
-                id="evt_001", session_id=session.id, type="decision",
+                id="evt_001",
+                session_id=session.id,
+                type="decision",
                 actor=Actor(type="ai", id="claude"),
                 decision=DecisionData(
                     description="Use Euclidean silhouette for post-UMAP evaluation",
@@ -461,7 +560,9 @@ class TestScratchpadGeneration:
                 ),
             ),
             TraceEvent(
-                id="evt_002", session_id=session.id, type="decision",
+                id="evt_002",
+                session_id=session.id,
+                type="decision",
                 actor=Actor(type="ai", id="claude"),
                 decision=DecisionData(
                     description="Deprioritize 10-K filing parsing",
@@ -471,7 +572,9 @@ class TestScratchpadGeneration:
                 ),
             ),
             TraceEvent(
-                id="evt_003", session_id=session.id, type="annotation",
+                id="evt_003",
+                session_id=session.id,
+                type="annotation",
                 actor=Actor(type="ai", id="claude"),
                 annotation=AnnotationData(
                     category="gotcha",
@@ -480,7 +583,9 @@ class TestScratchpadGeneration:
                 ),
             ),
             TraceEvent(
-                id="evt_004", session_id=session.id, type="contribution",
+                id="evt_004",
+                session_id=session.id,
+                type="contribution",
                 actor=Actor(type="ai", id="claude"),
                 contribution=ContributionData(
                     description="15 Pydantic models for sustainability reports",
@@ -494,7 +599,9 @@ class TestScratchpadGeneration:
                 ),
             ),
             TraceEvent(
-                id="evt_005", session_id=session.id, type="annotation",
+                id="evt_005",
+                session_id=session.id,
+                type="annotation",
                 actor=Actor(type="ai", id="claude"),
                 annotation=AnnotationData(
                     category="learning",
@@ -541,9 +648,7 @@ class TestScratchpadGeneration:
         # No crash on empty events
         assert "### Summary" not in section  # no summary set
 
-    def test_scratchpad_write_creates_file(
-        self, scratchpad_dir: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_scratchpad_write_creates_file(self, scratchpad_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """write_scratchpad creates SCRATCHPAD.md with header and content.
 
         monkeypatch (not set/pop) so the suite-wide TRACE_SCRATCHPAD_DIR
@@ -565,9 +670,7 @@ class TestScratchpadGeneration:
         assert "narrative-analysis" in content
         assert "Test session" in content
 
-    def test_scratchpad_replaces_previous_session(
-        self, scratchpad_dir: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_scratchpad_replaces_previous_session(self, scratchpad_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """write_scratchpad keeps only the most recent session."""
         monkeypatch.setenv("TRACE_SCRATCHPAD_DIR", str(scratchpad_dir))
         # First session
@@ -595,7 +698,9 @@ class TestScratchpadGeneration:
         session = _make_meeting_recorder_session()
         session.events = [
             TraceEvent(
-                id="evt_001", session_id=session.id, type="annotation",
+                id="evt_001",
+                session_id=session.id,
+                type="annotation",
                 actor=Actor(type="ai", id="claude"),
                 annotation=AnnotationData(
                     category="todo",
@@ -615,14 +720,19 @@ class TestScratchpadGeneration:
         session = _make_green_narrative_session()
         session.events = [
             TraceEvent(
-                id="evt_001", session_id=session.id, type="annotation",
+                id="evt_001",
+                session_id=session.id,
+                type="annotation",
                 actor=Actor(type="ai", id="claude"),
                 annotation=AnnotationData(
-                    category="observation", content="Using base conda env",
+                    category="observation",
+                    content="Using base conda env",
                 ),
             ),
             TraceEvent(
-                id="evt_002", session_id=session.id, type="annotation",
+                id="evt_002",
+                session_id=session.id,
+                type="annotation",
                 actor=Actor(type="human", id="researcher"),
                 annotation=AnnotationData(
                     category="correction",
@@ -649,24 +759,30 @@ class TestGreenNarrativePatterns:
     """Validate TRACE behavior with patterns from real narrative-analysis sessions."""
 
     async def test_comprehensive_session_workflow(
-        self, storage: JsonFileStorage, active: dict[str, Session],
+        self,
+        storage: JsonFileStorage,
+        active: dict[str, Session],
     ) -> None:
         """Full narrative-analysis workflow: decisions, contributions, learnings.
 
         Modeled on trace_20260320_ba3fa7 (20 events).
         """
         sid, session = await _create_session(
-            storage, active, project="narrative-analysis",
+            storage,
+            active,
+            project="narrative-analysis",
             description="Deep review of consensus UMAP methodology",
             tags=["consensus-umap", "review"],
         )
 
         # Decision 1: Keep Procrustes as baseline (proactive)
         d1 = await decision_tools.propose_decision(
-            storage, session,
+            storage,
+            session,
             description="Keep Procrustes alignment as comparison baseline",
             rationale="Standard approach, widely published",
-            proposed_by_type="ai", proposed_by_id="claude",
+            proposed_by_type="ai",
+            proposed_by_id="claude",
             suggestion_type="proactive",
             conversation_snippet="should we keep the procrustes alignment?",
         )
@@ -674,24 +790,30 @@ class TestGreenNarrativePatterns:
 
         # Decision 2: Investigate cosine vs euclidean (requested by human)
         d2 = await decision_tools.propose_decision(
-            storage, session,
+            storage,
+            session,
             description="Investigate cosine vs euclidean for post-UMAP evaluation",
-            proposed_by_type="human", proposed_by_id="researcher",
+            proposed_by_type="human",
+            proposed_by_id="researcher",
             suggestion_type="requested",
             conversation_snippet="we need to settle the cosine vs euclidean question",
         )
 
         # Resolve d2 as accepted
         await decision_tools.resolve_decision(
-            storage, session,
-            event_id=d2, disposition="accepted",
-            resolved_by_type="human", resolved_by_id="researcher",
+            storage,
+            session,
+            event_id=d2,
+            disposition="accepted",
+            resolved_by_type="human",
+            resolved_by_id="researcher",
             revision_note="Definitively resolved: Euclidean is correct for post-UMAP",
         )
 
         # Learning annotation
         await logging_tools.log_annotation(
-            storage, session,
+            storage,
+            session,
             category="learning",
             content="Euclidean distance is appropriate for post-UMAP evaluation",
             tags=["methodology", "distance-metric"],
@@ -699,9 +821,11 @@ class TestGreenNarrativePatterns:
 
         # Contribution with all required fields
         await logging_tools.log_contribution(
-            storage, session,
+            storage,
+            session,
             description="15 Pydantic models for sustainability reports",
-            direction="human", execution="ai",
+            direction="human",
+            execution="ai",
             artifact="src/models/corporate.py",
             related_decision_ids=[d1],
             conversation_snippet="create comprehensive data models for all domains",
@@ -709,7 +833,9 @@ class TestGreenNarrativePatterns:
 
         # End session
         result = await session_tools.end_session(
-            storage, active, session_id=sid,
+            storage,
+            active,
+            session_id=sid,
             summary="Deep review session with 5 events",
         )
         assert "Session ended" in result
@@ -717,7 +843,9 @@ class TestGreenNarrativePatterns:
         assert "Decisions (2)" in result
 
     async def test_conversation_snippet_presence_loudly_verified(
-        self, storage: JsonFileStorage, active: dict[str, Session],
+        self,
+        storage: JsonFileStorage,
+        active: dict[str, Session],
     ) -> None:
         """Verify conversation_snippet is properly stored and retrievable.
 
@@ -725,22 +853,27 @@ class TestGreenNarrativePatterns:
         This test FAILS LOUDLY if snippets are lost.
         """
         sid, session = await _create_session(
-            storage, active, project="narrative-analysis",
+            storage,
+            active,
+            project="narrative-analysis",
         )
 
         snippet_text = "what metric should we use for evaluating clusters?"
 
         # Log contribution WITH snippet
         await logging_tools.log_contribution(
-            storage, session,
+            storage,
+            session,
             description="Created evaluation pipeline",
-            direction="human", execution="ai",
+            direction="human",
+            execution="ai",
             conversation_snippet=snippet_text,
         )
 
         # Log annotation WITH snippet
         await logging_tools.log_annotation(
-            storage, session,
+            storage,
+            session,
             category="correction",
             content="Wrong metric used",
             corrects_event_ids=["evt_001"],
@@ -760,27 +893,34 @@ class TestGreenNarrativePatterns:
         assert reloaded.events[0].context.conversation_snippet == snippet_text
 
     async def test_conversation_snippet_missing_produces_warning(
-        self, storage: JsonFileStorage, active: dict[str, Session],
+        self,
+        storage: JsonFileStorage,
+        active: dict[str, Session],
     ) -> None:
         """Missing conversation_snippet on contributions/corrections must warn.
 
         Based on trace_20260316_2e6a9e where 7/7 events had no snippet.
         """
-        sid, session = await _create_session(
-            storage, active, project="narrative-analysis",
+        _sid, session = await _create_session(
+            storage,
+            active,
+            project="narrative-analysis",
         )
 
         # Contribution without snippet should warn
         result = await logging_tools.log_contribution(
-            storage, session,
+            storage,
+            session,
             description="Updated CLAUDE.md",
-            direction="ai", execution="ai",
+            direction="ai",
+            execution="ai",
         )
         assert "conversation_snippet" in result
 
         # Correction without snippet should warn
         result = await logging_tools.log_annotation(
-            storage, session,
+            storage,
+            session,
             category="correction",
             content="Wrong extension listed",
             conversation_snippet=None,  # explicitly missing
@@ -788,7 +928,9 @@ class TestGreenNarrativePatterns:
         assert "conversation_snippet" in result
 
     async def test_correction_micro_session_pattern(
-        self, storage: JsonFileStorage, active: dict[str, Session],
+        self,
+        storage: JsonFileStorage,
+        active: dict[str, Session],
     ) -> None:
         """Correction micro-sessions (like trace_20260320_3a4123) work correctly.
 
@@ -797,7 +939,9 @@ class TestGreenNarrativePatterns:
         in THIS session — this is intentional for cross-session corrections).
         """
         sid, session = await _create_session(
-            storage, active, project="narrative-analysis",
+            storage,
+            active,
+            project="narrative-analysis",
             description="Micro-session: correct missing conversation_snippets",
             tags=["correction", "trace-discipline"],
         )
@@ -807,15 +951,13 @@ class TestGreenNarrativePatterns:
         # rejected by referential integrity. This tests that cross-session
         # corrections need a different approach (annotation without corrects_event_ids,
         # or using content to describe what was corrected).
-        snippet = (
-            "i noticed that all of the trace logs have a warning saying "
-            "that no conversation_snippet was recorded"
-        )
+        snippet = "i noticed that all of the trace logs have a warning saying that no conversation_snippet was recorded"
 
         # Log correction WITHOUT corrects_event_ids (cross-session reference
         # documented in content instead)
         result = await logging_tools.log_annotation(
-            storage, session,
+            storage,
+            session,
             category="correction",
             content="evt_001 in trace_20260319_e4cf1e: missing conversation_snippet. "
             "User said: 'create the Pydantic models for all data domains'",
@@ -824,7 +966,9 @@ class TestGreenNarrativePatterns:
         assert result.startswith("evt_")
 
         await session_tools.end_session(
-            storage, active, session_id=sid,
+            storage,
+            active,
+            session_id=sid,
             summary="Correction micro-session: 1 cross-session correction logged",
         )
 
@@ -833,54 +977,78 @@ class TestWhenAlgorithmsMeetArtistsPatterns:
     """Validate patterns from computational-art sessions."""
 
     async def test_session_with_mixed_dispositions(
-        self, storage: JsonFileStorage, active: dict[str, Session],
+        self,
+        storage: JsonFileStorage,
+        active: dict[str, Session],
     ) -> None:
         """Test a session with accepted, revised, and rejected decisions."""
         sid, session = await _create_session(
-            storage, active, project="computational-art",
+            storage,
+            active,
+            project="computational-art",
             description="Review manuscript structure",
         )
 
         # Accepted decision
         d1 = await decision_tools.propose_decision(
-            storage, session,
+            storage,
+            session,
             description="Use hypothesis-driven narrative structure",
-            proposed_by_type="human", proposed_by_id="researcher",
+            proposed_by_type="human",
+            proposed_by_id="researcher",
             suggestion_type="requested",
         )
         await decision_tools.resolve_decision(
-            storage, session, event_id=d1, disposition="accepted",
-            resolved_by_type="human", resolved_by_id="researcher",
+            storage,
+            session,
+            event_id=d1,
+            disposition="accepted",
+            resolved_by_type="human",
+            resolved_by_id="researcher",
         )
 
         # Revised decision
         d2 = await decision_tools.propose_decision(
-            storage, session,
+            storage,
+            session,
             description="Submit to ACM C&C 2026",
-            proposed_by_type="ai", proposed_by_id="claude",
+            proposed_by_type="ai",
+            proposed_by_id="claude",
             suggestion_type="proactive",
         )
         await decision_tools.resolve_decision(
-            storage, session, event_id=d2, disposition="revised",
-            resolved_by_type="human", resolved_by_id="researcher",
+            storage,
+            session,
+            event_id=d2,
+            disposition="revised",
+            resolved_by_type="human",
+            resolved_by_id="researcher",
             revision_note="Submit methods paper to methods venue instead",
         )
 
         # Rejected decision
         d3 = await decision_tools.propose_decision(
-            storage, session,
+            storage,
+            session,
             description="Include all 6 available figures in main paper",
-            proposed_by_type="ai", proposed_by_id="claude",
+            proposed_by_type="ai",
+            proposed_by_id="claude",
             suggestion_type="proactive",
         )
         await decision_tools.resolve_decision(
-            storage, session, event_id=d3, disposition="rejected",
-            resolved_by_type="human", resolved_by_id="researcher",
+            storage,
+            session,
+            event_id=d3,
+            disposition="rejected",
+            resolved_by_type="human",
+            resolved_by_id="researcher",
             revision_note="Too many figures; select top 3 only",
         )
 
         result = await session_tools.end_session(
-            storage, active, session_id=sid,
+            storage,
+            active,
+            session_id=sid,
             summary="Manuscript review with mixed decision outcomes",
         )
         assert "Decisions (3)" in result
@@ -894,11 +1062,14 @@ class TestMeetingRecorderPatterns:
     """Validate patterns specific to meeting-recorder."""
 
     async def test_transcription_pipeline_session(
-        self, storage: JsonFileStorage, active: dict[str, Session],
+        self,
+        storage: JsonFileStorage,
+        active: dict[str, Session],
     ) -> None:
         """Full transcription pipeline workflow."""
         sid, session = await _create_session(
-            storage, active,
+            storage,
+            active,
             project="meeting-recorder",
             description="Recording esg-group meeting 2026-04-02",
             tags=["meeting", "esg-group", "transcription"],
@@ -906,20 +1077,27 @@ class TestMeetingRecorderPatterns:
 
         # Decision: recording strategy
         d1 = await decision_tools.propose_decision(
-            storage, session,
+            storage,
+            session,
             description="Use Loopback multi-output for app audio + mic",
-            proposed_by_type="ai", proposed_by_id="claude",
+            proposed_by_type="ai",
+            proposed_by_id="claude",
             suggestion_type="proactive",
             conversation_snippet="how should we set up recording?",
         )
         await decision_tools.resolve_decision(
-            storage, session, event_id=d1, disposition="accepted",
-            resolved_by_type="human", resolved_by_id="researcher",
+            storage,
+            session,
+            event_id=d1,
+            disposition="accepted",
+            resolved_by_type="human",
+            resolved_by_id="researcher",
         )
 
         # Tool call: Whisper transcription
         await logging_tools.log_tool_call(
-            storage, session,
+            storage,
+            session,
             server="openai",
             tool_name="audio.transcriptions.create",
             input={"model": "whisper-1", "file": "esg_group_20260402.wav"},
@@ -930,7 +1108,8 @@ class TestMeetingRecorderPatterns:
 
         # Gotcha: device instability
         await logging_tools.log_annotation(
-            storage, session,
+            storage,
+            session,
             category="gotcha",
             content="ffmpeg device indices shift when Bluetooth devices connect/disconnect",
             tags=["ffmpeg", "macos", "audio-device"],
@@ -938,16 +1117,20 @@ class TestMeetingRecorderPatterns:
 
         # Contribution: transcript file
         await logging_tools.log_contribution(
-            storage, session,
+            storage,
+            session,
             description="Transcribed esg-group meeting: 24 segments, 4 speakers",
-            direction="human", execution="ai",
+            direction="human",
+            execution="ai",
             artifact="recordings/esg-group/esg-group_20260402.json",
             related_decision_ids=[d1],
             conversation_snippet="transcribe the meeting recording",
         )
 
         result = await session_tools.end_session(
-            storage, active, session_id=sid,
+            storage,
+            active,
+            session_id=sid,
             summary="Recorded and transcribed esg-group meeting",
         )
         assert "Session ended" in result
@@ -958,17 +1141,22 @@ class TestEmbeddingsPipelinePatterns:
     """Validate patterns from embeddings-pipeline project sessions."""
 
     async def test_projection_head_workflow(
-        self, storage: JsonFileStorage, active: dict[str, Session],
+        self,
+        storage: JsonFileStorage,
+        active: dict[str, Session],
     ) -> None:
         """embeddings-pipeline session: projection head pipeline updates."""
         sid, session = await _create_session(
-            storage, active, project="embeddings-pipeline",
+            storage,
+            active,
+            project="embeddings-pipeline",
             description="Projection head pipeline updates and training",
         )
 
         # State change: conda env switch
         await logging_tools.log_state_change(
-            storage, session,
+            storage,
+            session,
             description="Switched conda environment",
             field="conda_env",
             old_value="nlp_py3_12",
@@ -978,7 +1166,8 @@ class TestEmbeddingsPipelinePatterns:
 
         # Gotcha: env mismatch
         await logging_tools.log_annotation(
-            storage, session,
+            storage,
+            session,
             category="gotcha",
             content="nlp_py3_12 env lacks sentence-transformers needed for projection head",
             tags=["conda", "environment"],
@@ -986,15 +1175,19 @@ class TestEmbeddingsPipelinePatterns:
 
         # Contribution with retroactive note
         await logging_tools.log_contribution(
-            storage, session,
+            storage,
+            session,
             description="Updated projection head training script",
-            direction="collaborative", execution="ai",
+            direction="collaborative",
+            execution="ai",
             artifact="hye_in/projection/train.py",
             conversation_snippet="update the training script",
         )
 
         result = await session_tools.end_session(
-            storage, active, session_id=sid,
+            storage,
+            active,
+            session_id=sid,
             summary="Projection head pipeline updated",
         )
         assert "3 events" in result
@@ -1010,35 +1203,41 @@ class TestConversationSnippetCompleteness:
     """Ensure conversation_snippet is properly handled across all event types."""
 
     async def test_snippet_roundtrip_contribution(
-        self, storage: JsonFileStorage, active: dict[str, Session],
+        self,
+        storage: JsonFileStorage,
+        active: dict[str, Session],
     ) -> None:
         """conversation_snippet on contributions must survive write→read roundtrip."""
         sid, session = await _create_session(storage, active)
         snippet = "create comprehensive data models for all narrative-analysis domains"
 
         await logging_tools.log_contribution(
-            storage, session,
+            storage,
+            session,
             description="15 Pydantic models",
-            direction="human", execution="ai",
+            direction="human",
+            execution="ai",
             conversation_snippet=snippet,
         )
 
         reloaded = await storage.get_session(sid)
         evt = reloaded.events[0]
         assert evt.context.conversation_snippet == snippet, (
-            f"SNIPPET LOST! Expected: {snippet!r}, "
-            f"Got: {evt.context.conversation_snippet!r}"
+            f"SNIPPET LOST! Expected: {snippet!r}, Got: {evt.context.conversation_snippet!r}"
         )
 
     async def test_snippet_roundtrip_annotation(
-        self, storage: JsonFileStorage, active: dict[str, Session],
+        self,
+        storage: JsonFileStorage,
+        active: dict[str, Session],
     ) -> None:
         """conversation_snippet on annotations must survive write→read roundtrip."""
         sid, session = await _create_session(storage, active)
         snippet = "that's wrong, use ml-dev conda env"
 
         await logging_tools.log_annotation(
-            storage, session,
+            storage,
+            session,
             category="observation",
             content="Wrong env used",
             conversation_snippet=snippet,
@@ -1049,16 +1248,20 @@ class TestConversationSnippetCompleteness:
         assert evt.context.conversation_snippet == snippet
 
     async def test_snippet_roundtrip_decision(
-        self, storage: JsonFileStorage, active: dict[str, Session],
+        self,
+        storage: JsonFileStorage,
+        active: dict[str, Session],
     ) -> None:
         """conversation_snippet on decisions must survive write→read roundtrip."""
         sid, session = await _create_session(storage, active)
         snippet = "should we use cosine or euclidean for post-UMAP?"
 
         await decision_tools.propose_decision(
-            storage, session,
+            storage,
+            session,
             description="Use Euclidean for post-UMAP",
-            proposed_by_type="ai", proposed_by_id="claude",
+            proposed_by_type="ai",
+            proposed_by_id="claude",
             conversation_snippet=snippet,
         )
 
@@ -1067,22 +1270,30 @@ class TestConversationSnippetCompleteness:
         assert evt.context.conversation_snippet == snippet
 
     async def test_snippet_preserved_through_decision_resolution(
-        self, storage: JsonFileStorage, active: dict[str, Session],
+        self,
+        storage: JsonFileStorage,
+        active: dict[str, Session],
     ) -> None:
         """conversation_snippet must survive decision resolution updates."""
         sid, session = await _create_session(storage, active)
         snippet = "should we keep the procrustes alignment?"
 
         dec_id = await decision_tools.propose_decision(
-            storage, session,
+            storage,
+            session,
             description="Keep Procrustes as baseline",
-            proposed_by_type="ai", proposed_by_id="claude",
+            proposed_by_type="ai",
+            proposed_by_id="claude",
             conversation_snippet=snippet,
         )
 
         await decision_tools.resolve_decision(
-            storage, session, event_id=dec_id, disposition="accepted",
-            resolved_by_type="human", resolved_by_id="researcher",
+            storage,
+            session,
+            event_id=dec_id,
+            disposition="accepted",
+            resolved_by_type="human",
+            resolved_by_id="researcher",
         )
 
         reloaded = await storage.get_session(sid)
@@ -1102,46 +1313,63 @@ class TestAttributionAuditAccuracy:
     """Attribution audit at session end must accurately reflect all events."""
 
     async def test_audit_counts_all_event_types(
-        self, storage: JsonFileStorage, active: dict[str, Session],
+        self,
+        storage: JsonFileStorage,
+        active: dict[str, Session],
     ) -> None:
         """Audit must correctly count decisions, contributions, corrections."""
         sid, session = await _create_session(storage, active)
 
         # 2 decisions (1 accepted, 1 proposed)
         d1 = await decision_tools.propose_decision(
-            storage, session,
+            storage,
+            session,
             description="Decision 1",
-            proposed_by_type="ai", proposed_by_id="claude",
+            proposed_by_type="ai",
+            proposed_by_id="claude",
         )
         await decision_tools.resolve_decision(
-            storage, session, event_id=d1, disposition="accepted",
-            resolved_by_type="human", resolved_by_id="researcher",
+            storage,
+            session,
+            event_id=d1,
+            disposition="accepted",
+            resolved_by_type="human",
+            resolved_by_id="researcher",
         )
         await decision_tools.propose_decision(
-            storage, session,
+            storage,
+            session,
             description="Decision 2 (unresolved)",
-            proposed_by_type="ai", proposed_by_id="claude",
+            proposed_by_type="ai",
+            proposed_by_id="claude",
         )
 
         # 1 correction
         await logging_tools.log_annotation(
-            storage, session,
-            category="correction", content="Fix",
+            storage,
+            session,
+            category="correction",
+            content="Fix",
             corrects_event_ids=[d1],
             conversation_snippet="that was wrong",
         )
 
         # 1 contribution
         await logging_tools.log_contribution(
-            storage, session,
+            storage,
+            session,
             description="Built the thing",
-            direction="human", execution="ai",
+            direction="human",
+            execution="ai",
             related_decision_ids=[d1],
             conversation_snippet="build it",
         )
 
         result = await session_tools.end_session(
-            storage, active, session_id=sid, summary="test",
+            storage,
+            active,
+            session_id=sid,
+            summary="test",
         )
 
         assert "Contributions (1)" in result
@@ -1151,29 +1379,40 @@ class TestAttributionAuditAccuracy:
         assert "Human interventions: 1" in result  # 1 correction
 
     async def test_audit_detects_ai_self_resolution(
-        self, storage: JsonFileStorage, active: dict[str, Session],
+        self,
+        storage: JsonFileStorage,
+        active: dict[str, Session],
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Audit must flag decisions where AI resolved its own proposal."""
         sid, session = await _create_session(storage, active)
 
         d1 = await decision_tools.propose_decision(
-            storage, session,
+            storage,
+            session,
             description="AI proposes and resolves",
-            proposed_by_type="ai", proposed_by_id="claude",
+            proposed_by_type="ai",
+            proposed_by_id="claude",
         )
 
         # monkeypatch (not set/pop): a bare os.environ.pop() would delete any
         # pre-existing value instead of restoring it.
         monkeypatch.setenv("TRACE_SUPPRESS_SELF_RESOLVE_WARNING", "true")
         await decision_tools.resolve_decision(
-            storage, session, event_id=d1, disposition="accepted",
-            resolved_by_type="ai", resolved_by_id="claude",
+            storage,
+            session,
+            event_id=d1,
+            disposition="accepted",
+            resolved_by_type="ai",
+            resolved_by_id="claude",
         )
         monkeypatch.delenv("TRACE_SUPPRESS_SELF_RESOLVE_WARNING")
 
         result = await session_tools.end_session(
-            storage, active, session_id=sid, summary="test",
+            storage,
+            active,
+            session_id=sid,
+            summary="test",
         )
         assert "AI self-resolutions: 1" in result
 
@@ -1187,26 +1426,34 @@ class TestDecisionChainIntegrity:
     """Decision chains must maintain valid links."""
 
     async def test_valid_revision_chain(
-        self, storage: JsonFileStorage, active: dict[str, Session],
+        self,
+        storage: JsonFileStorage,
+        active: dict[str, Session],
     ) -> None:
         """A chain of decisions linked via revises_event_id must be walkable."""
         sid, session = await _create_session(storage, active)
 
         d1 = await decision_tools.propose_decision(
-            storage, session,
+            storage,
+            session,
             description="Original approach: use method A",
-            proposed_by_type="ai", proposed_by_id="claude",
+            proposed_by_type="ai",
+            proposed_by_id="claude",
         )
         d2 = await decision_tools.propose_decision(
-            storage, session,
+            storage,
+            session,
             description="Revised: use method B instead",
-            proposed_by_type="ai", proposed_by_id="claude",
+            proposed_by_type="ai",
+            proposed_by_id="claude",
             revises_event_id=d1,
         )
         d3 = await decision_tools.propose_decision(
-            storage, session,
+            storage,
+            session,
             description="Final: use method C",
-            proposed_by_type="human", proposed_by_id="researcher",
+            proposed_by_type="human",
+            proposed_by_id="researcher",
             revises_event_id=d2,
         )
 
@@ -1223,16 +1470,20 @@ class TestDecisionChainIntegrity:
         assert dec1.revises_event_id is None
 
     async def test_revision_chain_rejects_invalid_parent(
-        self, storage: JsonFileStorage, active: dict[str, Session],
+        self,
+        storage: JsonFileStorage,
+        active: dict[str, Session],
     ) -> None:
         """revises_event_id pointing to nonexistent event must be rejected."""
-        sid, session = await _create_session(storage, active)
+        _sid, session = await _create_session(storage, active)
 
         with pytest.raises(ValueError, match="Dangling reference.*revises_event_id"):
             await decision_tools.propose_decision(
-                storage, session,
+                storage,
+                session,
                 description="Revises phantom",
-                proposed_by_type="ai", proposed_by_id="claude",
+                proposed_by_type="ai",
+                proposed_by_id="claude",
                 revises_event_id="evt_phantom",
             )
 
@@ -1246,21 +1497,28 @@ class TestToolCallRetryChains:
     """Tool call retry chains must maintain valid references."""
 
     async def test_valid_retry_chain(
-        self, storage: JsonFileStorage, active: dict[str, Session],
+        self,
+        storage: JsonFileStorage,
+        active: dict[str, Session],
     ) -> None:
         """Retry chain: tc1 (error) → tc2 (retries tc1, success)."""
         sid, session = await _create_session(storage, active)
 
         tc1 = await logging_tools.log_tool_call(
-            storage, session,
-            server="openai", tool_name="whisper",
+            storage,
+            session,
+            server="openai",
+            tool_name="whisper",
             input={"file": "meeting.wav"},
-            status="error", error_message="File too large",
+            status="error",
+            error_message="File too large",
         )
 
         tc2 = await logging_tools.log_tool_call(
-            storage, session,
-            server="openai", tool_name="whisper",
+            storage,
+            session,
+            server="openai",
+            tool_name="whisper",
             input={"file": "meeting_chunk1.wav"},
             status="success",
             retries_event_id=tc1,
@@ -1272,15 +1530,20 @@ class TestToolCallRetryChains:
         assert retry_evt.tool_call.retries_event_id == tc1
 
     async def test_retry_rejects_invalid_parent(
-        self, storage: JsonFileStorage, active: dict[str, Session],
+        self,
+        storage: JsonFileStorage,
+        active: dict[str, Session],
     ) -> None:
         """retries_event_id pointing to nonexistent event must be rejected."""
-        sid, session = await _create_session(storage, active)
+        _sid, session = await _create_session(storage, active)
 
         with pytest.raises(ValueError, match="Dangling reference.*retries_event_id"):
             await logging_tools.log_tool_call(
-                storage, session,
-                server="test", tool_name="test", input={},
+                storage,
+                session,
+                server="test",
+                tool_name="test",
+                input={},
                 retries_event_id="evt_nonexistent",
             )
 
@@ -1320,14 +1583,12 @@ class TestRealSessionDataIntegrity:
         if session is None:
             return
 
-        events_with_snippets = [
-            e for e in session.events if e.context.conversation_snippet
-        ]
+        events_with_snippets = [e for e in session.events if e.context.conversation_snippet]
         events_needing_snippets = [
-            e for e in session.events
+            e
+            for e in session.events
             if e.type in ("decision", "contribution")
-            or (e.type == "annotation" and e.annotation
-                and e.annotation.category == "correction")
+            or (e.type == "annotation" and e.annotation and e.annotation.category == "correction")
         ]
 
         # This session should have good snippet coverage
@@ -1351,13 +1612,11 @@ class TestRealSessionDataIntegrity:
 
         for evt in session.events:
             assert evt.type == "annotation", (
-                f"Event {evt.id} is type '{evt.type}', expected 'annotation' "
-                f"in a pure correction micro-session"
+                f"Event {evt.id} is type '{evt.type}', expected 'annotation' in a pure correction micro-session"
             )
             assert evt.annotation is not None
             assert evt.annotation.category == "correction", (
-                f"Event {evt.id} has category '{evt.annotation.category}', "
-                f"expected 'correction'"
+                f"Event {evt.id} has category '{evt.annotation.category}', expected 'correction'"
             )
 
     def test_green_narrative_2e6a9e_has_gotcha(self) -> None:
@@ -1367,9 +1626,7 @@ class TestRealSessionDataIntegrity:
             return
 
         gotchas = [
-            e for e in session.events
-            if e.type == "annotation" and e.annotation
-            and e.annotation.category == "gotcha"
+            e for e in session.events if e.type == "annotation" and e.annotation and e.annotation.category == "gotcha"
         ]
         assert len(gotchas) > 0, (
             "Session trace_20260316_2e6a9e should have at least one gotcha "
@@ -1390,9 +1647,7 @@ class TestRealSessionDataIntegrity:
 
             if ended is not None and status == "active":
                 pytest.fail(
-                    f"STATUS MISMATCH in {path.name}: "
-                    f"ended={ended} but status='active'. "
-                    f"Session should be 'completed'."
+                    f"STATUS MISMATCH in {path.name}: ended={ended} but status='active'. Session should be 'completed'."
                 )
 
 
@@ -1431,8 +1686,7 @@ class TestCrossProjectConsistency:
         if missing_summaries:
             pytest.fail(
                 f"MISSING SUMMARIES on {len(missing_summaries)} completed sessions: "
-                f"{', '.join(missing_summaries[:10])}"
-                + ("..." if len(missing_summaries) > 10 else "")
+                f"{', '.join(missing_summaries[:10])}" + ("..." if len(missing_summaries) > 10 else "")
             )
 
     def test_project_naming_consistency(self) -> None:

--- a/tests/test_installation_health.py
+++ b/tests/test_installation_health.py
@@ -62,6 +62,8 @@ class TestPackageImport:
             TraceEvent,
         )
 
+        for model in (Actor, AnnotationData, ContributionData, DecisionData, SessionMetadata):
+            assert model is not None  # the module exports each required model
         assert hasattr(Session, "model_validate")
         assert hasattr(TraceEvent, "model_validate")
 
@@ -147,8 +149,7 @@ class TestMCPConfiguration:
         # source after --from must be the local path '.', never a PyPI
         # package spec. This is the load-bearing local-only guarantee.
         assert args[args.index("--from") + 1] == ".", (
-            "uvx --from must point at the local path '.', not a PyPI "
-            f"package. Got: {args[args.index('--from') + 1]!r}"
+            f"uvx --from must point at the local path '.', not a PyPI package. Got: {args[args.index('--from') + 1]!r}"
         )
         # A refresh flag must be present so local source changes are picked
         # up on server restart. Either form is valid: `--refresh-package
@@ -179,8 +180,7 @@ class TestMCPConfiguration:
         """The legacy bin/ launcher should not exist (replaced by uvx)."""
         legacy_bin = TRACE_ROOT / "bin" / "trace-mcp-server"
         assert not legacy_bin.exists(), (
-            f"Legacy launcher {legacy_bin} still exists. "
-            "Remove it — all projects now use uvx."
+            f"Legacy launcher {legacy_bin} still exists. Remove it — all projects now use uvx."
         )
 
 
@@ -228,8 +228,7 @@ class TestPyprojectConsistency:
             pytest.fail("Could not find version in pyproject.toml")
 
         assert trace_mcp.__version__ == pyproject_version, (
-            f"Installed version {trace_mcp.__version__} != "
-            f"pyproject.toml version {pyproject_version}"
+            f"Installed version {trace_mcp.__version__} != pyproject.toml version {pyproject_version}"
         )
 
     def test_entry_points_in_pyproject(self) -> None:
@@ -293,10 +292,7 @@ class TestConsumerProjects:
 
             trace_config = servers["trace"]
             if trace_config.get("command") != "uvx":
-                failures.append(
-                    f"{project_dir}/.mcp.json: command is "
-                    f"'{trace_config.get('command')}', expected 'uvx'"
-                )
+                failures.append(f"{project_dir}/.mcp.json: command is '{trace_config.get('command')}', expected 'uvx'")
                 continue
 
             args = trace_config.get("args", [])
@@ -306,7 +302,4 @@ class TestConsumerProjects:
                 failures.append(f"{project_dir}/.mcp.json: missing 'trace-mcp' in uvx args")
 
         if failures:
-            pytest.fail(
-                "Consumer project configuration check failed:\n  - "
-                + "\n  - ".join(failures)
-            )
+            pytest.fail("Consumer project configuration check failed:\n  - " + "\n  - ".join(failures))

--- a/tests/test_integrity_hardening.py
+++ b/tests/test_integrity_hardening.py
@@ -40,13 +40,17 @@ from trace_mcp.tools import logging_tools, query_tools, session_tools
 def _write_invalid_session(directory, session_id: str, project: str) -> Path:
     """Write a VALID-JSON but SCHEMA-INVALID session file (bad status enum)."""
     path = Path(str(directory)) / f"{session_id}.json"
-    path.write_text(json.dumps({
-        "id": session_id,
-        "status": "not-a-valid-status",  # invalid enum -> pydantic ValidationError
-        "created": "2026-06-16T00:00:00Z",
-        "metadata": {"project": project},
-        "events": [],
-    }))
+    path.write_text(
+        json.dumps(
+            {
+                "id": session_id,
+                "status": "not-a-valid-status",  # invalid enum -> pydantic ValidationError
+                "created": "2026-06-16T00:00:00Z",
+                "metadata": {"project": project},
+                "events": [],
+            }
+        )
+    )
     return path
 
 
@@ -178,15 +182,19 @@ async def test_future_version_session_preserves_unknown_fields_on_rewrite(storag
     """
     sid = "trace_20260616_futur1"
     path = Path(str(tmp_path)) / f"{sid}.json"
-    path.write_text(json.dumps({
-        "id": sid,
-        "trace_version": "0.9.9",
-        "status": "active",
-        "created": "2026-06-16T00:00:00Z",
-        "metadata": {"project": "p", "future_meta_field": "keep-meta"},
-        "events": [],
-        "future_top_level_field": "keep-top",
-    }))
+    path.write_text(
+        json.dumps(
+            {
+                "id": sid,
+                "trace_version": "0.9.9",
+                "status": "active",
+                "created": "2026-06-16T00:00:00Z",
+                "metadata": {"project": "p", "future_meta_field": "keep-meta"},
+                "events": [],
+                "future_top_level_field": "keep-top",
+            }
+        )
+    )
 
     s = await storage.get_session(sid)
     await storage.update_session(s)  # full-file rewrite
@@ -202,14 +210,18 @@ async def test_get_session_warns_on_future_schema_version(storage, tmp_path, cap
 
     sid = "trace_20260616_futur2"
     path = Path(str(tmp_path)) / f"{sid}.json"
-    path.write_text(json.dumps({
-        "id": sid,
-        "trace_version": "0.9.9",
-        "status": "active",
-        "created": "2026-06-16T00:00:00Z",
-        "metadata": {"project": "p"},
-        "events": [],
-    }))
+    path.write_text(
+        json.dumps(
+            {
+                "id": sid,
+                "trace_version": "0.9.9",
+                "status": "active",
+                "created": "2026-06-16T00:00:00Z",
+                "metadata": {"project": "p"},
+                "events": [],
+            }
+        )
+    )
 
     with caplog.at_level(logging.WARNING):
         await storage.get_session(sid)
@@ -288,22 +300,28 @@ async def test_extra_allow_preserves_unknown_event_and_nested_fields(storage, tm
     level (not just top-level / metadata) through a rewrite."""
     sid = "trace_20260616_xtraev"
     path = Path(str(tmp_path)) / f"{sid}.json"
-    path.write_text(json.dumps({
-        "id": sid,
-        "trace_version": "0.9.9",
-        "status": "active",
-        "created": "2026-06-16T00:00:00Z",
-        "metadata": {"project": "p"},
-        "events": [{
-            "id": "evt_001",
-            "session_id": sid,
-            "type": "annotation",
-            "timestamp": "2026-06-16T00:00:00Z",
-            "actor": {"type": "ai", "id": "claude"},
-            "annotation": {"category": "gotcha", "content": "x", "future_anno_field": "keep-anno"},
-            "future_event_field": "keep-evt",
-        }],
-    }))
+    path.write_text(
+        json.dumps(
+            {
+                "id": sid,
+                "trace_version": "0.9.9",
+                "status": "active",
+                "created": "2026-06-16T00:00:00Z",
+                "metadata": {"project": "p"},
+                "events": [
+                    {
+                        "id": "evt_001",
+                        "session_id": sid,
+                        "type": "annotation",
+                        "timestamp": "2026-06-16T00:00:00Z",
+                        "actor": {"type": "ai", "id": "claude"},
+                        "annotation": {"category": "gotcha", "content": "x", "future_anno_field": "keep-anno"},
+                        "future_event_field": "keep-evt",
+                    }
+                ],
+            }
+        )
+    )
 
     s = await storage.get_session(sid)
     await storage.update_session(s)
@@ -321,14 +339,18 @@ async def test_no_version_skew_warning_for_equal_or_older_version(storage, tmp_p
     for ver in (SCHEMA_VERSION, "0.3.0"):
         sid = f"trace_20260616_v{ver.replace('.', '')}"
         path = Path(str(tmp_path)) / f"{sid}.json"
-        path.write_text(json.dumps({
-            "id": sid,
-            "trace_version": ver,
-            "status": "active",
-            "created": "2026-06-16T00:00:00Z",
-            "metadata": {"project": "p"},
-            "events": [],
-        }))
+        path.write_text(
+            json.dumps(
+                {
+                    "id": sid,
+                    "trace_version": ver,
+                    "status": "active",
+                    "created": "2026-06-16T00:00:00Z",
+                    "metadata": {"project": "p"},
+                    "events": [],
+                }
+            )
+        )
         caplog.clear()
         with caplog.at_level(logging.WARNING):
             await storage.get_session(sid)
@@ -350,9 +372,7 @@ async def test_end_session_refuses_when_disk_already_completed(storage):
     stale.ended = None
     active2 = {session.id: stale}
 
-    result = await session_tools.end_session(
-        storage, active2, session_id=session.id, summary="SECOND"
-    )
+    result = await session_tools.end_session(storage, active2, session_id=session.id, summary="SECOND")
 
     assert "already ended" in result
     disk = await storage.get_session(session.id)
@@ -361,7 +381,10 @@ async def test_end_session_refuses_when_disk_already_completed(storage):
 
 async def test_locked_disk_session_without_lock_method():
     """The helper degrades to a no-op context for a storage backend with no lock."""
+    from typing import cast
+
     from trace_mcp.schema import Session, SessionMetadata
+    from trace_mcp.storage.base import TraceStorage
     from trace_mcp.storage.locked import locked_disk_session
 
     class NoLockStore:
@@ -380,9 +403,9 @@ async def test_locked_disk_session_without_lock_method():
     mem = Session(id="trace_nolock", metadata=SessionMetadata(project="p"))
 
     # Not persisted -> yields the fallback (by identity).
-    async with locked_disk_session(store, "trace_nolock", fallback=mem) as disk:
+    async with locked_disk_session(cast(TraceStorage, store), "trace_nolock", fallback=mem) as disk:
         assert disk is mem
     store._store["trace_nolock"] = mem
     # Persisted -> yields the disk-loaded object.
-    async with locked_disk_session(store, "trace_nolock", fallback=mem) as disk:
+    async with locked_disk_session(cast(TraceStorage, store), "trace_nolock", fallback=mem) as disk:
         assert disk is mem  # same object the stub returns

--- a/tests/test_invariants.py
+++ b/tests/test_invariants.py
@@ -62,10 +62,7 @@ def _functions_calling(callee: str) -> set[tuple[str, str]]:
         tree = ast.parse(path.read_text(), filename=str(path))
         for node in ast.walk(tree):
             if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
-                if any(
-                    isinstance(sub, ast.Call) and _call_name(sub) == callee
-                    for sub in ast.walk(node)
-                ):
+                if any(isinstance(sub, ast.Call) and _call_name(sub) == callee for sub in ast.walk(node)):
                     found.add((_rel(path), node.name))
     return found
 
@@ -90,8 +87,7 @@ def test_inv1_registered_writers_use_the_locked_helper() -> None:
     helper_users = _functions_calling("locked_disk_session")
     missing = INV1_REGISTERED_WRITERS - helper_users
     assert not missing, (
-        "INV-1 violation: registered write paths that do NOT route through "
-        f"locked_disk_session: {sorted(missing)}."
+        f"INV-1 violation: registered write paths that do NOT route through locked_disk_session: {sorted(missing)}."
     )
 
 

--- a/tests/test_knowledge_metrics.py
+++ b/tests/test_knowledge_metrics.py
@@ -91,10 +91,7 @@ class TestComputeKnowledgeMetrics:
     def test_most_surfaced_caps_at_five(self, tmp_path, monkeypatch):
         monkeypatch.setenv("TRACE_KNOWLEDGE_DIR", str(tmp_path))
         ks = KnowledgeStore(project="test")
-        ks.learnings = [
-            Learning(id=f"lrn_{i:03d}", content=f"learning {i}", recall_count=i)
-            for i in range(1, 10)
-        ]
+        ks.learnings = [Learning(id=f"lrn_{i:03d}", content=f"learning {i}", recall_count=i) for i in range(1, 10)]
         save_store(ks)
         metrics = _compute_knowledge_metrics("test")
         assert len(metrics["most_surfaced"]) == 5

--- a/tests/test_learn_dedup.py
+++ b/tests/test_learn_dedup.py
@@ -67,9 +67,7 @@ class TestFindDuplicate:
     def test_near_match(self):
         ks = KnowledgeStore(project="test")
         add_learning(ks, content="Always use ml-dev conda environment for ML tasks")
-        result = find_duplicate(
-            ks, "Always use the ml-dev conda environment for ML tasks", threshold=0.7
-        )
+        result = find_duplicate(ks, "Always use the ml-dev conda environment for ML tasks", threshold=0.7)
         assert result is not None
 
     def test_no_match(self):
@@ -92,13 +90,9 @@ class TestFindDuplicate:
         ks = KnowledgeStore(project="test")
         add_learning(ks, content="use conda environment ml-dev for ML")
         # Very high threshold — should not match slightly different content
-        result_strict = find_duplicate(
-            ks, "conda environment setup for data science", threshold=0.95
-        )
+        result_strict = find_duplicate(ks, "conda environment setup for data science", threshold=0.95)
         # Lower threshold — should match
-        result_lenient = find_duplicate(
-            ks, "conda environment setup for data science", threshold=0.1
-        )
+        result_lenient = find_duplicate(ks, "conda environment setup for data science", threshold=0.1)
         assert result_strict is None
         assert result_lenient is not None
 
@@ -117,9 +111,7 @@ class TestAddLearningDedup:
     def test_duplicate_content_skipped(self):
         ks = KnowledgeStore(project="test")
         add_learning(ks, content="Always use ml-dev conda environment")
-        result = add_learning_dedup(
-            ks, content="Always use ml-dev conda environment", dedup_threshold=0.5
-        )
+        result = add_learning_dedup(ks, content="Always use ml-dev conda environment", dedup_threshold=0.5)
         assert result.is_duplicate
         assert result.duplicate_of == "lrn_001"
         assert len(ks.learnings) == 1  # No new learning added
@@ -148,9 +140,7 @@ class TestAddLearningDedup:
     def test_different_content_not_deduplicated(self):
         ks = KnowledgeStore(project="test")
         add_learning(ks, content="Always use ml-dev conda environment")
-        result = add_learning_dedup(
-            ks, content="Best pasta recipe uses fresh tomatoes"
-        )
+        result = add_learning_dedup(ks, content="Best pasta recipe uses fresh tomatoes")
         assert not result.is_duplicate
         assert len(ks.learnings) == 2
 
@@ -166,11 +156,7 @@ class TestDedupInExtraction:
         add_learning(ks, content="Always check data types before processing")
 
         # Session with a very similar annotation
-        events = [
-            _make_annotation_event(
-                "evt_001", "learning", "Always check data types before processing"
-            )
-        ]
+        events = [_make_annotation_event("evt_001", "learning", "Always check data types before processing")]
         session = _make_session(events)
 
         new_ids = extract_from_session(ks, session, dedup_threshold=0.5)
@@ -182,11 +168,7 @@ class TestDedupInExtraction:
         ks = KnowledgeStore(project="test")
         add_learning(ks, content="Always check data types before processing")
 
-        events = [
-            _make_annotation_event(
-                "evt_001", "learning", "Always check data types before processing"
-            )
-        ]
+        events = [_make_annotation_event("evt_001", "learning", "Always check data types before processing")]
         session = _make_session(events)
 
         new_ids = extract_from_session(ks, session, dedup_threshold=None)

--- a/tests/test_learn_e2e.py
+++ b/tests/test_learn_e2e.py
@@ -223,10 +223,12 @@ class TestE2EWithBM25:
 
     async def test_idempotent_extraction_across_persist(self, tmp_path):
         """Extract → save → load → extract again → no duplicates."""
-        session = _session([
-            _annotation("evt_001", "learning", "Important insight"),
-            _annotation("evt_002", "gotcha", "Surprising behavior"),
-        ])
+        session = _session(
+            [
+                _annotation("evt_001", "learning", "Important insight"),
+                _annotation("evt_002", "gotcha", "Surprising behavior"),
+            ]
+        )
 
         # First extraction
         ks = KnowledgeStore(project="test")
@@ -247,11 +249,19 @@ class TestE2EWithBM25:
             session_id="sess_A",
         )
         session_b = _session(
-            [_annotation("evt_001", "gotcha", "ffmpeg audio device indices are unstable on macOS", tags=["ffmpeg", "macos"])],
+            [
+                _annotation(
+                    "evt_001", "gotcha", "ffmpeg audio device indices are unstable on macOS", tags=["ffmpeg", "macos"]
+                )
+            ],
             session_id="sess_B",
         )
         session_c = _session(
-            [_annotation("evt_001", "learning", "Log decisions before implementing, not after", tags=["trace", "logging"])],
+            [
+                _annotation(
+                    "evt_001", "learning", "Log decisions before implementing, not after", tags=["trace", "logging"]
+                )
+            ],
             session_id="sess_C",
         )
 
@@ -307,9 +317,7 @@ class TestE2EWithBM25:
 
         loaded = load_store("test", directory=str(tmp_path))
         assert len(loaded.learnings) == 1
-        results = await recall_learnings(
-            loaded.learnings, "info", threshold=0.0, backend=BM25Backend()
-        )
+        results = await recall_learnings(loaded.learnings, "info", threshold=0.0, backend=BM25Backend())
         ids = [r["learning"]["id"] for r in results]
         assert "lrn_001" not in ids
         assert "lrn_002" in ids
@@ -422,9 +430,7 @@ class TestE2EBackendFallback:
         with patch("trace_mcp.extensions.learn.matching._HAS_OPENAI", True):
             with patch("trace_mcp.extensions.learn.matching.AsyncOpenAI") as MockClient:
                 mock_client = AsyncMock()
-                mock_client.chat.completions.create = AsyncMock(
-                    side_effect=Exception("API down")
-                )
+                mock_client.chat.completions.create = AsyncMock(side_effect=Exception("API down"))
                 MockClient.return_value = mock_client
 
                 from trace_mcp.extensions.learn.matching import LLMBackend
@@ -539,15 +545,17 @@ class TestE2ECorrectionChains:
 
     async def test_correction_chain_persists(self, tmp_path):
         """corrects_event_ids from annotations survive extract → persist → load."""
-        session = _session([
-            _annotation(
-                "evt_005",
-                "correction",
-                "Human caught: AI used wrong conda env 3 times",
-                tags=["conda", "correction"],
-                corrects_event_ids=["evt_001", "evt_002", "evt_003"],
-            ),
-        ])
+        session = _session(
+            [
+                _annotation(
+                    "evt_005",
+                    "correction",
+                    "Human caught: AI used wrong conda env 3 times",
+                    tags=["conda", "correction"],
+                    corrects_event_ids=["evt_001", "evt_002", "evt_003"],
+                ),
+            ]
+        )
 
         ks = KnowledgeStore(project="test")
         extract_from_session(ks, session)

--- a/tests/test_learn_embeddings.py
+++ b/tests/test_learn_embeddings.py
@@ -97,11 +97,14 @@ class TestCosineSimilarityMatrix:
 
     def test_batch_scoring(self):
         q = [1.0, 0.0, 0.0]
-        matrix = np.array([
-            [1.0, 0.0, 0.0],  # identical
-            [0.0, 1.0, 0.0],  # orthogonal
-            [0.7, 0.7, 0.0],  # 45 degrees
-        ], dtype=np.float32)
+        matrix = np.array(
+            [
+                [1.0, 0.0, 0.0],  # identical
+                [0.0, 1.0, 0.0],  # orthogonal
+                [0.7, 0.7, 0.0],  # 45 degrees
+            ],
+            dtype=np.float32,
+        )
         result = cosine_similarity_matrix(q, matrix)
         assert len(result) == 3
         assert float(result[0]) == pytest.approx(1.0, abs=1e-5)
@@ -322,10 +325,14 @@ class TestEmbeddingBackend:
         backend_no_tags = EmbeddingBackend(provider=provider, tag_weight=0.0)
 
         results_with = await backend_with_tags.score_batch(
-            [CONDA_LEARNING], "environment", context_tags=["conda", "env"],
+            [CONDA_LEARNING],
+            "environment",
+            context_tags=["conda", "env"],
         )
         results_without = await backend_no_tags.score_batch(
-            [CONDA_LEARNING], "environment", context_tags=["conda", "env"],
+            [CONDA_LEARNING],
+            "environment",
+            context_tags=["conda", "env"],
         )
         # Tag weight of 0.5 with perfect tag match should boost score
         score_with = results_with[0][1]
@@ -367,7 +374,9 @@ class TestEmbeddingBackend:
         backend = EmbeddingBackend(provider=provider, tag_weight=0.0)
         # Opposite vector learning
         opposite_lrn = Learning(
-            id="lrn_neg", content="x", embedding=[-1.0, 0.0, 0.0, 0.0],
+            id="lrn_neg",
+            content="x",
+            embedding=[-1.0, 0.0, 0.0, 0.0],
             embedding_model="test-model",
         )
         results = await backend.score_batch([opposite_lrn], "x")
@@ -388,12 +397,18 @@ class TestEmbeddingBackendWithDecay:
             update={"created": datetime.now(UTC) - timedelta(days=60)},
         )
         results = await recall_learnings(
-            [old_learning], "conda environment",
-            backend=backend, decay_config=decay, threshold=0.0,
+            [old_learning],
+            "conda environment",
+            backend=backend,
+            decay_config=decay,
+            threshold=0.0,
         )
         fresh_results = await recall_learnings(
-            [CONDA_LEARNING], "conda environment",
-            backend=backend, decay_config=decay, threshold=0.0,
+            [CONDA_LEARNING],
+            "conda environment",
+            backend=backend,
+            decay_config=decay,
+            threshold=0.0,
         )
         assert results[0]["score"] < fresh_results[0]["score"]
 
@@ -410,7 +425,11 @@ class TestEmbeddingBackendWithDecay:
             },
         )
         results = await recall_learnings(
-            [evergreen], "conda", backend=backend, decay_config=decay, threshold=0.0,
+            [evergreen],
+            "conda",
+            backend=backend,
+            decay_config=decay,
+            threshold=0.0,
         )
         # Score should be at least floor * raw_score (which is high for identical vectors)
         assert results[0]["score"] > 0.5
@@ -424,10 +443,18 @@ class TestEmbeddingBackendWithDecay:
             update={"created": datetime.now(UTC) - timedelta(days=9999)},
         )
         results = await recall_learnings(
-            [old], "conda", backend=backend, decay_config=decay, threshold=0.0,
+            [old],
+            "conda",
+            backend=backend,
+            decay_config=decay,
+            threshold=0.0,
         )
         fresh = await recall_learnings(
-            [CONDA_LEARNING], "conda", backend=backend, decay_config=decay, threshold=0.0,
+            [CONDA_LEARNING],
+            "conda",
+            backend=backend,
+            decay_config=decay,
+            threshold=0.0,
         )
         # With decay disabled, age makes no difference
         assert results[0]["score"] == pytest.approx(fresh[0]["score"], abs=0.01)
@@ -496,16 +523,20 @@ class TestSidecarNpyCache:
 class TestStaleEmbeddingDetection:
     def test_detects_stale_when_model_changes(self):
         lrn = Learning(
-            id="lrn_001", content="test",
-            embedding=[0.1, 0.2], embedding_model="old-model",
+            id="lrn_001",
+            content="test",
+            embedding=[0.1, 0.2],
+            embedding_model="old-model",
         )
         # Stale if learning's model != current model
         assert lrn.embedding_model != "new-model"
 
     def test_no_stale_when_model_matches(self):
         lrn = Learning(
-            id="lrn_001", content="test",
-            embedding=[0.1, 0.2], embedding_model="current-model",
+            id="lrn_001",
+            content="test",
+            embedding=[0.1, 0.2],
+            embedding_model="current-model",
         )
         assert lrn.embedding_model == "current-model"
 
@@ -571,7 +602,8 @@ class TestBackwardCompatibility:
         provider = _mock_provider(CONDA_VEC)
         backend = EmbeddingBackend(provider=provider)
         results = await backend.score_batch(
-            [CONDA_LEARNING, NONEMB_LEARNING], "conda",
+            [CONDA_LEARNING, NONEMB_LEARNING],
+            "conda",
         )
         assert len(results) == 2
 

--- a/tests/test_learn_embeddings_e2e.py
+++ b/tests/test_learn_embeddings_e2e.py
@@ -42,31 +42,46 @@ class TestEmbeddingE2ESubprocess:
                 await _initialize_server(proc)
 
                 # Add the target learning + a distractor (BM25 needs a corpus)
-                result = await _call_tool(proc, "trace_learn_add", {
-                    "project": "e2e-embed-test",
-                    "content": "Always use the ml-dev conda environment, not base",
-                    "category": "gotcha",
-                    "tags": ["conda", "env"],
-                }, request_id=10)
+                result = await _call_tool(
+                    proc,
+                    "trace_learn_add",
+                    {
+                        "project": "e2e-embed-test",
+                        "content": "Always use the ml-dev conda environment, not base",
+                        "category": "gotcha",
+                        "tags": ["conda", "env"],
+                    },
+                    request_id=10,
+                )
 
                 response_text = result["result"]["content"][0]["text"]
                 data = json.loads(response_text)
                 assert "added" in data or "duplicate" in data
 
-                await _call_tool(proc, "trace_learn_add", {
-                    "project": "e2e-embed-test",
-                    "content": "Fresh pasta needs semolina flour and eggs",
-                    "category": "gotcha",
-                    "tags": ["food"],
-                }, request_id=11)
+                await _call_tool(
+                    proc,
+                    "trace_learn_add",
+                    {
+                        "project": "e2e-embed-test",
+                        "content": "Fresh pasta needs semolina flour and eggs",
+                        "category": "gotcha",
+                        "tags": ["food"],
+                    },
+                    request_id=11,
+                )
 
                 # Recall — an overlapping query must surface the conda learning first
-                recall_result = await _call_tool(proc, "trace_learn_recall", {
-                    "project": "e2e-embed-test",
-                    "context": "which conda environment should I use",
-                    "threshold": 0.05,
-                    "limit": 5,
-                }, request_id=12)
+                recall_result = await _call_tool(
+                    proc,
+                    "trace_learn_recall",
+                    {
+                        "project": "e2e-embed-test",
+                        "context": "which conda environment should I use",
+                        "threshold": 0.05,
+                        "limit": 5,
+                    },
+                    request_id=12,
+                )
 
                 recall_text = recall_result["result"]["content"][0]["text"]
                 recall_data = json.loads(recall_text)
@@ -84,24 +99,39 @@ class TestEmbeddingE2ESubprocess:
                 await _initialize_server(proc)
 
                 # Add two learnings with different content
-                await _call_tool(proc, "trace_learn_add", {
-                    "project": "e2e-scores",
-                    "content": "BM25 uses term frequency and inverse document frequency",
-                    "tags": ["bm25", "search"],
-                }, request_id=20)
-                await _call_tool(proc, "trace_learn_add", {
-                    "project": "e2e-scores",
-                    "content": "Fresh pasta needs semolina flour and eggs",
-                    "tags": ["food"],
-                }, request_id=21)
+                await _call_tool(
+                    proc,
+                    "trace_learn_add",
+                    {
+                        "project": "e2e-scores",
+                        "content": "BM25 uses term frequency and inverse document frequency",
+                        "tags": ["bm25", "search"],
+                    },
+                    request_id=20,
+                )
+                await _call_tool(
+                    proc,
+                    "trace_learn_add",
+                    {
+                        "project": "e2e-scores",
+                        "content": "Fresh pasta needs semolina flour and eggs",
+                        "tags": ["food"],
+                    },
+                    request_id=21,
+                )
 
                 # Recall — search-related query with low threshold
-                result = await _call_tool(proc, "trace_learn_recall", {
-                    "project": "e2e-scores",
-                    "context": "BM25 term frequency search ranking",
-                    "threshold": 0.05,
-                    "limit": 5,
-                }, request_id=22)
+                result = await _call_tool(
+                    proc,
+                    "trace_learn_recall",
+                    {
+                        "project": "e2e-scores",
+                        "context": "BM25 term frequency search ranking",
+                        "threshold": 0.05,
+                        "limit": 5,
+                    },
+                    request_id=22,
+                )
 
                 data = json.loads(result["result"]["content"][0]["text"])
                 assert data["total"] >= 1
@@ -111,7 +141,6 @@ class TestEmbeddingE2ESubprocess:
 
             finally:
                 await _shutdown_server(proc)
-
 
 
 # ── Real data E2E tests ──────────────────────────────────────────────────
@@ -136,6 +165,7 @@ class TestRealDataE2E:
             knowledge_dir = Path(sessions_dir) / "knowledge"
             knowledge_dir.mkdir()
             import shutil
+
             shutil.copy2(_REAL_STORE, knowledge_dir / "TRACE.json")
 
             env_override = {"TRACE_KNOWLEDGE_DIR": str(knowledge_dir)}
@@ -145,11 +175,16 @@ class TestRealDataE2E:
             try:
                 await _initialize_server(proc)
 
-                result = await _call_tool(proc, "trace_learn_recall", {
-                    "project": "TRACE",
-                    "context": "schema validation rules for actor types",
-                    "limit": 5,
-                }, request_id=50)
+                result = await _call_tool(
+                    proc,
+                    "trace_learn_recall",
+                    {
+                        "project": "TRACE",
+                        "context": "schema validation rules for actor types",
+                        "limit": 5,
+                    },
+                    request_id=50,
+                )
 
                 data = json.loads(result["result"]["content"][0]["text"])
                 assert data["total"] >= 1

--- a/tests/test_learn_embeddings_integration.py
+++ b/tests/test_learn_embeddings_integration.py
@@ -35,7 +35,7 @@ def _mock_provider(vectors: list[list[float]] | None = None, model_name: str = "
 
     async def _embed(texts):
         if vectors:
-            return vectors[:len(texts)]
+            return vectors[: len(texts)]
         # Default: return distinct vectors for each text
         return [[float(i), 0.0, 0.0, 0.0] for i in range(len(texts))]
 
@@ -62,8 +62,10 @@ class TestEmbeddingFullPipeline:
         provider = _mock_provider([ML_VEC])
         backend = EmbeddingBackend(provider=provider)
         results = await recall_learnings(
-            loaded.learnings, "which anaconda environment?",
-            backend=backend, threshold=0.0,
+            loaded.learnings,
+            "which anaconda environment?",
+            backend=backend,
+            threshold=0.0,
         )
         assert len(results) == 1
         assert results[0]["score"] > 0.5
@@ -96,8 +98,10 @@ class TestEmbeddingFullPipeline:
         # BM25 test — "anaconda" has no keyword overlap with "conda"
         bm25 = BM25Backend()
         bm25_results = await recall_learnings(
-            loaded.learnings, "which anaconda environment should I activate",
-            backend=bm25, threshold=0.0,
+            loaded.learnings,
+            "which anaconda environment should I activate",
+            backend=bm25,
+            threshold=0.0,
         )
         bm25_score = bm25_results[0]["score"] if bm25_results else 0.0
 
@@ -105,8 +109,10 @@ class TestEmbeddingFullPipeline:
         provider = _mock_provider([ML_VEC])  # close to CONDA_VEC
         emb_backend = EmbeddingBackend(provider=provider)
         emb_results = await recall_learnings(
-            loaded.learnings, "which anaconda environment should I activate",
-            backend=emb_backend, threshold=0.0,
+            loaded.learnings,
+            "which anaconda environment should I activate",
+            backend=emb_backend,
+            threshold=0.0,
         )
         emb_score = emb_results[0]["score"]
 
@@ -133,8 +139,11 @@ class TestEmbeddingFullPipeline:
         provider = _mock_provider([CONDA_VEC])
         backend = EmbeddingBackend(provider=provider)
         results = await recall_learnings(
-            loaded.learnings, "conda environment",
-            backend=backend, threshold=0.0, limit=3,
+            loaded.learnings,
+            "conda environment",
+            backend=backend,
+            threshold=0.0,
+            limit=3,
         )
         assert results[0]["learning"]["content"] == "Always use conda ml-dev"
 
@@ -160,8 +169,10 @@ class TestBackendFallbackChain:
         backend = EmbeddingBackend(provider=provider)
         learnings = [
             Learning(
-                id="lrn_001", content="conda env",
-                embedding=CONDA_VEC, embedding_model="test",
+                id="lrn_001",
+                content="conda env",
+                embedding=CONDA_VEC,
+                embedding_model="test",
             ),
             Learning(id="lrn_002", content="conda setup"),  # no embedding
         ]
@@ -175,8 +186,10 @@ class TestBackendFallbackChain:
         backend = EmbeddingBackend(provider=provider)
         learnings = [
             Learning(
-                id="lrn_001", content="test",
-                embedding=CONDA_VEC, embedding_model="test",
+                id="lrn_001",
+                content="test",
+                embedding=CONDA_VEC,
+                embedding_model="test",
             ),
         ]
         with pytest.raises(RuntimeError, match="API down"):
@@ -190,8 +203,10 @@ class TestModelChangeIntegration:
     def test_stale_detection(self):
         """Learnings with different embedding_model are stale."""
         lrn = Learning(
-            id="lrn_001", content="test",
-            embedding=[0.1], embedding_model="old-model",
+            id="lrn_001",
+            content="test",
+            embedding=[0.1],
+            embedding_model="old-model",
         )
         assert lrn.embedding_model != "new-model"
         assert lrn.embedding is not None
@@ -199,8 +214,10 @@ class TestModelChangeIntegration:
     async def test_fresh_embeddings_not_stale(self):
         """Learnings with matching embedding_model are fresh."""
         lrn = Learning(
-            id="lrn_001", content="test",
-            embedding=[0.1], embedding_model="current-model",
+            id="lrn_001",
+            content="test",
+            embedding=[0.1],
+            embedding_model="current-model",
         )
         assert lrn.embedding_model == "current-model"
 
@@ -247,8 +264,11 @@ class TestRealDataEmbeddings:
             pytest.skip("real store currently has no actor-related learning to recall")
         bm25 = BM25Backend()
         results = await recall_learnings(
-            ks.learnings, "schema validation rules for actors",
-            backend=bm25, threshold=0.0, limit=5,
+            ks.learnings,
+            "schema validation rules for actors",
+            backend=bm25,
+            threshold=0.0,
+            limit=5,
         )
         assert len(results) > 0
         ids = {r["learning"]["id"] for r in results}
@@ -275,8 +295,11 @@ class TestRealDataEmbeddings:
 
         backend = EmbeddingBackend(provider=provider)
         results = await recall_learnings(
-            ks.learnings, "audio recording problems on mac",
-            backend=backend, threshold=0.0, limit=5,
+            ks.learnings,
+            "audio recording problems on mac",
+            backend=backend,
+            threshold=0.0,
+            limit=5,
         )
         assert len(results) > 0
         expected = self._ids_with_content(ks, "audio") | self._ids_with_content(ks, "ffmpeg")

--- a/tests/test_learn_extraction.py
+++ b/tests/test_learn_extraction.py
@@ -132,9 +132,9 @@ class TestAnnotationExtraction:
         assert ks.learnings[0].source_event == "evt_001"
 
     def test_extract_correction(self):
-        session = _session([
-            _annotation("evt_001", "correction", "Wrong env — use ml-dev", corrects_event_ids=["evt_000"])
-        ])
+        session = _session(
+            [_annotation("evt_001", "correction", "Wrong env — use ml-dev", corrects_event_ids=["evt_000"])]
+        )
         ks = KnowledgeStore(project="test")
         new_ids = extract_from_session(ks, session)
         assert len(new_ids) == 1
@@ -142,14 +142,16 @@ class TestAnnotationExtraction:
 
     def test_extract_correction_preserves_corrects_event_ids(self):
         """corrects_event_ids from annotation are preserved in the learning."""
-        session = _session([
-            _annotation(
-                "evt_001",
-                "correction",
-                "Fixed wrong env",
-                corrects_event_ids=["evt_010", "evt_011"],
-            )
-        ])
+        session = _session(
+            [
+                _annotation(
+                    "evt_001",
+                    "correction",
+                    "Fixed wrong env",
+                    corrects_event_ids=["evt_010", "evt_011"],
+                )
+            ]
+        )
         ks = KnowledgeStore(project="test")
         extract_from_session(ks, session)
         assert ks.learnings[0].corrects_event_ids == ["evt_010", "evt_011"]
@@ -162,9 +164,7 @@ class TestAnnotationExtraction:
         assert ks.learnings[0].category == "gotcha"
 
     def test_extract_preserves_tags(self):
-        session = _session([
-            _annotation("evt_001", "learning", "test", tags=["conda", "env"])
-        ])
+        session = _session([_annotation("evt_001", "learning", "test", tags=["conda", "env"])])
         ks = KnowledgeStore(project="test")
         extract_from_session(ks, session)
         assert ks.learnings[0].tags == ["conda", "env"]
@@ -196,14 +196,16 @@ class TestDecisionExtraction:
     """Tests for extracting learnings from decision events."""
 
     def test_extract_rejected_decision(self):
-        session = _session([
-            _decision(
-                "evt_001",
-                "Use base conda env",
-                disposition="rejected",
-                revision_note="Always use ml-dev",
-            )
-        ])
+        session = _session(
+            [
+                _decision(
+                    "evt_001",
+                    "Use base conda env",
+                    disposition="rejected",
+                    revision_note="Always use ml-dev",
+                )
+            ]
+        )
         ks = KnowledgeStore(project="test")
         new_ids = extract_from_session(ks, session)
         assert len(new_ids) == 1
@@ -211,23 +213,23 @@ class TestDecisionExtraction:
         assert ks.learnings[0].category == "decision"
 
     def test_extract_revised_decision(self):
-        session = _session([
-            _decision(
-                "evt_001",
-                "Use GPU for training",
-                disposition="revised",
-                revision_note="Use CPU — GPU quota exhausted",
-            )
-        ])
+        session = _session(
+            [
+                _decision(
+                    "evt_001",
+                    "Use GPU for training",
+                    disposition="revised",
+                    revision_note="Use CPU — GPU quota exhausted",
+                )
+            ]
+        )
         ks = KnowledgeStore(project="test")
         new_ids = extract_from_session(ks, session)
         assert len(new_ids) == 1
         assert "CPU" in ks.learnings[0].content
 
     def test_skip_accepted_decision(self):
-        session = _session([
-            _decision("evt_001", "Use pandas", disposition="accepted")
-        ])
+        session = _session([_decision("evt_001", "Use pandas", disposition="accepted")])
         ks = KnowledgeStore(project="test")
         assert extract_from_session(ks, session) == []
 
@@ -238,15 +240,17 @@ class TestDecisionExtraction:
 
     def test_preserves_rationale(self):
         """Decision rationale is included in the extracted learning content."""
-        session = _session([
-            _decision(
-                "evt_001",
-                "Switch to BM25",
-                disposition="rejected",
-                rationale="Jaccard is too simple for semantic matching",
-                revision_note="Use LLM instead",
-            )
-        ])
+        session = _session(
+            [
+                _decision(
+                    "evt_001",
+                    "Switch to BM25",
+                    disposition="rejected",
+                    rationale="Jaccard is too simple for semantic matching",
+                    revision_note="Use LLM instead",
+                )
+            ]
+        )
         ks = KnowledgeStore(project="test")
         extract_from_session(ks, session)
         content = ks.learnings[0].content
@@ -255,16 +259,18 @@ class TestDecisionExtraction:
 
     def test_preserves_suggestion_type_as_tag(self):
         """suggestion_type is added as a tag on the extracted learning."""
-        session = _session([
-            _decision(
-                "evt_001",
-                "Use BM25",
-                disposition="rejected",
-                suggestion_type="proactive",
-                revision_note="Rejected",
-                tags=["matching"],
-            )
-        ])
+        session = _session(
+            [
+                _decision(
+                    "evt_001",
+                    "Use BM25",
+                    disposition="rejected",
+                    suggestion_type="proactive",
+                    revision_note="Rejected",
+                    tags=["matching"],
+                )
+            ]
+        )
         ks = KnowledgeStore(project="test")
         extract_from_session(ks, session)
         assert "proactive" in ks.learnings[0].tags
@@ -278,15 +284,17 @@ class TestContributionExtraction:
     """Tests for extracting learnings from contribution events."""
 
     def test_extract_collaborative_contribution(self):
-        session = _session([
-            _contribution(
-                "evt_001",
-                "Developed hybrid matching approach",
-                direction="collaborative",
-                artifact="matching.py",
-                tags=["matching"],
-            )
-        ])
+        session = _session(
+            [
+                _contribution(
+                    "evt_001",
+                    "Developed hybrid matching approach",
+                    direction="collaborative",
+                    artifact="matching.py",
+                    tags=["matching"],
+                )
+            ]
+        )
         ks = KnowledgeStore(project="test")
         new_ids = extract_from_session(ks, session)
         assert len(new_ids) == 1
@@ -295,16 +303,12 @@ class TestContributionExtraction:
         assert ks.learnings[0].category == "observation"
 
     def test_skip_human_directed_contribution(self):
-        session = _session([
-            _contribution("evt_001", "Wrote the code", direction="human")
-        ])
+        session = _session([_contribution("evt_001", "Wrote the code", direction="human")])
         ks = KnowledgeStore(project="test")
         assert extract_from_session(ks, session) == []
 
     def test_skip_ai_directed_contribution(self):
-        session = _session([
-            _contribution("evt_001", "AI suggested this", direction="ai")
-        ])
+        session = _session([_contribution("evt_001", "AI suggested this", direction="ai")])
         ks = KnowledgeStore(project="test")
         assert extract_from_session(ks, session) == []
 
@@ -314,10 +318,12 @@ class TestContributionExtraction:
 
 class TestIdempotency:
     def test_double_extraction_no_duplicates(self):
-        session = _session([
-            _annotation("evt_001", "learning", "insight A"),
-            _annotation("evt_002", "gotcha", "gotcha B"),
-        ])
+        session = _session(
+            [
+                _annotation("evt_001", "learning", "insight A"),
+                _annotation("evt_002", "gotcha", "gotcha B"),
+            ]
+        )
         ks = KnowledgeStore(project="test")
 
         ids1 = extract_from_session(ks, session)
@@ -351,24 +357,26 @@ class TestIdempotency:
 class TestMultiEventExtraction:
     def test_mixed_events(self):
         """Extract from a session with multiple event types."""
-        session = _session([
-            _annotation("evt_001", "correction", "Wrong env", corrects_event_ids=["evt_000"]),
-            _annotation("evt_002", "learning", "Always activate first"),
-            _annotation("evt_003", "observation", "Pipeline took 45 min"),
-            _decision(
-                "evt_004",
-                "Use GPU",
-                disposition="revised",
-                revision_note="Use CPU instead",
-                tags=["compute"],
-            ),
-            _contribution(
-                "evt_005",
-                "Collaborative analysis approach",
-                direction="collaborative",
-                tags=["analysis"],
-            ),
-        ])
+        session = _session(
+            [
+                _annotation("evt_001", "correction", "Wrong env", corrects_event_ids=["evt_000"]),
+                _annotation("evt_002", "learning", "Always activate first"),
+                _annotation("evt_003", "observation", "Pipeline took 45 min"),
+                _decision(
+                    "evt_004",
+                    "Use GPU",
+                    disposition="revised",
+                    revision_note="Use CPU instead",
+                    tags=["compute"],
+                ),
+                _contribution(
+                    "evt_005",
+                    "Collaborative analysis approach",
+                    direction="collaborative",
+                    tags=["analysis"],
+                ),
+            ]
+        )
         ks = KnowledgeStore(project="test")
         new_ids = extract_from_session(ks, session)
         # correction + learning + revised decision + collaborative contribution = 4
@@ -402,10 +410,12 @@ class TestLLMExtraction:
 
     async def test_llm_extraction_basic(self):
         config = self._make_config()
-        session = _session([
-            _annotation("evt_001", "correction", "Wrong conda env"),
-            _annotation("evt_002", "learning", "Always use ml-dev"),
-        ])
+        session = _session(
+            [
+                _annotation("evt_001", "correction", "Wrong conda env"),
+                _annotation("evt_002", "learning", "Always use ml-dev"),
+            ]
+        )
         ks = KnowledgeStore(project="test")
 
         llm_response = {
@@ -445,17 +455,17 @@ class TestLLMExtraction:
     async def test_llm_extraction_fallback_on_error(self):
         """Permissive mode: when LLM fails, falls back to rule-based extraction."""
         config = self._make_config(strict=False)
-        session = _session([
-            _annotation("evt_001", "learning", "Rule-based fallback content"),
-        ])
+        session = _session(
+            [
+                _annotation("evt_001", "learning", "Rule-based fallback content"),
+            ]
+        )
         ks = KnowledgeStore(project="test")
 
         with patch("trace_mcp.extensions.learn.extraction._HAS_OPENAI", True):
             with patch("trace_mcp.extensions.learn.extraction.AsyncOpenAI") as MockClient:
                 mock_client = AsyncMock()
-                mock_client.chat.completions.create = AsyncMock(
-                    side_effect=Exception("API error")
-                )
+                mock_client.chat.completions.create = AsyncMock(side_effect=Exception("API error"))
                 MockClient.return_value = mock_client
 
                 new_ids = await extract_from_session_llm(ks, session, config)
@@ -469,17 +479,17 @@ class TestLLMExtraction:
         from trace_mcp.extensions.learn.config import LLMFallbackError
 
         config = self._make_config(strict=True)
-        session = _session([
-            _annotation("evt_001", "learning", "Rule-based fallback content"),
-        ])
+        session = _session(
+            [
+                _annotation("evt_001", "learning", "Rule-based fallback content"),
+            ]
+        )
         ks = KnowledgeStore(project="test")
 
         with patch("trace_mcp.extensions.learn.extraction._HAS_OPENAI", True):
             with patch("trace_mcp.extensions.learn.extraction.AsyncOpenAI") as MockClient:
                 mock_client = AsyncMock()
-                mock_client.chat.completions.create = AsyncMock(
-                    side_effect=Exception("API error")
-                )
+                mock_client.chat.completions.create = AsyncMock(side_effect=Exception("API error"))
                 MockClient.return_value = mock_client
 
                 with pytest.raises(LLMFallbackError, match="LLM extraction failed"):
@@ -488,13 +498,17 @@ class TestLLMExtraction:
     async def test_llm_extraction_idempotent(self):
         """LLM extraction skips already-extracted events."""
         config = self._make_config()
-        session = _session([
-            _annotation("evt_001", "learning", "Already extracted"),
-        ])
+        session = _session(
+            [
+                _annotation("evt_001", "learning", "Already extracted"),
+            ]
+        )
         ks = KnowledgeStore(project="test")
         # Pre-add a learning from this event
         ks.learnings.append(
-            Learning(id="lrn_001", content="Already extracted", source_session="test_session_001", source_event="evt_001")
+            Learning(
+                id="lrn_001", content="Already extracted", source_session="test_session_001", source_event="evt_001"
+            )
         )
 
         llm_response = {
@@ -574,10 +588,12 @@ class TestAutoExtraction:
 class TestExtractionEdgeCases:
     def test_extract_corrections_only(self):
         """Session with only correction annotations extracts them all."""
-        session = _session([
-            _annotation("evt_001", "correction", "Fix A", corrects_event_ids=["evt_000"]),
-            _annotation("evt_002", "correction", "Fix B", corrects_event_ids=["evt_000"]),
-        ])
+        session = _session(
+            [
+                _annotation("evt_001", "correction", "Fix A", corrects_event_ids=["evt_000"]),
+                _annotation("evt_002", "correction", "Fix B", corrects_event_ids=["evt_000"]),
+            ]
+        )
         ks = KnowledgeStore(project="test")
         new_ids = extract_from_session(ks, session)
         assert len(new_ids) == 2
@@ -593,16 +609,18 @@ class TestExtractionEdgeCases:
 
     def test_extract_collaborative_contribution(self):
         """Collaborative direction contributions are extracted as observations."""
-        session = _session([
-            _contribution(
-                "evt_001",
-                "Joint brainstorming produced new approach",
-                direction="collaborative",
-                execution="ai",
-                artifact="src/new_approach.py",
-                tags=["collab"],
-            )
-        ])
+        session = _session(
+            [
+                _contribution(
+                    "evt_001",
+                    "Joint brainstorming produced new approach",
+                    direction="collaborative",
+                    execution="ai",
+                    artifact="src/new_approach.py",
+                    tags=["collab"],
+                )
+            ]
+        )
         ks = KnowledgeStore(project="test")
         new_ids = extract_from_session(ks, session)
         assert len(new_ids) == 1

--- a/tests/test_learn_matching.py
+++ b/tests/test_learn_matching.py
@@ -122,9 +122,7 @@ class TestJaccardBackend:
 
     def test_score_learning_with_tags(self):
         score_no_tags = score_learning(CONDA_LEARNING, "conda environment setup")
-        score_with_tags = score_learning(
-            CONDA_LEARNING, "conda environment setup", context_tags=["conda"]
-        )
+        score_with_tags = score_learning(CONDA_LEARNING, "conda environment setup", context_tags=["conda"])
         assert score_with_tags > score_no_tags
 
     async def test_backend_interface(self):
@@ -227,9 +225,7 @@ class TestBM25Backend:
     async def test_tag_boosting(self):
         backend = BM25Backend(tag_weight=0.3)
         results_no_tags = await backend.score_batch(ALL_LEARNINGS, "environment")
-        results_with_tags = await backend.score_batch(
-            ALL_LEARNINGS, "environment", context_tags=["conda"]
-        )
+        results_with_tags = await backend.score_batch(ALL_LEARNINGS, "environment", context_tags=["conda"])
         # Conda learning should score higher with matching tags
         conda_idx = 0  # lrn_001
         score_no_tags = dict(results_no_tags)[conda_idx]
@@ -274,12 +270,14 @@ class TestLLMBackend:
 
         mock_response = MagicMock()
         mock_response.choices = [MagicMock()]
-        mock_response.choices[0].message.content = json.dumps({
-            "0": 0.95,
-            "1": 0.3,
-            "2": 0.05,
-            "3": 0.7,
-        })
+        mock_response.choices[0].message.content = json.dumps(
+            {
+                "0": 0.95,
+                "1": 0.3,
+                "2": 0.05,
+                "3": 0.7,
+            }
+        )
 
         with patch("trace_mcp.extensions.learn.matching._HAS_OPENAI", True):
             with patch("trace_mcp.extensions.learn.matching.AsyncOpenAI") as MockClient:
@@ -305,9 +303,7 @@ class TestLLMBackend:
         with patch("trace_mcp.extensions.learn.matching._HAS_OPENAI", True):
             with patch("trace_mcp.extensions.learn.matching.AsyncOpenAI") as MockClient:
                 mock_client = AsyncMock()
-                mock_client.chat.completions.create = AsyncMock(
-                    side_effect=Exception("API error")
-                )
+                mock_client.chat.completions.create = AsyncMock(side_effect=Exception("API error"))
                 MockClient.return_value = mock_client
 
                 from trace_mcp.extensions.learn.matching import LLMBackend
@@ -332,9 +328,7 @@ class TestLLMBackend:
         with patch("trace_mcp.extensions.learn.matching._HAS_OPENAI", True):
             with patch("trace_mcp.extensions.learn.matching.AsyncOpenAI") as MockClient:
                 mock_client = AsyncMock()
-                mock_client.chat.completions.create = AsyncMock(
-                    side_effect=Exception("API error")
-                )
+                mock_client.chat.completions.create = AsyncMock(side_effect=Exception("API error"))
                 MockClient.return_value = mock_client
 
                 from trace_mcp.extensions.learn.matching import LLMBackend
@@ -383,7 +377,8 @@ class TestBackendSelection:
     """Test backend auto-selection priority: Embedding > LLM > BM25."""
 
     _NO_EMBEDDING = patch(
-        "trace_mcp.extensions.learn.matching.get_embedding_provider", return_value=None,
+        "trace_mcp.extensions.learn.matching.get_embedding_provider",
+        return_value=None,
     )
 
     def test_bm25_when_no_api_key(self):
@@ -683,9 +678,7 @@ class TestBM25Stemming:
             Learning(id="lrn_002", content="Log decisions before implementing — TRACE discipline"),
         ]
         backend = BM25Backend(tag_weight=0.0)
-        results = await backend.score_batch(
-            learnings, "implementing decisions in the workflow"
-        )
+        results = await backend.score_batch(learnings, "implementing decisions in the workflow")
         scores = dict(results)
         assert scores[1] > scores[0]  # lrn_002 > lrn_001
 
@@ -715,7 +708,10 @@ class TestBackendThresholds:
         """When threshold=None, recall uses the backend's default."""
         backend = BM25Backend()
         results = await recall_learnings(
-            ALL_LEARNINGS, "conda environment", threshold=None, backend=backend,
+            ALL_LEARNINGS,
+            "conda environment",
+            threshold=None,
+            backend=backend,
         )
         for r in results:
             assert r["score"] >= backend.default_threshold
@@ -724,10 +720,16 @@ class TestBackendThresholds:
         """Explicit threshold takes precedence over backend default."""
         backend = BM25Backend()
         results_low = await recall_learnings(
-            ALL_LEARNINGS, "conda environment", threshold=0.01, backend=backend,
+            ALL_LEARNINGS,
+            "conda environment",
+            threshold=0.01,
+            backend=backend,
         )
         results_default = await recall_learnings(
-            ALL_LEARNINGS, "conda environment", threshold=None, backend=backend,
+            ALL_LEARNINGS,
+            "conda environment",
+            threshold=None,
+            backend=backend,
         )
         assert len(results_low) >= len(results_default)
 
@@ -743,7 +745,10 @@ class TestRecallTracking:
         lrn = Learning(id="lrn_001", content="use ml-dev conda environment")
         assert lrn.recall_count == 0
         results = await recall_learnings(
-            [lrn], "conda environment", threshold=0.0, backend=BM25Backend(),
+            [lrn],
+            "conda environment",
+            threshold=0.0,
+            backend=BM25Backend(),
         )
         assert len(results) > 0
         assert lrn.recall_count == 1
@@ -753,7 +758,10 @@ class TestRecallTracking:
         lrn = Learning(id="lrn_001", content="use ml-dev conda environment")
         assert lrn.last_surfaced is None
         await recall_learnings(
-            [lrn], "conda environment", threshold=0.0, backend=BM25Backend(),
+            [lrn],
+            "conda environment",
+            threshold=0.0,
+            backend=BM25Backend(),
         )
         assert lrn.last_surfaced is not None
 
@@ -761,7 +769,10 @@ class TestRecallTracking:
         """Learnings that don't match (below threshold) should not be tracked."""
         lrn = Learning(id="lrn_001", content="best pasta recipe with tomatoes")
         await recall_learnings(
-            [lrn], "conda environment ml-dev", threshold=0.5, backend=BM25Backend(),
+            [lrn],
+            "conda environment ml-dev",
+            threshold=0.5,
+            backend=BM25Backend(),
         )
         assert lrn.recall_count == 0
         assert lrn.last_surfaced is None
@@ -771,7 +782,10 @@ class TestRecallTracking:
         lrn = Learning(id="lrn_001", content="use ml-dev conda environment")
         for _ in range(3):
             await recall_learnings(
-                [lrn], "conda environment", threshold=0.0, backend=BM25Backend(),
+                [lrn],
+                "conda environment",
+                threshold=0.0,
+                backend=BM25Backend(),
             )
         assert lrn.recall_count == 3
 

--- a/tests/test_learn_models.py
+++ b/tests/test_learn_models.py
@@ -50,7 +50,14 @@ class TestLearningModel:
     def test_all_valid_categories(self):
         """Every LearningCategory literal is accepted."""
         valid: list[LearningCategory] = [
-            "learning", "gotcha", "correction", "decision", "observation", "todo", "question", "other",
+            "learning",
+            "gotcha",
+            "correction",
+            "decision",
+            "observation",
+            "todo",
+            "question",
+            "other",
         ]
         for cat in valid:
             lrn = Learning(content="test", category=cat)

--- a/tests/test_learn_recall_layers.py
+++ b/tests/test_learn_recall_layers.py
@@ -125,7 +125,10 @@ async def _create_session(
 ) -> tuple[str, Session]:
     """Create an active test session. Returns (session_id, session)."""
     await start_session(
-        storage, active, project=project, description=description,
+        storage,
+        active,
+        project=project,
+        description=description,
     )
     session_id = list(active.keys())[-1]
     return session_id, active[session_id]
@@ -157,9 +160,7 @@ class TestHooksRegistry:
     async def test_recall_hook_failure_returns_empty(self):
         """Hooks fail open — errors return empty list, not exceptions."""
 
-        async def _bad_hook(
-            project: str, context: str, tags: list[str] | None, limit: int
-        ) -> list[dict]:
+        async def _bad_hook(project: str, context: str, tags: list[str] | None, limit: int) -> list[dict]:
             raise RuntimeError("Simulated failure")
 
         register_recall_hook(_bad_hook)
@@ -234,9 +235,7 @@ class TestFormatFunctions:
 class TestLayer1SessionStart:
     """Tests that session-start + recall surfaces relevant learnings."""
 
-    async def test_start_session_includes_recalled_learnings(
-        self, storage, knowledge_dir
-    ):
+    async def test_start_session_includes_recalled_learnings(self, storage, knowledge_dir):
         """Starting a session about conda surfaces the conda correction."""
         _seed_knowledge(knowledge_dir)
         _register_recall_hook(knowledge_dir)
@@ -245,7 +244,11 @@ class TestLayer1SessionStart:
         description = "Setting up conda environment for ML pipeline"
         tags = ["conda", "ml"]
         result = await start_session(
-            storage, {}, project="test", description=description, tags=tags,
+            storage,
+            {},
+            project="test",
+            description=description,
+            tags=tags,
         )
 
         # Layer 1: recall based on description + tags
@@ -256,9 +259,7 @@ class TestLayer1SessionStart:
         assert "Relevant learnings from past sessions" in result
         assert "conda" in result.lower()
 
-    async def test_start_session_low_relevance_for_unrelated_topic(
-        self, storage, knowledge_dir
-    ):
+    async def test_start_session_low_relevance_for_unrelated_topic(self, storage, knowledge_dir):
         """Starting a session about an unrelated topic returns no high-relevance learnings."""
         _seed_knowledge(knowledge_dir)
         _register_recall_hook(knowledge_dir)
@@ -266,20 +267,26 @@ class TestLayer1SessionStart:
         description = "Writing the abstract for the conference paper"
         tags = ["writing"]
         await start_session(
-            storage, {}, project="test", description=description, tags=tags,
+            storage,
+            {},
+            project="test",
+            description=description,
+            tags=tags,
         )
 
         # Use a stricter threshold — low-score noise should be filtered out
         ks = load_store("test", directory=knowledge_dir)
         results = await recall_learnings(
-            ks.learnings, description, context_tags=tags,
-            threshold=0.3, limit=5, backend=BM25Backend(),
+            ks.learnings,
+            description,
+            context_tags=tags,
+            threshold=0.3,
+            limit=5,
+            backend=BM25Backend(),
         )
         assert len(results) == 0
 
-    async def test_start_session_respects_recall_limit(
-        self, storage, knowledge_dir
-    ):
+    async def test_start_session_respects_recall_limit(self, storage, knowledge_dir):
         """Only top-K learnings are returned."""
         _seed_knowledge(knowledge_dir)
         _register_recall_hook(knowledge_dir)
@@ -288,7 +295,11 @@ class TestLayer1SessionStart:
         description = "conda env ml ffmpeg audio log decisions trace"
         tags = ["conda", "ffmpeg", "trace"]
         await start_session(
-            storage, {}, project="test", description=description, tags=tags,
+            storage,
+            {},
+            project="test",
+            description=description,
+            tags=tags,
         )
 
         recalled = await recall_if_available("test", description, tags, limit=1)
@@ -298,9 +309,7 @@ class TestLayer1SessionStart:
             matches = re.findall(r"\[(?:correction|learning|gotcha|decision)\]", result)
             assert len(matches) <= 1
 
-    async def test_start_session_no_recall_without_description(
-        self, storage, knowledge_dir
-    ):
+    async def test_start_session_no_recall_without_description(self, storage, knowledge_dir):
         """No description means no context to recall against — skip recall."""
         _seed_knowledge(knowledge_dir)
         _register_recall_hook(knowledge_dir)
@@ -314,7 +323,10 @@ class TestLayer1SessionStart:
     async def test_start_session_works_without_hooks(self, storage):
         """Starting a session works normally when no learn extension is loaded."""
         result = await start_session(
-            storage, {}, project="test", description="Some work",
+            storage,
+            {},
+            project="test",
+            description="Some work",
         )
         # No hooks → recall returns empty → no learnings appended
         recalled = await recall_if_available("test", "Some work", None, 5)
@@ -332,9 +344,7 @@ class TestLayer1SessionStart:
 class TestLayer3DecisionRecall:
     """Tests that decision proposal + recall surfaces related learnings."""
 
-    async def test_propose_decision_shows_related_learnings(
-        self, storage, knowledge_dir
-    ):
+    async def test_propose_decision_shows_related_learnings(self, storage, knowledge_dir):
         """Proposing a decision about conda surfaces the conda correction."""
         _seed_knowledge(knowledge_dir)
         _register_recall_hook(knowledge_dir)
@@ -346,7 +356,8 @@ class TestLayer3DecisionRecall:
         tags = ["conda"]
 
         event_id = await propose_decision(
-            storage, session,
+            storage,
+            session,
             description=description,
             proposed_by_type="ai",
             proposed_by_id="ai-assistant",
@@ -356,7 +367,10 @@ class TestLayer3DecisionRecall:
 
         # Layer 3: recall related learnings for this decision
         related = await recall_if_available(
-            session.metadata.project, description, tags, limit=3,
+            session.metadata.project,
+            description,
+            tags,
+            limit=3,
         )
         assert len(related) > 0
         contents = [r["learning"]["content"].lower() for r in related]
@@ -366,15 +380,13 @@ class TestLayer3DecisionRecall:
         warnings = format_decision_warnings(related)
         assert "Related learnings" in warnings
 
-    async def test_propose_decision_low_relevance_for_novel_topic(
-        self, storage, knowledge_dir
-    ):
+    async def test_propose_decision_low_relevance_for_novel_topic(self, storage, knowledge_dir):
         """Decisions about topics with no learnings return no high-relevance warnings."""
         _seed_knowledge(knowledge_dir)
         _register_recall_hook(knowledge_dir)
 
         active: dict[str, Session] = {}
-        _, session = await _create_session(storage, active, description="test session")
+        _, _session = await _create_session(storage, active, description="test session")
 
         # Use a query with zero vocabulary overlap with seeded learnings
         ks = load_store("test", directory=knowledge_dir)
@@ -382,7 +394,9 @@ class TestLayer3DecisionRecall:
             ks.learnings,
             "transformer architecture text classification",
             context_tags=["nlp", "transformer"],
-            threshold=0.3, limit=3, backend=BM25Backend(),
+            threshold=0.3,
+            limit=3,
+            backend=BM25Backend(),
         )
         assert len(results) == 0
 
@@ -392,7 +406,8 @@ class TestLayer3DecisionRecall:
         _, session = await _create_session(storage, active, description="test session")
 
         event_id = await propose_decision(
-            storage, session,
+            storage,
+            session,
             description="Use some method",
             proposed_by_type="ai",
             proposed_by_id="ai-assistant",
@@ -447,7 +462,9 @@ class TestAutoExtract:
         """Extract learnings from a session with real annotations."""
         active: dict[str, Session] = {}
         session_id, session = await _create_session(
-            storage, active, description="test session",
+            storage,
+            active,
+            description="test session",
         )
 
         # Add an observation that will be corrected
@@ -514,7 +531,9 @@ class TestFullE2EAllLayers:
         # ── Session A: create a correction ──
         active_a: dict[str, Session] = {}
         session_a_id, session_a = await _create_session(
-            storage, active_a, description="Debugging pipeline failures",
+            storage,
+            active_a,
+            description="Debugging pipeline failures",
         )
 
         # Add a correction annotation
@@ -545,8 +564,11 @@ class TestFullE2EAllLayers:
         description_b = "Setting up conda environment for new analysis"
         tags_b = ["conda"]
         result_b = await start_session(
-            storage, active_b, project="test",
-            description=description_b, tags=tags_b,
+            storage,
+            active_b,
+            project="test",
+            description=description_b,
+            tags=tags_b,
         )
 
         # Layer 1: recall based on session B's description
@@ -557,22 +579,25 @@ class TestFullE2EAllLayers:
         assert "conda" in result_b.lower()
         assert "ml-dev" in result_b.lower()
 
-    async def test_decision_recall_prevents_known_mistake(
-        self, storage, knowledge_dir
-    ):
+    async def test_decision_recall_prevents_known_mistake(self, storage, knowledge_dir):
         """A learning about ml-dev surfaces when proposing to use base env."""
         _seed_knowledge(knowledge_dir)
         _register_recall_hook(knowledge_dir)
 
         active: dict[str, Session] = {}
-        _, session = await _create_session(
-            storage, active, description="ML analysis",
+        _, _session = await _create_session(
+            storage,
+            active,
+            description="ML analysis",
         )
 
         # Propose using base conda (a known mistake)
         decision_desc = "Use base conda environment for running the ML pipeline"
         related = await recall_if_available(
-            "test", decision_desc, ["conda"], limit=3,
+            "test",
+            decision_desc,
+            ["conda"],
+            limit=3,
         )
 
         # The system should surface the correction about ml-dev

--- a/tests/test_learn_store.py
+++ b/tests/test_learn_store.py
@@ -254,9 +254,7 @@ class TestAddLearningDedup:
     def test_skips_duplicate(self):
         ks = KnowledgeStore(project="test")
         add_learning(ks, content="use ml-dev conda environment")
-        result = add_learning_dedup(
-            ks, content="use ml-dev conda environment", dedup_threshold=0.5
-        )
+        result = add_learning_dedup(ks, content="use ml-dev conda environment", dedup_threshold=0.5)
         assert result.is_duplicate
         assert len(ks.learnings) == 1
 

--- a/tests/test_packaging_artifacts.py
+++ b/tests/test_packaging_artifacts.py
@@ -49,9 +49,7 @@ def get_expected_asset_relpaths() -> list[str]:
     the guard. A floor of 6 known assets (settings template, CLAUDE block,
     4 hook scripts) protects against the tree itself going missing.
     """
-    assets = sorted(
-        str(p.relative_to(TRACE_ROOT / "src")) for p in ASSETS_DIR.rglob("*") if p.is_file()
-    )
+    assets = sorted(str(p.relative_to(TRACE_ROOT / "src")) for p in ASSETS_DIR.rglob("*") if p.is_file())
     assert len(assets) >= 6, (
         f"Expected at least the 6 known adapter assets under {ASSETS_DIR}, found {len(assets)}: {assets}"
     )
@@ -113,9 +111,7 @@ class TestWheelContainsRequiredFiles:
         installs zero hooks silently, then crashes in _merge_settings."""
         members = get_wheel_members(built_dist["wheel"])
         missing = [a for a in get_expected_asset_relpaths() if a not in members]
-        assert not missing, (
-            f"Adapter assets missing from the wheel (trace-mcp-init is dead on arrival): {missing}"
-        )
+        assert not missing, f"Adapter assets missing from the wheel (trace-mcp-init is dead on arrival): {missing}"
 
     def test_wheel_contains_packaged_schema(self, built_dist: dict[str, Path]) -> None:
         """`trace-mcp validate` loads the schema as package data; a wheel
@@ -150,9 +146,7 @@ class TestWheelContainsRequiredFiles:
 
         members = get_wheel_members(built_dist["wheel"])
         tree_files = sorted(
-            line.removeprefix("src/")
-            for line in ls.stdout.splitlines()
-            if line and not line.endswith(".py")
+            line.removeprefix("src/") for line in ls.stdout.splitlines() if line and not line.endswith(".py")
         )
         assert tree_files, "Expected tracked non-Python package files under src/trace_mcp"
         missing = [f for f in tree_files if f not in members]
@@ -167,9 +161,7 @@ class TestWheelInstallE2E:
     script — the original C2 reproduction path ('crashes on any installed
     package'). Network + ~seconds of venv setup; uv's cache keeps it fast."""
 
-    def test_trace_mcp_validate_works_from_wheel_install(
-        self, built_dist: dict[str, Path], tmp_path: Path
-    ) -> None:
+    def test_trace_mcp_validate_works_from_wheel_install(self, built_dist: dict[str, Path], tmp_path: Path) -> None:
         venv_dir = tmp_path / "venv"
         subprocess.run(["uv", "venv", str(venv_dir)], check=True, capture_output=True, timeout=120)
         python = venv_dir / ("Scripts" if sys.platform == "win32" else "bin") / "python"
@@ -234,8 +226,7 @@ class TestNoPersonalDataInSdist:
                 if needle.encode("utf-8") in content:
                     offenders.append(member.name)
         assert not offenders, (
-            f"Personal home-directory paths found inside sdist file contents "
-            f"(sanitize before shipping): {offenders}"
+            f"Personal home-directory paths found inside sdist file contents (sanitize before shipping): {offenders}"
         )
 
 
@@ -258,6 +249,15 @@ class TestSdistContainsRequiredFiles:
         (gitignore-style patterns otherwise match at any depth); make sure the
         anchored syntax still ships them at the sdist root."""
         members = get_sdist_members(built_dist["sdist"])
-        expected = ["README.md", "LICENSE", "NOTICE", "SECURITY.md", "CONTRIBUTING.md", "CHANGELOG.md", "server.json", "pyproject.toml"]
+        expected = [
+            "README.md",
+            "LICENSE",
+            "NOTICE",
+            "SECURITY.md",
+            "CONTRIBUTING.md",
+            "CHANGELOG.md",
+            "server.json",
+            "pyproject.toml",
+        ]
         missing = [f for f in expected if f not in members]
         assert not missing, f"Anchored top-level metadata missing from the sdist: {missing}"

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -476,6 +476,7 @@ class TestDeadFieldRemoval:
     def test_event_context_has_no_parent_event_id(self) -> None:
         """parent_event_id field was removed from EventContext."""
         from trace_mcp.schema.events import EventContext
+
         assert "parent_event_id" not in EventContext.model_fields
 
     def test_old_json_with_extra_fields_still_loads(self) -> None:

--- a/tests/test_specification_conformance.py
+++ b/tests/test_specification_conformance.py
@@ -277,7 +277,10 @@ def _handcrafted_session() -> dict[str, Any]:
                 "session_id": "handcrafted_20260319_aaa111",
                 "type": "annotation",
                 "actor": {"type": "human", "id": "tester-alice"},
-                "annotation": {"category": "observation", "content": "R² improved from 0.72 to 0.81 after fixing imputation."},
+                "annotation": {
+                    "category": "observation",
+                    "content": "R² improved from 0.72 to 0.81 after fixing imputation.",
+                },
                 "context": {},
             },
             {
@@ -386,7 +389,8 @@ async def _trace_generated_session(tmp_path: Path) -> dict[str, Any]:
 
     # Start session
     session = await session_tools.create_session(
-        storage, active,
+        storage,
+        active,
         project="conformance-test",
         experiment_id="exp-conf-002",
         description="TRACE-generated conformance test session.",
@@ -400,87 +404,119 @@ async def _trace_generated_session(tmp_path: Path) -> dict[str, Any]:
 
     # Tool call — success
     await logging_tools.log_tool_call(
-        storage, session,
-        server="search-server", tool_name="search_documents",
+        storage,
+        session,
+        server="search-server",
+        tool_name="search_documents",
         input={"query": "climate change", "limit": 10},
-        output={"results": 42}, duration_ms=1500, status="success",
-        actor_type="ai", actor_id="model-beta",
-        reasoning="Searching for relevant documents.", conversation_turn=1,
+        output={"results": 42},
+        duration_ms=1500,
+        status="success",
+        actor_type="ai",
+        actor_id="model-beta",
+        reasoning="Searching for relevant documents.",
+        conversation_turn=1,
     )
 
     # Tool call — error
     await logging_tools.log_tool_call(
-        storage, session,
-        server="analysis-server", tool_name="run_analysis",
-        input={"method": "regression"}, status="error",
+        storage,
+        session,
+        server="analysis-server",
+        tool_name="run_analysis",
+        input={"method": "regression"},
+        status="error",
         error_message="Connection timeout",
-        actor_type="ai", actor_id="model-beta",
+        actor_type="ai",
+        actor_id="model-beta",
     )
 
     # Tool call — retry
     await logging_tools.log_tool_call(
-        storage, session,
-        server="analysis-server", tool_name="run_analysis",
-        input={"method": "regression"}, status="success", duration_ms=800,
+        storage,
+        session,
+        server="analysis-server",
+        tool_name="run_analysis",
+        input={"method": "regression"},
+        status="success",
+        duration_ms=800,
         retries_event_id="evt_002",
-        actor_type="ai", actor_id="model-beta",
+        actor_type="ai",
+        actor_id="model-beta",
     )
 
     # Decision — propose
     await decision_tools.propose_decision(
-        storage, session,
+        storage,
+        session,
         description="Use random forest with 100 trees",
         rationale="Good balance of accuracy and speed",
-        proposed_by_type="ai", proposed_by_id="model-beta",
+        proposed_by_type="ai",
+        proposed_by_id="model-beta",
         suggestion_type="proactive",
         tags=["methodology", "model-selection"],
     )
 
     # Decision — accept (resolve evt_004 in-place, no new event)
     await decision_tools.resolve_decision(
-        storage, session,
-        event_id="evt_004", disposition="accepted",
-        resolved_by_type="human", resolved_by_id="tester-alice",
+        storage,
+        session,
+        event_id="evt_004",
+        disposition="accepted",
+        resolved_by_type="human",
+        resolved_by_id="tester-alice",
     )
 
     # Decision — propose + revise (chain)
     # propose → evt_005, resolve in-place
     await decision_tools.propose_decision(
-        storage, session,
+        storage,
+        session,
         description="Switch to 200 trees for better accuracy",
         rationale="100 trees underfitting on validation data",
-        proposed_by_type="human", proposed_by_id="tester-alice",
+        proposed_by_type="human",
+        proposed_by_id="tester-alice",
         suggestion_type="requested",
         revises_event_id="evt_004",
     )
     await decision_tools.resolve_decision(
-        storage, session,
-        event_id="evt_005", disposition="revised",
-        resolved_by_type="human", resolved_by_id="tester-alice",
+        storage,
+        session,
+        event_id="evt_005",
+        disposition="revised",
+        resolved_by_type="human",
+        resolved_by_id="tester-alice",
         revision_note="Validation accuracy jumped 3% with 200 trees",
     )
 
     # Decision — propose + reject
     # propose → evt_006, resolve in-place
     await decision_tools.propose_decision(
-        storage, session,
+        storage,
+        session,
         description="Use GPU-accelerated XGBoost instead",
         rationale="Faster training on large datasets",
-        proposed_by_type="ai", proposed_by_id="model-beta",
+        proposed_by_type="ai",
+        proposed_by_id="model-beta",
     )
     await decision_tools.resolve_decision(
-        storage, session,
-        event_id="evt_006", disposition="rejected",
-        resolved_by_type="human", resolved_by_id="tester-alice",
+        storage,
+        session,
+        event_id="evt_006",
+        disposition="rejected",
+        resolved_by_type="human",
+        resolved_by_id="tester-alice",
         revision_note="RF is already fast enough and more interpretable",
     )
 
     # Decision — left in proposed state (unresolved)
     await decision_tools.propose_decision(
-        storage, session,
+        storage,
+        session,
         description="Consider adding cross-validation",
         rationale="Would improve confidence in results",
-        proposed_by_type="ai", proposed_by_id="model-beta",
+        proposed_by_type="ai",
+        proposed_by_id="model-beta",
         suggestion_type="collaborative",
     )
 
@@ -494,54 +530,75 @@ async def _trace_generated_session(tmp_path: Path) -> dict[str, Any]:
         ("other", "Session running on shared cluster node 7."),
     ]:
         await logging_tools.log_annotation(
-            storage, session, category=cat, content=content,
-            actor_type="ai", actor_id="model-beta",
+            storage,
+            session,
+            category=cat,
+            content=content,
+            actor_type="ai",
+            actor_id="model-beta",
         )
 
     # Correction annotation with corrects_event_ids
     await logging_tools.log_annotation(
-        storage, session,
+        storage,
+        session,
         category="correction",
         content="The AI used mean imputation but should have used median.",
         corrects_event_ids=["evt_003"],
         related_event_ids=["evt_007"],
-        actor_type="human", actor_id="tester-alice",
+        actor_type="human",
+        actor_id="tester-alice",
         conversation_snippet="No, use median — the distribution is skewed.",
     )
 
     # State change
     await logging_tools.log_state_change(
-        storage, session,
+        storage,
+        session,
         description="Switched from CPU to GPU compute",
-        field="environment.compute", old_value="cpu", new_value="gpu-a100",
+        field="environment.compute",
+        old_value="cpu",
+        new_value="gpu-a100",
         reason="Training too slow on CPU",
-        actor_type="human", actor_id="tester-alice",
+        actor_type="human",
+        actor_id="tester-alice",
     )
 
     # Contributions — multiple direction×execution combos
     await logging_tools.log_contribution(
-        storage, session,
+        storage,
+        session,
         description="Implemented random forest classifier",
-        direction="human", execution="ai", artifact="src/classifier.py",
+        direction="human",
+        execution="ai",
+        artifact="src/classifier.py",
         related_decision_ids=["evt_005"],
         tags=["implementation"],
-        actor_type="ai", actor_id="model-beta",
+        actor_type="ai",
+        actor_id="model-beta",
         conversation_snippet="Write the classifier using RF with 200 trees.",
     )
     await logging_tools.log_contribution(
-        storage, session,
+        storage,
+        session,
         description="Generated feature importance visualization",
-        direction="ai", execution="ai", artifact="figures/feature_importance.png",
+        direction="ai",
+        execution="ai",
+        artifact="figures/feature_importance.png",
         tags=["visualization"],
-        actor_type="ai", actor_id="model-beta",
+        actor_type="ai",
+        actor_id="model-beta",
     )
     await logging_tools.log_contribution(
-        storage, session,
+        storage,
+        session,
         description="Manually annotated 50 validation examples",
-        direction="collaborative", execution="human",
+        direction="collaborative",
+        execution="human",
         artifact="data/validation_labels.csv",
         tags=["data"],
-        actor_type="human", actor_id="tester-alice",
+        actor_type="human",
+        actor_id="tester-alice",
     )
 
     # End session
@@ -621,10 +678,7 @@ class TestStructuralEquivalence:
         trace = await _trace_generated_session(tmp_path)
 
         for doc_name, doc in [("handcrafted", hand), ("TRACE", trace)]:
-            revisions = [
-                e for e in doc["events"]
-                if e["type"] == "decision" and e["decision"].get("revises_event_id")
-            ]
+            revisions = [e for e in doc["events"] if e["type"] == "decision" and e["decision"].get("revises_event_id")]
             assert len(revisions) >= 1, f"{doc_name} has no decision chain (no revises_event_id)"
 
     async def test_both_have_retry_chain(self, tmp_path: Path) -> None:
@@ -633,10 +687,7 @@ class TestStructuralEquivalence:
         trace = await _trace_generated_session(tmp_path)
 
         for doc_name, doc in [("handcrafted", hand), ("TRACE", trace)]:
-            retries = [
-                e for e in doc["events"]
-                if e["type"] == "tool_call" and e["tool_call"].get("retries_event_id")
-            ]
+            retries = [e for e in doc["events"] if e["type"] == "tool_call" and e["tool_call"].get("retries_event_id")]
             assert len(retries) >= 1, f"{doc_name} has no retry chain"
 
     async def test_both_have_correction_with_links(self, tmp_path: Path) -> None:
@@ -646,7 +697,8 @@ class TestStructuralEquivalence:
 
         for doc_name, doc in [("handcrafted", hand), ("TRACE", trace)]:
             corrections = [
-                e for e in doc["events"]
+                e
+                for e in doc["events"]
                 if e["type"] == "annotation"
                 and e["annotation"]["category"] == "correction"
                 and e["annotation"].get("corrects_event_ids")
@@ -661,7 +713,8 @@ class TestStructuralEquivalence:
         for doc_name, doc in [("handcrafted", hand), ("TRACE", trace)]:
             combos = {
                 (e["contribution"]["direction"], e["contribution"]["execution"])
-                for e in doc["events"] if e["type"] == "contribution"
+                for e in doc["events"]
+                if e["type"] == "contribution"
             }
             assert len(combos) >= 3, f"{doc_name} only has {len(combos)} direction×execution combos"
 
@@ -718,8 +771,19 @@ class TestSpecDataModelCoverage:
     # §3.4 Event
     def test_event_has_required_fields(self) -> None:
         fields = TraceEvent.model_fields
-        for f in ["id", "timestamp", "session_id", "type", "actor", "context",
-                   "tool_call", "decision", "annotation", "state_change", "contribution"]:
+        for f in [
+            "id",
+            "timestamp",
+            "session_id",
+            "type",
+            "actor",
+            "context",
+            "tool_call",
+            "decision",
+            "annotation",
+            "state_change",
+            "contribution",
+        ]:
             assert f in fields, f"TraceEvent missing field: {f}"
 
     def test_event_type_values(self) -> None:
@@ -738,8 +802,19 @@ class TestSpecDataModelCoverage:
     # §3.5 ToolCallData
     def test_tool_call_data_has_fields(self) -> None:
         fields = ToolCallData.model_fields
-        for f in ["server", "method", "name", "input", "output", "output_truncated",
-                   "output_hash", "duration_ms", "status", "error_message", "retries_event_id"]:
+        for f in [
+            "server",
+            "method",
+            "name",
+            "input",
+            "output",
+            "output_truncated",
+            "output_hash",
+            "duration_ms",
+            "status",
+            "error_message",
+            "retries_event_id",
+        ]:
             assert f in fields, f"ToolCallData missing field: {f}"
 
     def test_tool_call_status_values(self) -> None:
@@ -751,31 +826,49 @@ class TestSpecDataModelCoverage:
     # §3.6 DecisionData
     def test_decision_data_has_fields(self) -> None:
         fields = DecisionData.model_fields
-        for f in ["description", "rationale", "proposed_by", "disposition", "resolved_by",
-                   "revision_note", "revises_event_id", "suggestion_type", "tags", "warnings"]:
+        for f in [
+            "description",
+            "rationale",
+            "proposed_by",
+            "disposition",
+            "resolved_by",
+            "revision_note",
+            "revises_event_id",
+            "suggestion_type",
+            "tags",
+            "warnings",
+        ]:
             assert f in fields, f"DecisionData missing field: {f}"
 
     def test_decision_disposition_values(self) -> None:
         dispositions: list[Literal["proposed", "accepted", "revised", "rejected"]] = [
-            "proposed", "accepted", "revised", "rejected",
+            "proposed",
+            "accepted",
+            "revised",
+            "rejected",
         ]
         for d in dispositions:
             if d == "proposed":
                 dec = DecisionData(description="t", proposed_by=Actor(type="ai", id="x"), disposition=d)
             else:
                 import warnings
+
                 with warnings.catch_warnings():
                     warnings.simplefilter("ignore")
                     dec = DecisionData(
-                        description="t", proposed_by=Actor(type="ai", id="x"),
-                        disposition=d, resolved_by=Actor(type="human", id="y"),
+                        description="t",
+                        proposed_by=Actor(type="ai", id="x"),
+                        disposition=d,
+                        resolved_by=Actor(type="human", id="y"),
                         revision_note="note" if d in ("revised", "rejected") else None,
                     )
             assert dec.disposition == d
 
     def test_suggestion_type_values(self) -> None:
         suggestion_types: list[Literal["proactive", "requested", "collaborative"]] = [
-            "proactive", "requested", "collaborative",
+            "proactive",
+            "requested",
+            "collaborative",
         ]
         for st in suggestion_types:
             d = DecisionData(description="t", proposed_by=Actor(type="ai", id="x"), suggestion_type=st)
@@ -838,7 +931,10 @@ class TestSpecValidationRules:
         """Only one data field may be populated."""
         with pytest.raises(ValueError, match="must not have"):
             TraceEvent(
-                id="e", session_id="s", type="tool_call", actor=Actor(type="ai", id="x"),
+                id="e",
+                session_id="s",
+                type="tool_call",
+                actor=Actor(type="ai", id="x"),
                 tool_call=ToolCallData(server="s", name="n", input={}),
                 annotation=AnnotationData(category="observation", content="extra"),
             )
@@ -872,17 +968,29 @@ class TestSpecDecisionProvenance:
 
         # Create a 3-link chain: evt_001 → evt_002 → evt_003
         await decision_tools.propose_decision(
-            storage, session, description="Original", rationale="v1",
-            proposed_by_type="ai", proposed_by_id="ai",
+            storage,
+            session,
+            description="Original",
+            rationale="v1",
+            proposed_by_type="ai",
+            proposed_by_id="ai",
         )
         await decision_tools.propose_decision(
-            storage, session, description="Revision 1", rationale="v2",
-            proposed_by_type="human", proposed_by_id="human",
+            storage,
+            session,
+            description="Revision 1",
+            rationale="v2",
+            proposed_by_type="human",
+            proposed_by_id="human",
             revises_event_id="evt_001",
         )
         await decision_tools.propose_decision(
-            storage, session, description="Revision 2", rationale="v3",
-            proposed_by_type="ai", proposed_by_id="ai",
+            storage,
+            session,
+            description="Revision 2",
+            rationale="v3",
+            proposed_by_type="ai",
+            proposed_by_id="ai",
             revises_event_id="evt_002",
         )
 
@@ -926,10 +1034,7 @@ class TestSpecDecisionProvenance:
         assert intervention_rate > 0
 
         # Direction × Execution matrix
-        combos = {
-            (c["contribution"]["direction"], c["contribution"]["execution"])
-            for c in contributions
-        }
+        combos = {(c["contribution"]["direction"], c["contribution"]["execution"]) for c in contributions}
         assert len(combos) >= 3
 
 
@@ -949,9 +1054,13 @@ class TestSpecProvMapping:
     def test_prov_mapping_covers_spec_concepts(self) -> None:
         """Every concept from spec §6 table has a PROV mapping."""
         required = [
-            "Session", "TraceEvent", "Actor",
-            "ToolCallData.input", "ToolCallData.output",
-            "DecisionData", "DecisionData.revision",
+            "Session",
+            "TraceEvent",
+            "Actor",
+            "ToolCallData.input",
+            "ToolCallData.output",
+            "DecisionData",
+            "DecisionData.revision",
             "AnnotationData",
         ]
         for concept in required:
@@ -1070,11 +1179,13 @@ class TestSpecMCPToolCoverage:
     def test_export_exists(self) -> None:
         """Exporting session documents."""
         from trace_mcp.tools import export_tools
+
         assert callable(export_tools.export_session)
 
     def test_mcp_tool_registration(self) -> None:
         """TRACE registers its tools with FastMCP."""
         from trace_mcp.server import mcp
+
         # FastMCP stores tools; just verify the server object exists
         assert mcp.name == "trace"
 
@@ -1163,7 +1274,7 @@ class TestSpecDocumentCompleteness:
         # The example should be valid JSON
         json_start = spec_text.index("```json", spec_text.index("Appendix A"))
         json_end = spec_text.index("```", json_start + 7)
-        example_json = spec_text[json_start + 7:json_end].strip()
+        example_json = spec_text[json_start + 7 : json_end].strip()
         doc = json.loads(example_json)
         assert doc["id"] == "trace_20260205_a1b2c3"
 
@@ -1171,7 +1282,7 @@ class TestSpecDocumentCompleteness:
         """The example document in the spec MUST validate against the schema."""
         json_start = spec_text.index("```json", spec_text.index("Appendix A"))
         json_end = spec_text.index("```", json_start + 7)
-        example_json = spec_text[json_start + 7:json_end].strip()
+        example_json = spec_text[json_start + 7 : json_end].strip()
         doc = json.loads(example_json)
         jsonschema.validate(doc, schema)
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -623,12 +623,21 @@ class TestHealthCheck:
         session = active[session_id]
 
         await logging_tools.log_tool_call(
-            storage, session, server="test", tool_name="foo", input={"a": 1},
-            actor_type="ai", actor_id="claude",
+            storage,
+            session,
+            server="test",
+            tool_name="foo",
+            input={"a": 1},
+            actor_type="ai",
+            actor_id="claude",
         )
         await logging_tools.log_annotation(
-            storage, session, category="learning", content="something interesting",
-            actor_type="human", actor_id="researcher",
+            storage,
+            session,
+            category="learning",
+            content="something interesting",
+            actor_type="human",
+            actor_id="researcher",
         )
         await session_tools.end_session(storage, active, session_id=session_id)
 
@@ -647,8 +656,13 @@ class TestHealthCheck:
         sid1 = msg1.split("Session: ")[1].split("\n")[0]
         session1 = active[sid1]
         await logging_tools.log_tool_call(
-            storage, session1, server="s", tool_name="t", input={},
-            actor_type="ai", actor_id="claude",
+            storage,
+            session1,
+            server="s",
+            tool_name="t",
+            input={},
+            actor_type="ai",
+            actor_id="claude",
         )
         await session_tools.end_session(storage, active, session_id=sid1)
 
@@ -656,12 +670,22 @@ class TestHealthCheck:
         sid2 = msg2.split("Session: ")[1].split("\n")[0]
         session2 = active[sid2]
         await logging_tools.log_tool_call(
-            storage, session2, server="s", tool_name="t", input={},
-            actor_type="ai", actor_id="claude",
+            storage,
+            session2,
+            server="s",
+            tool_name="t",
+            input={},
+            actor_type="ai",
+            actor_id="claude",
         )
         await logging_tools.log_tool_call(
-            storage, session2, server="s", tool_name="t2", input={},
-            actor_type="ai", actor_id="claude",
+            storage,
+            session2,
+            server="s",
+            tool_name="t2",
+            input={},
+            actor_type="ai",
+            actor_id="claude",
         )
         await session_tools.end_session(storage, active, session_id=sid2)
 
@@ -677,8 +701,13 @@ class TestHealthCheck:
         sid1 = msg1.split("Session: ")[1].split("\n")[0]
         session1 = active[sid1]
         await logging_tools.log_tool_call(
-            storage, session1, server="s", tool_name="t", input={},
-            actor_type="ai", actor_id="claude",
+            storage,
+            session1,
+            server="s",
+            tool_name="t",
+            input={},
+            actor_type="ai",
+            actor_id="claude",
         )
         await session_tools.end_session(storage, active, session_id=sid1)
 
@@ -686,12 +715,22 @@ class TestHealthCheck:
         sid2 = msg2.split("Session: ")[1].split("\n")[0]
         session2 = active[sid2]
         await logging_tools.log_tool_call(
-            storage, session2, server="s", tool_name="t", input={},
-            actor_type="ai", actor_id="claude",
+            storage,
+            session2,
+            server="s",
+            tool_name="t",
+            input={},
+            actor_type="ai",
+            actor_id="claude",
         )
         await logging_tools.log_tool_call(
-            storage, session2, server="s", tool_name="t2", input={},
-            actor_type="ai", actor_id="claude",
+            storage,
+            session2,
+            server="s",
+            tool_name="t2",
+            input={},
+            actor_type="ai",
+            actor_id="claude",
         )
         await session_tools.end_session(storage, active, session_id=sid2)
 
@@ -739,93 +778,118 @@ class TestErrorCases:
 
 class TestConversationSnippet:
     async def test_contribution_with_snippet(
-        self, storage: JsonFileStorage, active: dict[str, Session],
+        self,
+        storage: JsonFileStorage,
+        active: dict[str, Session],
     ) -> None:
         await session_tools.start_session(storage, active, project="snippet-test")
         session_id = list(active.keys())[0]
         session = active[session_id]
 
         await logging_tools.log_contribution(
-            storage, session,
+            storage,
+            session,
             description="Wrote analysis code",
-            direction="human", execution="ai",
+            direction="human",
+            execution="ai",
             conversation_snippet="User said: please write the analysis code",
         )
         evt = session.events[-1]
         assert evt.context.conversation_snippet == "User said: please write the analysis code"
 
     async def test_annotation_with_snippet(
-        self, storage: JsonFileStorage, active: dict[str, Session],
+        self,
+        storage: JsonFileStorage,
+        active: dict[str, Session],
     ) -> None:
         await session_tools.start_session(storage, active, project="snippet-test")
         session_id = list(active.keys())[0]
         session = active[session_id]
 
         await logging_tools.log_annotation(
-            storage, session,
-            category="correction", content="Wrong env",
+            storage,
+            session,
+            category="correction",
+            content="Wrong env",
             conversation_snippet="User: that's the wrong environment",
         )
         evt = session.events[-1]
         assert evt.context.conversation_snippet == "User: that's the wrong environment"
 
     async def test_decision_with_snippet(
-        self, storage: JsonFileStorage, active: dict[str, Session],
+        self,
+        storage: JsonFileStorage,
+        active: dict[str, Session],
     ) -> None:
         await session_tools.start_session(storage, active, project="snippet-test")
         session_id = list(active.keys())[0]
         session = active[session_id]
 
         await decision_tools.propose_decision(
-            storage, session,
+            storage,
+            session,
             description="Use BM25",
-            proposed_by_type="ai", proposed_by_id="claude",
+            proposed_by_type="ai",
+            proposed_by_id="claude",
             conversation_snippet="Let's try BM25 for matching",
         )
         evt = session.events[-1]
         assert evt.context.conversation_snippet == "Let's try BM25 for matching"
 
     async def test_contribution_without_snippet_backward_compat(
-        self, storage: JsonFileStorage, active: dict[str, Session],
+        self,
+        storage: JsonFileStorage,
+        active: dict[str, Session],
     ) -> None:
         await session_tools.start_session(storage, active, project="snippet-test")
         session_id = list(active.keys())[0]
         session = active[session_id]
 
         await logging_tools.log_contribution(
-            storage, session,
-            description="Code", direction="ai", execution="ai",
+            storage,
+            session,
+            description="Code",
+            direction="ai",
+            execution="ai",
         )
         evt = session.events[-1]
         assert evt.context.conversation_snippet is None
 
     async def test_search_finds_conversation_snippet(
-        self, storage: JsonFileStorage, active: dict[str, Session],
+        self,
+        storage: JsonFileStorage,
+        active: dict[str, Session],
     ) -> None:
         await session_tools.start_session(storage, active, project="snippet-test")
         session_id = list(active.keys())[0]
         session = active[session_id]
 
         await logging_tools.log_contribution(
-            storage, session,
+            storage,
+            session,
             description="Analysis code",
-            direction="human", execution="ai",
+            direction="human",
+            execution="ai",
             conversation_snippet="User asked for a correlation analysis",
         )
         results = query_tools.search_events(session, query="correlation analysis")
         assert len(results) >= 1
 
     async def test_snippet_persists_roundtrip(
-        self, storage: JsonFileStorage, active: dict[str, Session],
+        self,
+        storage: JsonFileStorage,
+        active: dict[str, Session],
     ) -> None:
         await session_tools.start_session(storage, active, project="snippet-test")
         session_id = list(active.keys())[0]
         session = active[session_id]
 
         await logging_tools.log_contribution(
-            storage, session,
+            storage,
+            session,
             description="Code",
-            direction="human", execution="ai",
+            direction="human",
+            execution="ai",
             conversation_snippet="roundtrip test snippet",
         )
         loaded = await storage.get_session(session_id)
@@ -838,22 +902,28 @@ class TestConversationSnippet:
 
 class TestAttributionAudit:
     async def test_audit_contributions(
-        self, storage: JsonFileStorage, active: dict[str, Session],
+        self,
+        storage: JsonFileStorage,
+        active: dict[str, Session],
     ) -> None:
         await session_tools.start_session(storage, active, project="audit-test")
         session_id = list(active.keys())[0]
         session = active[session_id]
 
         await logging_tools.log_contribution(
-            storage, session,
+            storage,
+            session,
             description="Human-directed code",
-            direction="human", execution="ai",
+            direction="human",
+            execution="ai",
             artifact="src/code.py",
         )
         await logging_tools.log_contribution(
-            storage, session,
+            storage,
+            session,
             description="AI-directed analysis",
-            direction="ai", execution="ai",
+            direction="ai",
+            execution="ai",
             artifact="src/analysis.py",
         )
         result = await session_tools.end_session(storage, active, session_id=session_id)
@@ -863,22 +933,29 @@ class TestAttributionAudit:
         assert "direction=ai" in result
 
     async def test_audit_decisions(
-        self, storage: JsonFileStorage, active: dict[str, Session],
+        self,
+        storage: JsonFileStorage,
+        active: dict[str, Session],
     ) -> None:
         await session_tools.start_session(storage, active, project="audit-test")
         session_id = list(active.keys())[0]
         session = active[session_id]
 
         await decision_tools.propose_decision(
-            storage, session,
+            storage,
+            session,
             description="Use method A",
-            proposed_by_type="ai", proposed_by_id="claude",
+            proposed_by_type="ai",
+            proposed_by_id="claude",
             suggestion_type="proactive",
         )
         await decision_tools.resolve_decision(
-            storage, session,
-            event_id="evt_001", disposition="accepted",
-            resolved_by_type="human", resolved_by_id="researcher",
+            storage,
+            session,
+            event_id="evt_001",
+            disposition="accepted",
+            resolved_by_type="human",
+            resolved_by_id="researcher",
         )
         result = await session_tools.end_session(storage, active, session_id=session_id)
         assert "Decisions (1)" in result
@@ -886,7 +963,9 @@ class TestAttributionAudit:
         assert "disposition=accepted" in result
 
     async def test_audit_corrections(
-        self, storage: JsonFileStorage, active: dict[str, Session],
+        self,
+        storage: JsonFileStorage,
+        active: dict[str, Session],
     ) -> None:
         await session_tools.start_session(storage, active, project="audit-test")
         session_id = list(active.keys())[0]
@@ -894,29 +973,39 @@ class TestAttributionAudit:
 
         # First log events that will be corrected
         await logging_tools.log_annotation(
-            storage, session,
-            category="observation", content="Using env X",
-            actor_type="ai", actor_id="claude",
+            storage,
+            session,
+            category="observation",
+            content="Using env X",
+            actor_type="ai",
+            actor_id="claude",
         )
         await logging_tools.log_annotation(
-            storage, session,
-            category="observation", content="Config is Y",
-            actor_type="ai", actor_id="claude",
+            storage,
+            session,
+            category="observation",
+            content="Config is Y",
+            actor_type="ai",
+            actor_id="claude",
         )
         # Now log a correction referencing the existing events
         await logging_tools.log_annotation(
-            storage, session,
+            storage,
+            session,
             category="correction",
             content="Wrong env used",
             corrects_event_ids=["evt_001", "evt_002"],
-            actor_type="human", actor_id="researcher",
+            actor_type="human",
+            actor_id="researcher",
         )
         result = await session_tools.end_session(storage, active, session_id=session_id)
         assert "Corrections: 1" in result
         assert "evt_001" in result
 
     async def test_audit_human_interventions(
-        self, storage: JsonFileStorage, active: dict[str, Session],
+        self,
+        storage: JsonFileStorage,
+        active: dict[str, Session],
     ) -> None:
         await session_tools.start_session(storage, active, project="audit-test")
         session_id = list(active.keys())[0]
@@ -924,32 +1013,45 @@ class TestAttributionAudit:
 
         # Correction
         await logging_tools.log_annotation(
-            storage, session,
-            category="correction", content="Fix",
-            actor_type="human", actor_id="researcher",
+            storage,
+            session,
+            category="correction",
+            content="Fix",
+            actor_type="human",
+            actor_id="researcher",
         )
         # Rejected decision
         await decision_tools.propose_decision(
-            storage, session,
+            storage,
+            session,
             description="Bad idea",
-            proposed_by_type="ai", proposed_by_id="claude",
+            proposed_by_type="ai",
+            proposed_by_id="claude",
         )
         await decision_tools.resolve_decision(
-            storage, session,
-            event_id="evt_002", disposition="rejected",
-            resolved_by_type="human", resolved_by_id="researcher",
+            storage,
+            session,
+            event_id="evt_002",
+            disposition="rejected",
+            resolved_by_type="human",
+            resolved_by_id="researcher",
             revision_note="No",
         )
         # Revised decision
         await decision_tools.propose_decision(
-            storage, session,
+            storage,
+            session,
             description="Tweakable idea",
-            proposed_by_type="ai", proposed_by_id="claude",
+            proposed_by_type="ai",
+            proposed_by_id="claude",
         )
         await decision_tools.resolve_decision(
-            storage, session,
-            event_id="evt_003", disposition="revised",
-            resolved_by_type="human", resolved_by_id="researcher",
+            storage,
+            session,
+            event_id="evt_003",
+            disposition="revised",
+            resolved_by_type="human",
+            resolved_by_id="researcher",
             revision_note="Use variant",
         )
         result = await session_tools.end_session(storage, active, session_id=session_id)
@@ -959,7 +1061,9 @@ class TestAttributionAudit:
         assert "1 rejection" in result
 
     async def test_audit_empty_session(
-        self, storage: JsonFileStorage, active: dict[str, Session],
+        self,
+        storage: JsonFileStorage,
+        active: dict[str, Session],
     ) -> None:
         await session_tools.start_session(storage, active, project="audit-test")
         session_id = list(active.keys())[0]
@@ -967,7 +1071,9 @@ class TestAttributionAudit:
         assert "No contributions, decisions, or corrections to review." in result
 
     async def test_audit_mixed_realistic(
-        self, storage: JsonFileStorage, active: dict[str, Session],
+        self,
+        storage: JsonFileStorage,
+        active: dict[str, Session],
     ) -> None:
         """Realistic session with 8+ events, full audit verification."""
         await session_tools.start_session(storage, active, project="audit-test")
@@ -976,55 +1082,76 @@ class TestAttributionAudit:
 
         # Tool call
         await logging_tools.log_tool_call(
-            storage, session, server="bash", tool_name="run",
-            input={"cmd": "test"}, status="success",
+            storage,
+            session,
+            server="bash",
+            tool_name="run",
+            input={"cmd": "test"},
+            status="success",
         )
         # Decision proposed + accepted
         await decision_tools.propose_decision(
-            storage, session,
+            storage,
+            session,
             description="Use cosine similarity",
-            proposed_by_type="ai", proposed_by_id="claude",
+            proposed_by_type="ai",
+            proposed_by_id="claude",
             suggestion_type="proactive",
         )
         await decision_tools.resolve_decision(
-            storage, session,
-            event_id="evt_002", disposition="accepted",
-            resolved_by_type="human", resolved_by_id="researcher",
+            storage,
+            session,
+            event_id="evt_002",
+            disposition="accepted",
+            resolved_by_type="human",
+            resolved_by_id="researcher",
         )
         # Contribution
         await logging_tools.log_contribution(
-            storage, session,
+            storage,
+            session,
             description="Similarity function",
-            direction="human", execution="ai",
+            direction="human",
+            execution="ai",
             artifact="src/sim.py",
         )
         # Annotation
         await logging_tools.log_annotation(
-            storage, session,
-            category="gotcha", content="Unicode issues",
+            storage,
+            session,
+            category="gotcha",
+            content="Unicode issues",
         )
         # Another contribution
         await logging_tools.log_contribution(
-            storage, session,
+            storage,
+            session,
             description="Test suite",
-            direction="ai", execution="ai",
+            direction="ai",
+            execution="ai",
             artifact="tests/test_sim.py",
         )
         # Decision rejected
         await decision_tools.propose_decision(
-            storage, session,
+            storage,
+            session,
             description="Use threshold 0.9",
-            proposed_by_type="ai", proposed_by_id="claude",
+            proposed_by_type="ai",
+            proposed_by_id="claude",
         )
         await decision_tools.resolve_decision(
-            storage, session,
-            event_id="evt_006", disposition="rejected",
-            resolved_by_type="human", resolved_by_id="researcher",
+            storage,
+            session,
+            event_id="evt_006",
+            disposition="rejected",
+            resolved_by_type="human",
+            resolved_by_id="researcher",
             revision_note="Too high",
         )
         # State change
         await logging_tools.log_state_change(
-            storage, session,
+            storage,
+            session,
             description="Switched model",
         )
 
@@ -1041,7 +1168,9 @@ class TestAttributionAudit:
 
 class TestDecisionChainEdgeCases:
     async def test_circular_chain_terminates(
-        self, storage: JsonFileStorage, active: dict[str, Session],
+        self,
+        storage: JsonFileStorage,
+        active: dict[str, Session],
     ) -> None:
         """A→B→A cycle should terminate without infinite loop."""
         await session_tools.start_session(storage, active, project="chain-test")
@@ -1050,15 +1179,19 @@ class TestDecisionChainEdgeCases:
 
         # Create decision A
         await decision_tools.propose_decision(
-            storage, session,
+            storage,
+            session,
             description="Decision A",
-            proposed_by_type="ai", proposed_by_id="claude",
+            proposed_by_type="ai",
+            proposed_by_id="claude",
         )
         # Create decision B that revises A
         await decision_tools.propose_decision(
-            storage, session,
+            storage,
+            session,
             description="Decision B",
-            proposed_by_type="ai", proposed_by_id="claude",
+            proposed_by_type="ai",
+            proposed_by_id="claude",
             revises_event_id="evt_001",
         )
         # Manually create cycle: patch A to revise B
@@ -1078,11 +1211,16 @@ class TestCreateSession:
     """Tests for the new create_session function used by auto-session."""
 
     async def test_create_session_returns_session_object(
-        self, storage: JsonFileStorage, active: dict[str, Session],
+        self,
+        storage: JsonFileStorage,
+        active: dict[str, Session],
     ) -> None:
         """create_session returns a Session, not a formatted string."""
         session = await session_tools.create_session(
-            storage, active, project="test-project", description="test",
+            storage,
+            active,
+            project="test-project",
+            description="test",
         )
         assert isinstance(session, Session)
         assert session.metadata.project == "test-project"
@@ -1090,29 +1228,42 @@ class TestCreateSession:
         assert session.id in active
 
     async def test_create_session_persists_to_disk(
-        self, storage: JsonFileStorage, active: dict[str, Session],
+        self,
+        storage: JsonFileStorage,
+        active: dict[str, Session],
     ) -> None:
         session = await session_tools.create_session(
-            storage, active, project="persist-test",
+            storage,
+            active,
+            project="persist-test",
         )
         # Load from disk independently
         loaded = await storage.get_session(session.id)
         assert loaded.metadata.project == "persist-test"
 
     async def test_create_session_with_tags(
-        self, storage: JsonFileStorage, active: dict[str, Session],
+        self,
+        storage: JsonFileStorage,
+        active: dict[str, Session],
     ) -> None:
         session = await session_tools.create_session(
-            storage, active, project="tag-test", tags=["auto-session"],
+            storage,
+            active,
+            project="tag-test",
+            tags=["auto-session"],
         )
         assert "auto-session" in session.metadata.tags
 
     async def test_start_session_still_returns_string(
-        self, storage: JsonFileStorage, active: dict[str, Session],
+        self,
+        storage: JsonFileStorage,
+        active: dict[str, Session],
     ) -> None:
         """Existing start_session API is unchanged — returns formatted string."""
         result = await session_tools.start_session(
-            storage, active, project="compat-test",
+            storage,
+            active,
+            project="compat-test",
         )
         assert isinstance(result, str)
         assert "TRACE audit logging is now active" in result
@@ -1123,7 +1274,9 @@ class TestAutoSession:
     """Tests for the server-level auto-session infrastructure."""
 
     async def test_ensure_session_with_explicit_id(
-        self, storage: JsonFileStorage, active: dict[str, Session],
+        self,
+        storage: JsonFileStorage,
+        active: dict[str, Session],
     ) -> None:
         """_ensure_session with explicit session_id returns that session."""
         import trace_mcp.server as srv
@@ -1135,7 +1288,9 @@ class TestAutoSession:
 
         try:
             session = await session_tools.create_session(
-                storage, active, project="explicit-test",
+                storage,
+                active,
+                project="explicit-test",
             )
             result_session, auto_msg = await srv._ensure_session(session.id)
             assert result_session.id == session.id
@@ -1146,7 +1301,9 @@ class TestAutoSession:
             srv._current_session_id = orig_current
 
     async def test_ensure_session_reuses_current(
-        self, storage: JsonFileStorage, active: dict[str, Session],
+        self,
+        storage: JsonFileStorage,
+        active: dict[str, Session],
     ) -> None:
         """_ensure_session with None reuses _current_session_id."""
         import trace_mcp.server as srv
@@ -1157,7 +1314,9 @@ class TestAutoSession:
 
         try:
             session = await session_tools.create_session(
-                storage, active, project="reuse-test",
+                storage,
+                active,
+                project="reuse-test",
             )
             srv._current_session_id = session.id
             result_session, auto_msg = await srv._ensure_session(None)
@@ -1168,7 +1327,9 @@ class TestAutoSession:
             srv._current_session_id = orig_current
 
     async def test_ensure_session_auto_creates(
-        self, storage: JsonFileStorage, active: dict[str, Session],
+        self,
+        storage: JsonFileStorage,
+        active: dict[str, Session],
     ) -> None:
         """_ensure_session auto-creates when no session exists."""
         import trace_mcp.server as srv
@@ -1190,7 +1351,9 @@ class TestAutoSession:
             srv._current_session_id = orig_current
 
     async def test_ensure_session_explicit_not_found_raises(
-        self, storage: JsonFileStorage, active: dict[str, Session],
+        self,
+        storage: JsonFileStorage,
+        active: dict[str, Session],
     ) -> None:
         """_ensure_session with invalid explicit ID raises FileNotFoundError."""
         import trace_mcp.server as srv
@@ -1207,7 +1370,9 @@ class TestAutoSession:
             srv._current_session_id = orig_current
 
     async def test_infer_project_from_recent_session(
-        self, storage: JsonFileStorage, active: dict[str, Session],
+        self,
+        storage: JsonFileStorage,
+        active: dict[str, Session],
     ) -> None:
         """_infer_project falls back to most recent session's project."""
         import trace_mcp.server as srv
@@ -1218,10 +1383,13 @@ class TestAutoSession:
         try:
             # Create a session so there's something to infer from
             await session_tools.create_session(
-                storage, active, project="inferred-project",
+                storage,
+                active,
+                project="inferred-project",
             )
             # Remove env var if set
             import os
+
             old_env = os.environ.pop("TRACE_DEFAULT_PROJECT", None)
             try:
                 project = await srv._infer_project()
@@ -1233,7 +1401,9 @@ class TestAutoSession:
             srv.storage = orig_storage
 
     async def test_infer_project_from_env_var(
-        self, storage: JsonFileStorage, active: dict[str, Session],
+        self,
+        storage: JsonFileStorage,
+        active: dict[str, Session],
     ) -> None:
         """_infer_project prefers TRACE_DEFAULT_PROJECT env var."""
         import os
@@ -1276,9 +1446,7 @@ class TestValidateSession:
             metadata=SessionMetadata(project="test"),
         )
         session_file = tmp_path / "trace_valid_001.json"
-        session_file.write_text(
-            json.dumps(session.model_dump(mode="json"), indent=2, default=str)
-        )
+        session_file.write_text(json.dumps(session.model_dump(mode="json"), indent=2, default=str))
         result = mod.main([str(session_file)])
         assert result == 0
 

--- a/tests/test_v041_attribution_audit.py
+++ b/tests/test_v041_attribution_audit.py
@@ -104,9 +104,7 @@ class TestExplicitAbsenceHelper:
 class TestMissingSnippetCounters:
     """v0.4.1 §3.4.1: count contributions and corrections missing snippets."""
 
-    async def test_contribution_without_snippet_is_counted(
-        self, storage: JsonFileStorage
-    ) -> None:
+    async def test_contribution_without_snippet_is_counted(self, storage: JsonFileStorage) -> None:
         session = _make_session("trace_test_contrib_missing")
         await storage.create_session(session)
 
@@ -127,9 +125,7 @@ class TestMissingSnippetCounters:
         assert audit.missing_snippet_contribution_count == 1
         assert audit.missing_snippet_correction_count == 0
 
-    async def test_correction_without_snippet_is_counted(
-        self, storage: JsonFileStorage
-    ) -> None:
+    async def test_correction_without_snippet_is_counted(self, storage: JsonFileStorage) -> None:
         session = _make_session("trace_test_correction_missing")
         await storage.create_session(session)
 
@@ -150,9 +146,7 @@ class TestMissingSnippetCounters:
         assert audit.missing_snippet_correction_count == 1
         assert audit.missing_snippet_contribution_count == 0
 
-    async def test_contribution_with_real_snippet_is_not_counted(
-        self, storage: JsonFileStorage
-    ) -> None:
+    async def test_contribution_with_real_snippet_is_not_counted(self, storage: JsonFileStorage) -> None:
         session = _make_session("trace_test_contrib_with_snippet")
         await storage.create_session(session)
 
@@ -177,9 +171,7 @@ class TestMissingSnippetCounters:
 class TestExplicitAbsenceCounters:
     """v0.4.1: snippets set to explicit absence markers count separately."""
 
-    async def test_autonomous_stretch_marker_is_explicit_absence(
-        self, storage: JsonFileStorage
-    ) -> None:
+    async def test_autonomous_stretch_marker_is_explicit_absence(self, storage: JsonFileStorage) -> None:
         session = _make_session("trace_test_autonomous_marker")
         await storage.create_session(session)
 
@@ -208,9 +200,7 @@ class TestExplicitAbsenceCounters:
 class TestAttributionWarningDetector:
     """v0.4.1 §3.6 Proposer Identity Rule: same-instance self-resolution."""
 
-    async def test_human_same_instance_self_resolution_counts(
-        self, storage: JsonFileStorage
-    ) -> None:
+    async def test_human_same_instance_self_resolution_counts(self, storage: JsonFileStorage) -> None:
         """The evt_025 pattern: human proposes and human accepts.
 
         Pre-v0.4.1 this was invisible. v0.4.1 surfaces it via
@@ -238,9 +228,7 @@ class TestAttributionWarningDetector:
         assert audit.attribution_warning_count == 1
         assert event.id in audit.attribution_warning_ids
 
-    async def test_single_actor_human_self_resolution_no_warning(
-        self, storage: JsonFileStorage
-    ) -> None:
+    async def test_single_actor_human_self_resolution_no_warning(self, storage: JsonFileStorage) -> None:
         """Round-3 A1 / decision evt_016: in a SINGLE-actor session
         ({human} only), human→human same-instance self-resolution must
         NOT increment attribution_warning_count. This is the false
@@ -268,9 +256,7 @@ class TestAttributionWarningDetector:
         assert audit.attribution_warning_count == 0
         assert audit.attribution_warning_ids == []
 
-    async def test_single_actor_ai_self_resolution_asymmetry(
-        self, storage: JsonFileStorage
-    ) -> None:
+    async def test_single_actor_ai_self_resolution_asymmetry(self, storage: JsonFileStorage) -> None:
         """Round-3 GAP-1: single-actor ai→ai self-resolution →
         self_resolution_count==1 (ai-only, ungated, backward-compat) but
         attribution_warning_count==0 (multi-actor-gated)."""
@@ -297,9 +283,7 @@ class TestAttributionWarningDetector:
         assert audit.self_resolution_count == 1
         assert audit.attribution_warning_count == 0
 
-    async def test_different_human_instances_no_warning(
-        self, storage: JsonFileStorage
-    ) -> None:
+    async def test_different_human_instances_no_warning(self, storage: JsonFileStorage) -> None:
         """Two different humans (e.g., reviewer + lead) does NOT trigger."""
         session = _make_session("trace_test_different_humans")
         await storage.create_session(session)
@@ -322,9 +306,7 @@ class TestAttributionWarningDetector:
         audit = _build_attribution_audit(session)
         assert audit.attribution_warning_count == 0
 
-    async def test_ai_self_resolution_counts_in_both_metrics(
-        self, storage: JsonFileStorage
-    ) -> None:
+    async def test_ai_self_resolution_counts_in_both_metrics(self, storage: JsonFileStorage) -> None:
         """ai→ai same-instance increments BOTH self_resolution_count (v0.3 ai-only)
         AND attribution_warning_count (v0.4.1 generalized). Backward compat."""
         session = _make_session("trace_test_ai_self_resolve")
@@ -379,9 +361,7 @@ class TestOrphanDiscoveryHint:
     """v0.4.1 §3.7 + §8.1: contributions describing discoveries without
     a near-in-time discovery/correction/gotcha annotation get flagged."""
 
-    async def test_contribution_with_discovery_phrase_no_anchor_fires(
-        self, storage: JsonFileStorage
-    ) -> None:
+    async def test_contribution_with_discovery_phrase_no_anchor_fires(self, storage: JsonFileStorage) -> None:
         """Plain contribution with 'discovered' in description, no prior annotation."""
         session = _make_session("trace_test_orphan_discovery")
         await storage.create_session(session)
@@ -403,9 +383,7 @@ class TestOrphanDiscoveryHint:
         assert audit.orphan_discovery_hint_count == 1
         assert event.id in audit.orphan_discovery_event_ids
 
-    async def test_orphan_discovery_is_hint_only_not_a_warning(
-        self, storage: JsonFileStorage
-    ) -> None:
+    async def test_orphan_discovery_is_hint_only_not_a_warning(self, storage: JsonFileStorage) -> None:
         """P4 / A8: orphan-discovery is a low-severity HINT
         (orphan_discovery_hint_count). It must NOT also be pushed into the
         higher-severity `warnings` list — that duplicate over-weighted a
@@ -427,14 +405,11 @@ class TestOrphanDiscoveryHint:
 
         audit = _build_attribution_audit(session)
         assert audit.orphan_discovery_hint_count == 1  # still surfaced as a hint
-        assert not any(
-            "discovery-language" in w or "moment of discovery" in w
-            for w in audit.warnings
-        ), f"orphan-discovery must not be a high-severity warning: {audit.warnings!r}"
+        assert not any("discovery-language" in w or "moment of discovery" in w for w in audit.warnings), (
+            f"orphan-discovery must not be a high-severity warning: {audit.warnings!r}"
+        )
 
-    async def test_innocuous_turned_out_phrase_does_not_fire(
-        self, storage: JsonFileStorage
-    ) -> None:
+    async def test_innocuous_turned_out_phrase_does_not_fire(self, storage: JsonFileStorage) -> None:
         """P4 / A8: 'turned out' is too broad ('turned out cleaner' etc.)
         and is dropped from the phrase list to cut false positives."""
         session = _make_session("trace_test_innocuous_phrase")
@@ -455,9 +430,7 @@ class TestOrphanDiscoveryHint:
         audit = _build_attribution_audit(session)
         assert audit.orphan_discovery_hint_count == 0
 
-    async def test_contribution_with_nearby_discovery_annotation_no_fire(
-        self, storage: JsonFileStorage
-    ) -> None:
+    async def test_contribution_with_nearby_discovery_annotation_no_fire(self, storage: JsonFileStorage) -> None:
         """Discovery annotation logged shortly before contribution → no orphan."""
         session = _make_session("trace_test_anchored_discovery")
         await storage.create_session(session)
@@ -493,9 +466,7 @@ class TestOrphanDiscoveryHint:
         # No orphan — there's a discovery anchor within 30min before
         assert audit.orphan_discovery_hint_count == 0
 
-    async def test_contribution_with_no_discovery_phrase_no_fire(
-        self, storage: JsonFileStorage
-    ) -> None:
+    async def test_contribution_with_no_discovery_phrase_no_fire(self, storage: JsonFileStorage) -> None:
         """Routine contribution description doesn't trigger the hint."""
         session = _make_session("trace_test_no_phrase")
         await storage.create_session(session)
@@ -527,9 +498,7 @@ class TestDispatchVisibilityHint:
     high enough to avoid permanent noise.
     """
 
-    async def test_high_contributions_no_tool_calls_claude_code_fires(
-        self, storage: JsonFileStorage
-    ) -> None:
+    async def test_high_contributions_no_tool_calls_claude_code_fires(self, storage: JsonFileStorage) -> None:
         session = _make_session("trace_test_dispatch_hint", with_claude_code_env=True)
         await storage.create_session(session)
 
@@ -634,9 +603,7 @@ class TestDispatchVisibilityHint:
         # Wrong client → no hint
         assert not any("[hint]" in w for w in audit.warnings)
 
-    async def test_no_environment_no_hint_no_crash(
-        self, storage: JsonFileStorage
-    ) -> None:
+    async def test_no_environment_no_hint_no_crash(self, storage: JsonFileStorage) -> None:
         """Round 3 amendment: guard against environment is None for legacy sessions."""
         session = _make_session("trace_test_no_env", with_claude_code_env=False)
         # environment remains None
@@ -671,9 +638,7 @@ class TestRenderOrdering:
     BEFORE less-critical ones (orphan-discovery hints, missing snippets).
     """
 
-    async def test_attribution_warning_before_missing_snippet_in_render(
-        self, storage: JsonFileStorage
-    ) -> None:
+    async def test_attribution_warning_before_missing_snippet_in_render(self, storage: JsonFileStorage) -> None:
         """Build a session triggering both signals, verify ordering."""
         session = _make_session("trace_test_render_order")
         await storage.create_session(session)

--- a/tests/test_v041_core_extension_boundary.py
+++ b/tests/test_v041_core_extension_boundary.py
@@ -52,13 +52,9 @@ async def test_project_summary_works_without_learn_extension(
 ) -> None:
     """trace_project_summary is a CORE tool — it must succeed when the
     trace-learn extension is absent (governance evt_002)."""
-    result = await session_tools.start_session(
-        storage, active, project="boundary-test", description="boundary"
-    )
+    result = await session_tools.start_session(storage, active, project="boundary-test", description="boundary")
     session_id = result.split("Session: ")[1].split("\n")[0]
-    await session_tools.end_session(
-        storage, active, session_id=session_id, summary="done"
-    )
+    await session_tools.end_session(storage, active, session_id=session_id, summary="done")
 
     _block_learn_extension(monkeypatch)
 
@@ -87,33 +83,45 @@ async def test_all_core_tools_run_without_learn_extension(
     _block_learn_extension(monkeypatch)
 
     # session lifecycle
-    start = await session_tools.start_session(
-        storage, active, project="boundary", description="full core sweep"
-    )
+    start = await session_tools.start_session(storage, active, project="boundary", description="full core sweep")
     sid = start.split("Session: ")[1].split("\n")[0]
     session = active[sid]
 
     # all four logging tools
-    await logging_tools.log_tool_call(
-        storage, session, server="s", tool_name="t", input={"q": 1}, status="success"
-    )
+    await logging_tools.log_tool_call(storage, session, server="s", tool_name="t", input={"q": 1}, status="success")
     await logging_tools.log_annotation(storage, session, category="gotcha", content="g")
     await logging_tools.log_state_change(
-        storage, session, description="env change", field="python",
-        old_value="3.12", new_value="3.13",
+        storage,
+        session,
+        description="env change",
+        field="python",
+        old_value="3.12",
+        new_value="3.13",
     )
     await logging_tools.log_contribution(
-        storage, session, description="a model", direction="human", execution="ai",
+        storage,
+        session,
+        description="a model",
+        direction="human",
+        execution="ai",
         conversation_snippet="build the model",
     )
 
     # both decision tools
     d_id = await decision_tools.propose_decision(
-        storage, session, description="use X", proposed_by_type="ai", proposed_by_id="claude",
+        storage,
+        session,
+        description="use X",
+        proposed_by_type="ai",
+        proposed_by_id="claude",
     )
     await decision_tools.resolve_decision(
-        storage, session, event_id=d_id, disposition="accepted",
-        resolved_by_type="human", resolved_by_id="researcher",
+        storage,
+        session,
+        event_id=d_id,
+        disposition="accepted",
+        resolved_by_type="human",
+        resolved_by_id="researcher",
     )
 
     # every query tool (sync; operate on the persisted session)

--- a/tests/test_v041_extension_status.py
+++ b/tests/test_v041_extension_status.py
@@ -88,9 +88,7 @@ async def test_start_session_response_includes_status(
 ) -> None:
     storage = JsonFileStorage(directory=str(tmp_path))
     active: dict[str, Session] = {}
-    result = await session_tools.start_session(
-        storage, active, project="status-test", description="d"
-    )
+    result = await session_tools.start_session(storage, active, project="status-test", description="d")
     assert "TRACE active" in result
     # Original content still present (additive, not replacing)
     assert "TRACE audit logging is now active." in result

--- a/tests/test_v041_p5_prov_roundtrip.py
+++ b/tests/test_v041_p5_prov_roundtrip.py
@@ -51,9 +51,7 @@ def _session_with_v041_prov_shapes() -> Session:
             session_id=s.id,
             type="annotation",
             actor=Actor(type="human", id="researcher"),
-            annotation=AnnotationData(
-                category="correction", content="fix", corrects_event_ids=["evt_001"]
-            ),
+            annotation=AnnotationData(category="correction", content="fix", corrects_event_ids=["evt_001"]),
         )
     )
     # URI-target correction → qualified prov:wasInfluencedBy + prov:atLocation
@@ -77,9 +75,7 @@ def _session_with_v041_prov_shapes() -> Session:
             session_id=s.id,
             type="tool_call",
             actor=Actor(type="ai", id="claude"),
-            tool_call=ToolCallData(
-                server="claude-code", name="Agent", input={}, parent_event_id="evt_001"
-            ),
+            tool_call=ToolCallData(server="claude-code", name="Agent", input={}, parent_event_id="evt_001"),
         )
     )
     return s

--- a/tests/test_v041_p9_atomic_npy.py
+++ b/tests/test_v041_p9_atomic_npy.py
@@ -40,9 +40,7 @@ def test_atomic_npy_roundtrip(tmp_path: Path) -> None:
     assert not list(tmp_path.glob("*.npy.tmp")), "temp residue left behind"
 
 
-def test_failed_save_does_not_corrupt_existing_sidecar(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_failed_save_does_not_corrupt_existing_sidecar(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     ks = _store_with_embedding("fault")
     # Baseline good sidecar.
     good_path = save_embeddings_cache(ks, directory=str(tmp_path))

--- a/tests/test_v041_p9_lazy_embedding.py
+++ b/tests/test_v041_p9_lazy_embedding.py
@@ -47,9 +47,7 @@ def fake_static_model(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
 def test_construction_does_not_load_model(fake_static_model: MagicMock) -> None:
     """Constructing the provider must NOT call StaticModel.from_pretrained."""
     provider = emb.Model2VecEmbeddingProvider()
-    assert fake_static_model.call_count == 0, (
-        "model loaded eagerly at __init__ — must be lazy"
-    )
+    assert fake_static_model.call_count == 0, "model loaded eagerly at __init__ — must be lazy"
     assert provider.model_name == "minishlab/potion-base-8M"
 
 

--- a/tests/test_v041_p9_lock.py
+++ b/tests/test_v041_p9_lock.py
@@ -41,14 +41,10 @@ def test_concurrent_adds_do_not_lose_updates(tmp_path: Path) -> None:
 
     ks = store.load_store("concur", directory=d)
     contents = {lrn.content for lrn in ks.learnings}
-    assert contents == {"alpha", "beta"}, (
-        f"lost update — lock did not serialize the RMW span: {contents}"
-    )
+    assert contents == {"alpha", "beta"}, f"lost update — lock did not serialize the RMW span: {contents}"
 
 
-def test_project_lock_graceful_without_filelock(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_project_lock_graceful_without_filelock(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """If filelock is unavailable the context manager is a safe no-op."""
     monkeypatch.setitem(sys.modules, "filelock", None)
     # Reset the one-time-warning flag so the fallback path is exercised.

--- a/tests/test_v041_prov_ld_split.py
+++ b/tests/test_v041_prov_ld_split.py
@@ -68,17 +68,22 @@ class TestCorrectionInvalidatedBy:
         session = _make_session()
         session.events.append(
             TraceEvent(
-                id="evt_001", session_id=session.id, type="annotation",
+                id="evt_001",
+                session_id=session.id,
+                type="annotation",
                 actor=Actor(type="ai", id="claude-opus-4.7"),
                 annotation=AnnotationData(category="observation", content="initial"),
             )
         )
         session.events.append(
             TraceEvent(
-                id="evt_002", session_id=session.id, type="annotation",
+                id="evt_002",
+                session_id=session.id,
+                type="annotation",
                 actor=Actor(type="human", id="researcher"),
                 annotation=AnnotationData(
-                    category="correction", content="that was wrong",
+                    category="correction",
+                    content="that was wrong",
                     corrects_event_ids=["evt_001"],
                 ),
             )
@@ -91,17 +96,22 @@ class TestCorrectionInvalidatedBy:
         session = _make_session()
         session.events.append(
             TraceEvent(
-                id="evt_001", session_id=session.id, type="annotation",
+                id="evt_001",
+                session_id=session.id,
+                type="annotation",
                 actor=Actor(type="ai", id="claude"),
                 annotation=AnnotationData(category="observation", content="x"),
             )
         )
         session.events.append(
             TraceEvent(
-                id="evt_002", session_id=session.id, type="annotation",
+                id="evt_002",
+                session_id=session.id,
+                type="annotation",
                 actor=Actor(type="human", id="researcher"),
                 annotation=AnnotationData(
-                    category="correction", content="wrong",
+                    category="correction",
+                    content="wrong",
                     corrects_event_ids=["evt_001"],
                 ),
             )
@@ -120,10 +130,13 @@ class TestCorrectionInfluencedByUri:
         uri = "external:https://example.com/transcript#L225"
         session.events.append(
             TraceEvent(
-                id="evt_001", session_id=session.id, type="annotation",
+                id="evt_001",
+                session_id=session.id,
+                type="annotation",
                 actor=Actor(type="human", id="researcher"),
                 annotation=AnnotationData(
-                    category="correction", content="claim was false",
+                    category="correction",
+                    content="claim was false",
                     corrects_event_ids=[uri],
                 ),
             )
@@ -139,10 +152,13 @@ class TestCorrectionInfluencedByUri:
         session = _make_session()
         session.events.append(
             TraceEvent(
-                id="evt_001", session_id=session.id, type="annotation",
+                id="evt_001",
+                session_id=session.id,
+                type="annotation",
                 actor=Actor(type="human", id="researcher"),
                 annotation=AnnotationData(
-                    category="correction", content="x",
+                    category="correction",
+                    content="x",
                     corrects_event_ids=["jsonl:/path#L1"],
                 ),
             )
@@ -154,10 +170,13 @@ class TestCorrectionInfluencedByUri:
         session = _make_session()
         session.events.append(
             TraceEvent(
-                id="evt_001", session_id=session.id, type="annotation",
+                id="evt_001",
+                session_id=session.id,
+                type="annotation",
                 actor=Actor(type="human", id="researcher"),
                 annotation=AnnotationData(
-                    category="correction", content="multi",
+                    category="correction",
+                    content="multi",
                     corrects_event_ids=["external:https://example.com/a", "jsonl:/path#L1"],
                 ),
             )
@@ -174,17 +193,22 @@ class TestMixedEventIdAndUriCorrection:
         session = _make_session()
         session.events.append(
             TraceEvent(
-                id="evt_001", session_id=session.id, type="annotation",
+                id="evt_001",
+                session_id=session.id,
+                type="annotation",
                 actor=Actor(type="ai", id="claude"),
                 annotation=AnnotationData(category="observation", content="x"),
             )
         )
         session.events.append(
             TraceEvent(
-                id="evt_002", session_id=session.id, type="annotation",
+                id="evt_002",
+                session_id=session.id,
+                type="annotation",
                 actor=Actor(type="human", id="researcher"),
                 annotation=AnnotationData(
-                    category="correction", content="wrong",
+                    category="correction",
+                    content="wrong",
                     corrects_event_ids=["evt_001", "external:https://example.com/source"],
                 ),
             )
@@ -201,21 +225,30 @@ class TestDispatchParentWasInformedBy:
         session = _make_session()
         session.events.append(
             TraceEvent(
-                id="evt_001", session_id=session.id, type="decision",
+                id="evt_001",
+                session_id=session.id,
+                type="decision",
                 actor=Actor(type="human", id="researcher"),
                 decision=DecisionData(
-                    description="start", proposed_by=Actor(type="human", id="researcher"),
-                    disposition="accepted", resolved_by=Actor(type="ai", id="claude-opus-4.7"),
+                    description="start",
+                    proposed_by=Actor(type="human", id="researcher"),
+                    disposition="accepted",
+                    resolved_by=Actor(type="ai", id="claude-opus-4.7"),
                 ),
             )
         )
         session.events.append(
             TraceEvent(
-                id="evt_002", session_id=session.id, type="tool_call",
+                id="evt_002",
+                session_id=session.id,
+                type="tool_call",
                 actor=Actor(type="ai", id="claude-opus-4.7"),
                 tool_call=ToolCallData(
-                    server="claude-code", name="Agent", input={"task": "x"},
-                    host="internal", parent_event_id="evt_001",
+                    server="claude-code",
+                    name="Agent",
+                    input={"task": "x"},
+                    host="internal",
+                    parent_event_id="evt_001",
                 ),
             )
         )
@@ -226,7 +259,9 @@ class TestDispatchParentWasInformedBy:
         session = _make_session()
         session.events.append(
             TraceEvent(
-                id="evt_001", session_id=session.id, type="tool_call",
+                id="evt_001",
+                session_id=session.id,
+                type="tool_call",
                 actor=Actor(type="ai", id="claude"),
                 tool_call=ToolCallData(server="mcp", name="search", input={"q": "x"}),
             )
@@ -242,22 +277,30 @@ class TestUnchangedRelations:
         session = _make_session()
         session.events.append(
             TraceEvent(
-                id="evt_001", session_id=session.id, type="decision",
+                id="evt_001",
+                session_id=session.id,
+                type="decision",
                 actor=Actor(type="ai", id="claude"),
                 decision=DecisionData(
-                    description="0.85", proposed_by=Actor(type="ai", id="claude"),
-                    disposition="revised", resolved_by=Actor(type="human", id="researcher"),
+                    description="0.85",
+                    proposed_by=Actor(type="ai", id="claude"),
+                    disposition="revised",
+                    resolved_by=Actor(type="human", id="researcher"),
                     revision_note="see evt_002",
                 ),
             )
         )
         session.events.append(
             TraceEvent(
-                id="evt_002", session_id=session.id, type="decision",
+                id="evt_002",
+                session_id=session.id,
+                type="decision",
                 actor=Actor(type="human", id="researcher"),
                 decision=DecisionData(
-                    description="0.80", proposed_by=Actor(type="human", id="researcher"),
-                    disposition="accepted", resolved_by=Actor(type="ai", id="claude"),
+                    description="0.80",
+                    proposed_by=Actor(type="human", id="researcher"),
+                    disposition="accepted",
+                    resolved_by=Actor(type="ai", id="claude"),
                     revises_event_id="evt_001",
                 ),
             )
@@ -269,14 +312,18 @@ class TestUnchangedRelations:
         session = _make_session()
         session.events.append(
             TraceEvent(
-                id="evt_001", session_id=session.id, type="tool_call",
+                id="evt_001",
+                session_id=session.id,
+                type="tool_call",
                 actor=Actor(type="ai", id="claude"),
                 tool_call=ToolCallData(server="mcp", name="s", input={"q": "x"}, status="error"),
             )
         )
         session.events.append(
             TraceEvent(
-                id="evt_002", session_id=session.id, type="tool_call",
+                id="evt_002",
+                session_id=session.id,
+                type="tool_call",
                 actor=Actor(type="ai", id="claude"),
                 tool_call=ToolCallData(server="mcp", name="s", input={"q": "x"}, retries_event_id="evt_001"),
             )
@@ -292,10 +339,13 @@ class TestConformance:
         session = _make_session()
         session.events.append(
             TraceEvent(
-                id="evt_001", session_id=session.id, type="annotation",
+                id="evt_001",
+                session_id=session.id,
+                type="annotation",
                 actor=Actor(type="ai", id="claude"),
                 annotation=AnnotationData(
-                    category="correction", content="x",
+                    category="correction",
+                    content="x",
                     corrects_event_ids=["external:https://example.com/foo"],
                 ),
             )

--- a/tests/test_v041_tool_call_wrapper.py
+++ b/tests/test_v041_tool_call_wrapper.py
@@ -100,9 +100,7 @@ class TestToolCallWrapperPassesV041Fields:
         assert len(tool_calls) == 1
         assert tool_calls[0]["tool_call"]["host"] == "mcp"
 
-    async def test_host_internal_passes_through(
-        self, server_and_dir: tuple[asyncio.subprocess.Process, str]
-    ) -> None:
+    async def test_host_internal_passes_through(self, server_and_dir: tuple[asyncio.subprocess.Process, str]) -> None:
         """host='internal' must reach the recorded event (the v0.4.1 subagent-dispatch use case)."""
         proc, tmpdir = server_and_dir
         sid, rid = await _start_session(proc)
@@ -112,9 +110,7 @@ class TestToolCallWrapperPassesV041Fields:
         tool_calls = [e for e in data["events"] if e["type"] == "tool_call"]
         assert tool_calls[0]["tool_call"]["host"] == "internal"
 
-    async def test_host_external_passes_through(
-        self, server_and_dir: tuple[asyncio.subprocess.Process, str]
-    ) -> None:
+    async def test_host_external_passes_through(self, server_and_dir: tuple[asyncio.subprocess.Process, str]) -> None:
         """host='external' must reach the recorded event (non-MCP external tools)."""
         proc, tmpdir = server_and_dir
         sid, rid = await _start_session(proc)
@@ -132,7 +128,9 @@ class TestToolCallWrapperPassesV041Fields:
 
         # First call: the parent / dispatching event.
         text1, rid = await _log_tool_call(
-            proc, sid, rid,
+            proc,
+            sid,
+            rid,
             tool_name="dispatch_subagents",
             host="internal",
         )
@@ -142,7 +140,9 @@ class TestToolCallWrapperPassesV041Fields:
 
         # Second call: child with parent_event_id pointing to the first.
         text2, rid = await _log_tool_call(
-            proc, sid, rid,
+            proc,
+            sid,
+            rid,
             tool_name="security_subagent",
             host="internal",
             parent_event_id=parent_id,
@@ -157,14 +157,14 @@ class TestToolCallWrapperPassesV041Fields:
         child = next(e for e in tool_calls if e["tool_call"]["name"] == "security_subagent")
         assert child["tool_call"]["parent_event_id"] == parent_id
 
-    async def test_dangling_parent_event_id_warns(
-        self, server_and_dir: tuple[asyncio.subprocess.Process, str]
-    ) -> None:
+    async def test_dangling_parent_event_id_warns(self, server_and_dir: tuple[asyncio.subprocess.Process, str]) -> None:
         """A parent_event_id that does not exist in-session must surface as a referential-integrity warning."""
         proc, _tmpdir = server_and_dir
         sid, rid = await _start_session(proc)
         text, _ = await _log_tool_call(
-            proc, sid, rid,
+            proc,
+            sid,
+            rid,
             host="internal",
             parent_event_id="evt_does_not_exist",
         )
@@ -172,9 +172,7 @@ class TestToolCallWrapperPassesV041Fields:
         assert "Dangling reference" in text or "evt_does_not_exist" in text
         assert "parent_event_id" in text
 
-    async def test_invalid_host_value_rejected(
-        self, server_and_dir: tuple[asyncio.subprocess.Process, str]
-    ) -> None:
+    async def test_invalid_host_value_rejected(self, server_and_dir: tuple[asyncio.subprocess.Process, str]) -> None:
         """host must be one of 'mcp' | 'internal' | 'external'; other values are rejected by Pydantic."""
         proc, tmpdir = server_and_dir
         sid, rid = await _start_session(proc)

--- a/tests/test_v041_uri_corrects_event_ids.py
+++ b/tests/test_v041_uri_corrects_event_ids.py
@@ -112,9 +112,7 @@ class TestUriSchemeHelperUnit:
 class TestUriFormCorrectsEventIdsE2E:
     """E2E tests: real storage, real session lifecycle, real validator."""
 
-    async def test_external_scheme_accepted_through_append_event(
-        self, storage: JsonFileStorage
-    ) -> None:
+    async def test_external_scheme_accepted_through_append_event(self, storage: JsonFileStorage) -> None:
         """A correction with external: scheme MUST NOT raise on append.
 
         This is the canonical scenario that was failing pre-L3.1: a
@@ -196,9 +194,7 @@ class TestUriFormCorrectsEventIdsE2E:
             "tool-result:xyz",
         ]
 
-    async def test_mixed_event_id_and_uri_form_accepted(
-        self, storage: JsonFileStorage
-    ) -> None:
+    async def test_mixed_event_id_and_uri_form_accepted(self, storage: JsonFileStorage) -> None:
         """A correction can anchor to both an in-session event ID AND a URI.
 
         Real workflow: the corrected work produced a contribution that's
@@ -243,9 +239,7 @@ class TestUriFormCorrectsEventIdsE2E:
         with pytest.raises(ValueError, match="Dangling reference"):
             await append_event(storage, session, event)
 
-    async def test_dangling_mixed_with_uri_still_raises_for_bad_event_id(
-        self, storage: JsonFileStorage
-    ) -> None:
+    async def test_dangling_mixed_with_uri_still_raises_for_bad_event_id(self, storage: JsonFileStorage) -> None:
         """A URI-form entry does NOT shield a bad event-ID entry beside it.
 
         Each entry is validated independently per its kind. URI-form
@@ -262,9 +256,7 @@ class TestUriFormCorrectsEventIdsE2E:
         with pytest.raises(ValueError, match="Dangling reference"):
             await append_event(storage, session, event)
 
-    async def test_uppercase_scheme_treated_as_event_id_and_fails_validation(
-        self, storage: JsonFileStorage
-    ) -> None:
+    async def test_uppercase_scheme_treated_as_event_id_and_fails_validation(self, storage: JsonFileStorage) -> None:
         """A string like `EXTERNAL:foo` is NOT URI-form (must be lowercase).
 
         Therefore it falls through to event-ID validation and (since no
@@ -292,9 +284,7 @@ class TestNonCorrectionFieldsUnchanged:
     event-ID-only.
     """
 
-    async def test_revises_event_id_still_validated(
-        self, storage: JsonFileStorage
-    ) -> None:
+    async def test_revises_event_id_still_validated(self, storage: JsonFileStorage) -> None:
         """A decision's revises_event_id must still be a real event ID."""
         from trace_mcp.schema.events import DecisionData
 
@@ -315,9 +305,7 @@ class TestNonCorrectionFieldsUnchanged:
         with pytest.raises(ValueError, match="Dangling reference"):
             await append_event(storage, session, bad)
 
-    async def test_related_decision_ids_still_validated(
-        self, storage: JsonFileStorage
-    ) -> None:
+    async def test_related_decision_ids_still_validated(self, storage: JsonFileStorage) -> None:
         """A contribution's related_decision_ids must reference real events."""
         from trace_mcp.schema.events import ContributionData
 

--- a/tests/test_v042_cheap_bootstrap.py
+++ b/tests/test_v042_cheap_bootstrap.py
@@ -59,8 +59,11 @@ def test_format_bootstrap_message_is_pure_and_complete():
         session_id="trace_x",
         project="P",
         path="/tmp/trace_x.json",
-        brief={"matched": 2, "capped": False,
-               "most_recent": {"id": "trace_prev", "event_count": 5, "created": "2026-05-30T00:00:00"}},
+        brief={
+            "matched": 2,
+            "capped": False,
+            "most_recent": {"id": "trace_prev", "event_count": 5, "created": "2026-05-30T00:00:00"},
+        },
         recalled_block="",
     )
     assert "trace_x" in msg and "P" in msg

--- a/tests/test_v042_payload_caps.py
+++ b/tests/test_v042_payload_caps.py
@@ -91,9 +91,7 @@ async def test_search_events_core_still_returns_list(storage, active):
 
 async def test_health_check_caps_scan(storage):
     for i in range(5):
-        await storage.create_session(
-            Session(id=f"trace_2026010{i}_000000", metadata=SessionMetadata(project="hc"))
-        )
+        await storage.create_session(Session(id=f"trace_2026010{i}_000000", metadata=SessionMetadata(project="hc")))
     result = await query_tools.health_check(storage, scan_cap=2)
     assert result["sessions_scanned"] <= 2
     assert result["scan_truncated"] is True

--- a/tests/test_v042_storage_concurrency.py
+++ b/tests/test_v042_storage_concurrency.py
@@ -138,9 +138,11 @@ async def test_resolve_decision_preserves_concurrent_append(storage):
     active: dict = {}
     session = await session_tools.create_session(storage, active, project="cc")
     d_id = await decision_tools.propose_decision(
-        storage, session,
+        storage,
+        session,
         description="use method X",
-        proposed_by_type="ai", proposed_by_id="claude",
+        proposed_by_type="ai",
+        proposed_by_id="claude",
     )
 
     # Another writer appends an annotation to disk; `session` view doesn't see it.
@@ -149,9 +151,12 @@ async def test_resolve_decision_preserves_concurrent_append(storage):
 
     # Resolve the decision using the (now stale) session view.
     await decision_tools.resolve_decision(
-        storage, session,
-        event_id=d_id, disposition="accepted",
-        resolved_by_type="human", resolved_by_id="researcher",
+        storage,
+        session,
+        event_id=d_id,
+        disposition="accepted",
+        resolved_by_type="human",
+        resolved_by_id="researcher",
     )
 
     final = await storage.get_session(session.id)

--- a/tests/test_validate_cli.py
+++ b/tests/test_validate_cli.py
@@ -55,9 +55,7 @@ class TestSchemaPackaging:
     def test_generated_schema_is_fresh(self) -> None:
         """Regenerating from the Pydantic models must reproduce both checked-in
         copies byte-for-byte (catches model drift without touching the tree)."""
-        spec = importlib.util.spec_from_file_location(
-            "generate_schema", TRACE_ROOT / "scripts" / "generate_schema.py"
-        )
+        spec = importlib.util.spec_from_file_location("generate_schema", TRACE_ROOT / "scripts" / "generate_schema.py")
         assert spec and spec.loader
         mod = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(mod)
@@ -96,9 +94,7 @@ class TestValidateFile:
         assert validate_file(garbage, load_schema()) is False
         assert "Invalid JSON" in capsys.readouterr().out
 
-    def test_nonexistent_file_fails_without_traceback(
-        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
-    ) -> None:
+    def test_nonexistent_file_fails_without_traceback(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
         """A missing file must produce a per-file FAIL line (so multi-file
         runs continue), never an unhandled traceback."""
         assert validate_file(tmp_path / "does-not-exist.json", load_schema()) is False
@@ -110,9 +106,7 @@ class TestValidateFile:
         assert validate_file(tmp_path, load_schema()) is False
         assert "FAIL" in capsys.readouterr().out
 
-    def test_non_utf8_file_fails_without_traceback(
-        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
-    ) -> None:
+    def test_non_utf8_file_fails_without_traceback(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
         binary = tmp_path / "binary.json"
         binary.write_bytes(b"\xff\xfe\x00\x01")
         assert validate_file(binary, load_schema()) is False


### PR DESCRIPTION
## Summary

- Align the static-quality gates across CI, the release workflow, CONTRIBUTING, and the actual tree, and fix the underlying debt so each gate runs on the full tree.

## Why

The documented gates did not match what CI enforced: `ruff check` and `pyright` were gated on `src/` only while CONTRIBUTING promised the full tree; `ruff format` was documented but never gated and never applied (53 unformatted files); and the full tree carried 2 pyright errors + 27 unused-symbol warnings. Documented-but-unenforced gates drift silently — this closes the gap and keeps the gate commands identical across CI, release, and docs so they cannot diverge again.

## Changes

- **CI + release** (`ci.yml`, `release.yml`): lint, format, and type checks now run on the full tree — `ruff check .`, `ruff format --check .`, `uv run pyright`.
- **Format debt**: applied `ruff format` across the tree (53 files), then gated `ruff format --check .`.
- **Type debt**: fixed 2 errors + 27 warnings at the source — cast a deliberate partial test stub to its storage interface; reference the schema importability-probe symbols; mark the optional-dependency and pytest-collection import probes with `pyright: ignore`. Full-tree `pyright` is now 0 errors / 0 warnings.
- **Docs**: corrected CONTRIBUTING's stale gate-scope and test-count claims; added a "Commit and PR messages" section; added `.github/pull_request_template.md` and `docs/maintenance.md` (gate / commit-PR / tagging / release conventions + maintenance backlog).

## Verification

- [x] `uv run ruff check .` and `uv run ruff format --check .`
- [x] `uv run pyright` — 0 errors / 0 warnings, full tree
- [x] `uv run pytest` — 959 passed, 11 skipped
- [ ] Built/verified artifact — n/a (no packaging change)
- [ ] Invariant guard — n/a (no write-path or invariant change; `tests/test_invariants.py` passes within the suite)

## Notes

- **Tagging**: `docs/maintenance.md` records the going-forward `vX.Y.Z`-per-release convention. Creating and pushing the actual version tags is intentionally deferred — a pushed tag currently triggers the (paused) PyPI publish, so the tag/publish coupling needs to be made safe first.
