### PR TITLE
feat(embeddings): unified TRACE_LOCAL_ONLY kill switch + egress disclosure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Egress kill switch + point-of-use disclosure
+
+- **`TRACE_LOCAL_ONLY=1` — one switch, no egress anywhere.** Forces all three
+  `trace-learn` cloud paths off in a single flag: OpenAI embeddings, LLM
+  extraction, and LLM matching. Enforced at config load (it overrides an explicit
+  `TRACE_EMBEDDING_BACKEND=openai` down to local `auto` and disables LLM features
+  regardless of key presence), so every downstream reader honors it. This closes
+  the "off-switch trap" where disabling one path (`TRACE_LLM_ENABLED=false` or
+  `TRACE_EMBEDDING_BACKEND=none`) still left the other egressing content.
+- **Point-of-use egress disclosure.** The `trace_learn_extract`,
+  `trace_learn_recall`, and `trace_learn_add` tool docstrings now state, at the
+  point of use, that content is sent to OpenAI when the OpenAI backend/LLM is
+  configured, and how to stay local (`TRACE_LOCAL_ONLY=1`).
+
 ### Local-strong embedding tier + local-first default
 
 - **Fully-local, open-weight embedding option (`fastembed` backend).** Adds a

--- a/docs/embeddings.md
+++ b/docs/embeddings.md
@@ -65,6 +65,23 @@ export OPENAI_API_KEY=not-needed-but-sdk-wants-one
 
 Because the endpoint is local, no content leaves your machine.
 
+## One switch to disable all egress
+
+`auto` is already local-first for *embeddings*, but the LLM extraction and
+LLM-matching paths can still use OpenAI when a key is configured. To force
+**everything** local in one move — no OpenAI embeddings, no LLM extraction, no
+LLM matching — set:
+
+```bash
+export TRACE_LOCAL_ONLY=1
+```
+
+This is the single, unambiguous kill switch. It overrides an explicit
+`TRACE_EMBEDDING_BACKEND=openai` (down to local `auto`) and disables cloud LLM
+features regardless of whether a key is present. It closes the "off-switch trap"
+where disabling one path (`TRACE_LLM_ENABLED=false` **or**
+`TRACE_EMBEDDING_BACKEND=none`) still left the other egressing.
+
 ## Switching backends re-embeds your store
 
 Each learning records the model that produced its vector. When you change the

--- a/src/trace_mcp/extensions/learn/__init__.py
+++ b/src/trace_mcp/extensions/learn/__init__.py
@@ -153,6 +153,10 @@ def register(mcp: FastMCP, storage: TraceStorage) -> None:
         and tag matching. Returns scored results above the threshold.
 
         When threshold is None, uses the backend's default (BM25: 0.15, LLM: 0.2).
+
+        Data flow: with the OpenAI embedding/LLM backend configured, the query
+        text is sent to OpenAI to score matches. Set ``TRACE_LOCAL_ONLY=1`` to
+        keep recall fully local.
         """
         try:
             # Lock the full span (recall may backfill
@@ -207,6 +211,9 @@ def register(mcp: FastMCP, storage: TraceStorage) -> None:
 
         Use this to record insights, patterns, or corrections that should
         persist across sessions.
+
+        Data flow: with the OpenAI embedding backend configured, the learning
+        content is embedded via OpenAI. Set ``TRACE_LOCAL_ONLY=1`` for local-only.
         """
         try:
             if category not in _VALID_CATEGORIES:
@@ -316,6 +323,12 @@ def register(mcp: FastMCP, storage: TraceStorage) -> None:
         on the same session produces no duplicates.
 
         Uses LLM-enhanced extraction when configured, otherwise rule-based.
+
+        Data flow: when an OpenAI key is configured and LLM features are enabled,
+        this sends session event content (and the existing knowledge store, as
+        de-duplication context) to OpenAI for extraction. To keep everything on
+        your machine, set ``TRACE_LOCAL_ONLY=1`` (forces local embeddings +
+        rule-based extraction, no egress). See docs/embeddings.md.
 
         If session_id is provided, extracts from that session only.
         Otherwise, extracts from all sessions for the project.

--- a/src/trace_mcp/extensions/learn/config.py
+++ b/src/trace_mcp/extensions/learn/config.py
@@ -83,6 +83,10 @@ class LearnConfig:
     # BM25/rule-based. Auto-defaults to True when an API key is present — the
     # assumption being "if you configured it, you expect it to work."
     strict_llm: bool = True
