### PR TITLE
fix(storage): scope project queries by exact match, not substring (INV-4)

### DIFF
--- a/docs/INVARIANTS.md
+++ b/docs/INVARIANTS.md
@@ -78,21 +78,24 @@ the parameter as a `Literal`.
 
 ---
 
-## INV-4 — Project scoping uses ONE comparison rule across core and hooks  · OPEN
+## INV-4 — Project scoping uses ONE comparison rule across core and hooks  · CLOSED
 
 **Statement.** A project name must resolve to the **same** session set in the
-core query layer and in the adapter hooks. Today they disagree: core
-(`json_file.py :: list_sessions` / `session_brief`) uses case-insensitive
-**substring** match (so `trace_project_summary("trace")` silently merges
-`trace-mcp` and `TRACE-research`), while the hooks use **exact** match.
+core query layer and in the adapter hooks. The single shared predicate is
+**exact, case-sensitive** match (`metadata.project == project`). A
+case-insensitive **substring** match must never be used, as it silently merges
+distinct projects (e.g. `trace_project_summary("trace")` pulling in `trace-mcp`
+and `TRACE-research`).
 
 **Sites:** `src/trace_mcp/storage/json_file.py` (`list_sessions`,
 `session_brief`); `src/trace_mcp/adapters/claude_code/assets/hooks/*.sh`.
 
-**Status.** OPEN — still present on `main`. The fix
-(make core exact, or an explicit `exact=` flag defaulting to exact) is tracked
-as a follow-up; `tests/test_invariants.py` should fail until the two layers
-share one predicate.
+**Guard:** `tests/test_invariants.py :: test_inv4_project_filter_is_exact_not_substring`
+fails if the substring idiom reappears at either core filter site; the exact
+semantics are pinned by `tests/test_storage.py :: test_list_filter_by_project`.
+
+**Status.** CLOSED — core (`list_sessions`, `session_brief`) now uses the same
+exact-match predicate as the hooks, so both layers resolve one session set.
 
 ---
 

--- a/src/trace_mcp/storage/json_file.py
+++ b/src/trace_mcp/storage/json_file.py
@@ -263,7 +263,11 @@ class JsonFileStorage(TraceStorage):
                 with open(path) as f:
                     raw = json.load(f)
                 proj = raw.get("metadata", {}).get("project", "")
-                if project and project.lower() not in proj.lower():
+                # INV-4: EXACT (case-sensitive) project match — the same predicate
+                # the adapter hooks use (metadata.project == project). A substring
+                # match here silently merged distinct projects (e.g. "trace" pulling
+                # in "trace-mcp" and "TRACE-research").
+                if project and proj != project:
                     continue
                 summaries.append(
                     {
@@ -307,7 +311,9 @@ class JsonFileStorage(TraceStorage):
             except (json.JSONDecodeError, OSError):
                 continue
             proj = raw.get("metadata", {}).get("project", "")
-            if project and project.lower() not in proj.lower():
+            # INV-4: EXACT (case-sensitive) project match — same predicate as the
+            # adapter hooks and list_sessions above (no substring merging).
+            if project and proj != project:
                 continue
             matched += 1
             if most_recent is None:

--- a/tests/test_invariants.py
+++ b/tests/test_invariants.py
@@ -100,3 +100,23 @@ def test_inv3_resolve_decision_validates_before_write() -> None:
         "INV-3 violation: resolve_decision no longer validates the decision via "
         "model_validate before writing — an invalid disposition could reach disk."
     )
+
+
+# ── INV-4: project scoping uses ONE (exact) predicate across core + hooks ──
+# The core query filters (list_sessions, session_brief) must match projects
+# EXACTLY (metadata.project == project) — the same predicate the adapter hooks
+# use — never a case-insensitive SUBSTRING match, which silently merged distinct
+# projects (e.g. "trace" pulling in "trace-mcp" and "TRACE-research"). See INV-4.
+
+
+def test_inv4_project_filter_is_exact_not_substring() -> None:
+    source = (SRC / "storage" / "json_file.py").read_text(encoding="utf-8")
+    assert "not in proj.lower()" not in source, (
+        "INV-4 regression: json_file.py filters projects by case-insensitive "
+        "SUBSTRING again — core must match projects EXACTLY (proj != project), "
+        "the same predicate the adapter hooks use, or distinct projects merge."
+    )
+    assert source.count("proj != project") >= 2, (
+        "INV-4: both list_sessions and session_brief must filter by exact project "
+        "match (proj != project) so core and hooks resolve one session set."
+    )

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -135,9 +135,12 @@ class TestListSessions:
                 metadata=SessionMetadata(project="materials-science"),
             )
         )
-        result = await storage.list_sessions(project="climate")
-        assert len(result) == 1
-        assert result[0]["project"] == "climate-analysis"
+        # INV-4: project filtering is EXACT (case-sensitive), matching the adapter
+        # hooks — a substring like "climate" must NOT merge in "climate-analysis".
+        assert await storage.list_sessions(project="climate") == []
+        exact = await storage.list_sessions(project="climate-analysis")
+        assert len(exact) == 1
+        assert exact[0]["project"] == "climate-analysis"
 
     async def test_list_limit(self, storage: JsonFileStorage) -> None:
         for i in range(5):


### PR DESCRIPTION
## Summary

`list_sessions` and `session_brief` filtered projects with a case-insensitive **substring** match, so a short project name silently merged distinct projects — e.g. `trace_project_summary("trace")` pulled in `trace-mcp` and `TRACE-research` into one result set. The adapter hooks already match projects **exactly** (`metadata.project == project`); core now uses the same predicate, so both layers resolve one session set.

## Why

This is the registered **INV-4** ("project scoping uses ONE comparison rule across core and hooks"), previously OPEN on `main`. A caller asking for one project's provenance could silently receive several projects' sessions — a correctness/scoping defect independent of any trust model.

## Verification

- `tests/test_storage.py::test_list_filter_by_project` updated to pin the exact-match contract (a substring query returns nothing; the exact name returns its one session).
- New durable guard `tests/test_invariants.py::test_inv4_project_filter_is_exact_not_substring` fails if the substring idiom reappears at either filter site.
- `docs/INVARIANTS.md` INV-4 moved OPEN → CLOSED.
- Full suite: 960 passed / 11 skipped. `ruff` clean; `uv run pyright` 0 errors.