### PR TITLE
fix(server,config): stop foreign-project misroute in auto-sessions + correct key-precedence docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Auto-created sessions no longer inherit a foreign project.** `_infer_project`
+  fell back to the most-recent session across the *shared* store, so when the
+  newest session on disk belonged to a different project, a pointer-less
+  `trace_log_*` call auto-created a session — and routed any learnings later
+  extracted from it — under that unrelated project. With no
+  `TRACE_DEFAULT_PROJECT` it now returns the stable `"auto"` sentinel rather than
+  a foreign project name.
+- **Corrected the OpenAI-key precedence docstring.** `config.py` described
+  resolution as "first match wins" and labeled `./.env` a "project-level
+  override", but the real behavior is a merge where the global `~/.trace/.env`
+  OVERRIDES a project-local `./.env` (env var > global > project). The docstring
+  now states this so a project's `./.env` is not mistaken for an override of the
+  shared key.
 - **Wheels built from the sdist were missing 7 runtime files** (`py.typed` and
   all six `adapters/claude_code/assets/` files: the settings template, the
   CLAUDE block, and the four hook scripts). The sdist allowlist's only src

--- a/src/trace_mcp/extensions/learn/config.py
+++ b/src/trace_mcp/extensions/learn/config.py
@@ -2,10 +2,18 @@
 
 Loads settings from environment variables and ~/.trace/.env.
 
-Resolution order for OPENAI_API_KEY (first match wins):
+Resolution order for OPENAI_API_KEY and every other setting
+(highest priority first):
   1. Environment variable (already set in shell)
   2. ~/.trace/.env (shared across all TRACE projects)
-  3. .env in current working directory (project-level override)
+  3. ./.env in the current working directory
+
+Precedence is a MERGE, not first-match-wins: when the same key is set in more
+than one place, the highest-priority source above supplies its value. Note the
+consequence — the global ~/.trace/.env OVERRIDES a project-local ./.env for a
+shared key, so ./.env is the LOWEST-priority source, not a "project override".
+A project's ./.env can still set keys that ~/.trace/.env does not (e.g.
+TRACE_EMBEDDING_BACKEND, TRACE_LOCAL_ONLY), and those do take effect.
 """
 
 from __future__ import annotations

--- a/src/trace_mcp/server.py
+++ b/src/trace_mcp/server.py
@@ -65,17 +65,17 @@ def _compact(obj: Any) -> str:
 
 
 async def _infer_project() -> str:
-    """Infer project name from env var or most recent session."""
-    project = os.environ.get("TRACE_DEFAULT_PROJECT")
-    if project:
-        return project
-    try:
-        sessions = await storage.list_sessions(limit=1)
-        if sessions:
-            return sessions[0].get("project", "auto")
-    except Exception:
-        pass
-    return "auto"
+    """Resolve the project for an auto-created session (no explicit start).
+
+    Uses ``TRACE_DEFAULT_PROJECT`` when set; otherwise returns the stable
+    ``"auto"`` sentinel. It deliberately does NOT infer from the most-recent
+    session on disk: that global fallback read the newest session across the
+    SHARED store and, when it belonged to a different project, silently misrouted
+    the auto-created session (and any learnings later extracted from it) into
+    that unrelated project's knowledge store. A stable sentinel keeps
+    unattributed sessions out of a real project's provenance.
+    """
+    return os.environ.get("TRACE_DEFAULT_PROJECT") or "auto"
 
 
 async def _ensure_session(session_id: str | None) -> tuple[Session, str]:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1369,31 +1369,37 @@ class TestAutoSession:
             srv.storage, srv.active_sessions = orig_storage, orig_active
             srv._current_session_id = orig_current
 
-    async def test_infer_project_from_recent_session(
+    async def test_infer_project_does_not_inherit_foreign_recent_session(
         self,
         storage: JsonFileStorage,
         active: dict[str, Session],
     ) -> None:
-        """_infer_project falls back to most recent session's project."""
+        """_infer_project must NOT adopt the most-recent session's project.
+
+        The newest session on the shared store can belong to any project;
+        inheriting it silently misrouted auto-created sessions (and any learnings
+        later extracted from them) into an unrelated project's knowledge store.
+        With no TRACE_DEFAULT_PROJECT, the fallback is the stable "auto" sentinel.
+        """
+        import os
+
         import trace_mcp.server as srv
 
         orig_storage = srv.storage
         srv.storage = storage
 
         try:
-            # Create a session so there's something to infer from
+            # A recent session belonging to a DIFFERENT project must not be adopted.
             await session_tools.create_session(
                 storage,
                 active,
-                project="inferred-project",
+                project="some-other-project",
             )
-            # Remove env var if set
-            import os
-
             old_env = os.environ.pop("TRACE_DEFAULT_PROJECT", None)
             try:
                 project = await srv._infer_project()
-                assert project == "inferred-project"
+                assert project == "auto"
+                assert project != "some-other-project"
             finally:
                 if old_env is not None:
                     os.environ["TRACE_DEFAULT_PROJECT"] = old_env


### PR DESCRIPTION
## Summary

Two independent correctness/clarity fixes surfaced by the cross-project data-flow review.

- **Auto-created sessions no longer inherit a foreign project.** `_infer_project` fell back to `list_sessions(limit=1)` — the most-recent session across the *shared* store — so when the newest session on disk belonged to a different project, a pointer-less `trace_log_*` call auto-created a session (and routed any learnings later extracted from it) under that unrelated project's knowledge store. With no `TRACE_DEFAULT_PROJECT` it now returns the stable `"auto"` sentinel instead of a foreign project name.
- **Corrected the OpenAI-key precedence docstring** in `config.py`: it claimed "first match wins" and labeled `./.env` a "project-level override", but the real behavior is a merge where the global `~/.trace/.env` **overrides** a project-local `./.env` (env var > global > project). The docstring now states this, so a project's `./.env` is not mistaken for an override of the shared key.

## Why

The first is a provenance-integrity bug: an auto-session's events and extracted learnings could be silently attributed to the wrong project. The second is an honesty fix — the code and its own documentation disagreed about where a project-scoped key takes effect.

## Verification

- `tests/test_tools.py::TestAutoSession` updated to the corrected contract: a foreign most-recent session is never adopted (falls back to `"auto"`).
- Full suite: 959 passed / 11 skipped. `ruff` clean; `uv run pyright` 0 errors.