+    # Unified kill switch: when True, ALL cloud egress is off — no OpenAI
+    # embeddings and no LLM extraction/matching — regardless of key presence or
+    # backend. Set via TRACE_LOCAL_ONLY; enforced in load_config().
+    local_only: bool = False
     bm25_k1: float = 1.5
     bm25_b: float = 0.75
     tag_weight: float = 0.3
@@ -118,6 +122,7 @@ def load_config() -> LearnConfig:
         "TRACE_LLM_EXTRACTION_MODEL",
         "TRACE_LLM_ENABLED",
         "TRACE_STRICT_LLM",
+        "TRACE_LOCAL_ONLY",
         "TRACE_BM25_K1",
         "TRACE_BM25_B",
         "TRACE_TAG_WEIGHT",
@@ -160,6 +165,21 @@ def load_config() -> LearnConfig:
             merged.get("TRACE_LLM_MODEL", "gpt-5.4-mini"),
         )
 
+    local_only = merged.get("TRACE_LOCAL_ONLY", "false").lower() in ("true", "1", "yes")
+    embedding_backend = merged.get("TRACE_EMBEDDING_BACKEND", "auto")
+    if local_only:
+        # One switch, all three egress paths: force cloud LLM features off and
+        # override an explicit OpenAI embedding backend to the local-first "auto".
+        # Closes the off-switch trap (TRACE_LLM_ENABLED=false alone still egressed
+        # via embeddings; TRACE_EMBEDDING_BACKEND=none alone still egressed via
+        # LLM matching/extraction).
+        if llm_enabled:
+            logger.info("TRACE_LOCAL_ONLY is set — forcing LLM features off (no cloud extraction/matching).")
+        llm_enabled = False
+        if embedding_backend == "openai":
+            logger.warning("TRACE_LOCAL_ONLY is set — overriding TRACE_EMBEDDING_BACKEND=openai to local 'auto'.")
+            embedding_backend = "auto"
+
     decay_enabled = merged.get("TRACE_DECAY_ENABLED", "true").lower() in ("true", "1", "yes")
     dedup_enabled = merged.get("TRACE_DEDUP_ENABLED", "true").lower() in ("true", "1", "yes")
 
@@ -169,6 +189,7 @@ def load_config() -> LearnConfig:
         llm_extraction_model=merged.get("TRACE_LLM_EXTRACTION_MODEL", "gpt-5.4-mini"),
         llm_enabled=llm_enabled,
         strict_llm=strict_llm,
+        local_only=local_only,
         bm25_k1=float(merged.get("TRACE_BM25_K1", "1.5")),
         bm25_b=float(merged.get("TRACE_BM25_B", "0.75")),
         tag_weight=float(merged.get("TRACE_TAG_WEIGHT", "0.3")),
@@ -178,7 +199,7 @@ def load_config() -> LearnConfig:
         evergreen_floor=float(merged.get("TRACE_EVERGREEN_FLOOR", "0.8")),
         dedup_enabled=dedup_enabled,
         dedup_threshold=float(merged.get("TRACE_DEDUP_THRESHOLD", "0.85")),
-        embedding_backend=merged.get("TRACE_EMBEDDING_BACKEND", "auto"),
+        embedding_backend=embedding_backend,
         embedding_model=merged.get("TRACE_EMBEDDING_MODEL", "text-embedding-3-small"),
         embedding_base_url=merged.get("TRACE_OPENAI_BASE_URL") or merged.get("OPENAI_BASE_URL") or None,
     )

--- a/src/trace_mcp/extensions/learn/embeddings.py
+++ b/src/trace_mcp/extensions/learn/embeddings.py
@@ -257,6 +257,13 @@ def get_embedding_provider(config: LearnConfig | None = None) -> EmbeddingProvid
 
     backend = config.embedding_backend
 
+    # Belt-and-suspenders for the unified kill switch: a local-only config must
+    # never reach the cloud provider even if backend=="openai". load_config()
+    # already downgrades this, but library callers / tests may build a
+    # LearnConfig directly and bypass that enforcement.
+    if config.local_only and backend == "openai":
+        backend = "auto"
+
     if backend == "none":
         return None
 

--- a/tests/test_local_only_kill_switch.py
+++ b/tests/test_local_only_kill_switch.py
@@ -1,0 +1,64 @@
+"""Tests for the unified TRACE_LOCAL_ONLY kill switch.
+
+A single opt-in flag must force ALL three trace-learn egress paths off-machine:
+- embeddings   (``embedding_backend`` must not resolve to ``openai``)
+- LLM matching (gated by ``llm_enabled``)
+- LLM extraction (gated by ``llm_enabled``)
+
+This closes the "off-switch trap" where ``TRACE_LLM_ENABLED=false`` alone still
+egressed content via the embedding path (and ``TRACE_EMBEDDING_BACKEND=none``
+alone still egressed via LLM matching/extraction). The switch is enforced at
+config load so every downstream reader honors it with no per-site logic.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from trace_mcp.extensions.learn.config import LearnConfig, load_config
+from trace_mcp.extensions.learn.embeddings import OpenAIEmbeddingProvider, get_embedding_provider
+
+_EMB = "trace_mcp.extensions.learn.embeddings"
+
+
+class TestLocalOnlyKillSwitch:
+    def test_env_sets_local_only_and_disables_cloud(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-x")
+        monkeypatch.setenv("TRACE_EMBEDDING_BACKEND", "openai")
+        monkeypatch.setenv("TRACE_LLM_ENABLED", "true")
+        monkeypatch.setenv("TRACE_LOCAL_ONLY", "1")
+        cfg = load_config()
+        assert cfg.local_only is True
+        assert cfg.llm_enabled is False  # LLM matching + extraction forced off
+        assert cfg.embedding_backend != "openai"  # embedding egress forced off
+
+    def test_local_only_off_by_default(self, monkeypatch):
+        monkeypatch.delenv("TRACE_LOCAL_ONLY", raising=False)
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-x")
+        cfg = load_config()
+        assert cfg.local_only is False
+
+    def test_local_only_provider_never_openai_even_if_backend_openai(self):
+        """A directly-constructed local-only config must never yield the cloud provider."""
+        cfg = LearnConfig(openai_api_key="sk-x", embedding_backend="openai", local_only=True)
+        with patch(f"{_EMB}._HAS_OPENAI", True):
+            with patch(f"{_EMB}.AsyncOpenAI"):
+                with patch(f"{_EMB}._HAS_FASTEMBED", False):
+                    with patch(f"{_EMB}._HAS_MODEL2VEC", False):
+                        provider = get_embedding_provider(cfg)
+        assert not isinstance(provider, OpenAIEmbeddingProvider)
+
+    def test_local_only_still_allows_local_backend(self):
+        """Local-only forbids OpenAI but still uses an installed local backend."""
+        cfg = LearnConfig(openai_api_key="sk-x", embedding_backend="openai", local_only=True)
+        from unittest.mock import MagicMock
+
+        from trace_mcp.extensions.learn.embeddings import Model2VecEmbeddingProvider
+
+        inst = MagicMock()
+        inst.dim = 256
+        with patch(f"{_EMB}._HAS_FASTEMBED", False):
+            with patch(f"{_EMB}._HAS_MODEL2VEC", True):
+                with patch("model2vec.StaticModel.from_pretrained", return_value=inst):
+                    provider = get_embedding_provider(cfg)
+        assert isinstance(provider, Model2VecEmbeddingProvider)


### PR DESCRIPTION
Stacked on #21 (base is `feat/local-embedding-backends`; will retarget to `main` when #21 merges).

## Summary

One flag that forces **all three** `trace-learn` cloud paths off — OpenAI embeddings, LLM extraction, and LLM matching — plus point-of-use disclosure of what leaves the machine.

- **`TRACE_LOCAL_ONLY=1`**, enforced at config load: forces `llm_enabled=False` and overrides an explicit `TRACE_EMBEDDING_BACKEND=openai` down to local `auto`, so every downstream reader honors it with no per-site logic. A defensive guard in `get_embedding_provider` also covers configs constructed directly (bypassing `load_config`).
- **Point-of-use disclosure**: the `trace_learn_extract`, `trace_learn_recall`, and `trace_learn_add` tool docstrings now state that content is sent to OpenAI when the OpenAI backend/LLM is configured, and how to stay local.

## Why

`auto` is already local-first for *embeddings* (#21), but the LLM extraction and matching paths still use OpenAI when a key is present. This closes the "off-switch trap": before, disabling one path (`TRACE_LLM_ENABLED=false` **or** `TRACE_EMBEDDING_BACKEND=none`) left the other silently egressing. `TRACE_LOCAL_ONLY` is the single, unambiguous switch, and the docstrings make the data flow visible where a user actually invokes it — aligning the tool with its own transparency premise.

## Verification

- `tests/test_local_only_kill_switch.py` (new): env sets the flag and disables all cloud; off by default; a local-only config never yields the OpenAI provider even with `backend=openai`; a local backend is still used.
- Full suite: 979 passed / 11 skipped. `ruff` clean; `uv run pyright` 0 errors.