### PR TITLE
feat(learn)!: cloud LLM matching/extraction now opt-in (TRACE_LLM_ENABLED defaults false)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Cloud LLM matching/extraction now opt-in (behavior change)
+
+- **`TRACE_LLM_ENABLED` now defaults to `false`.** An `OPENAI_API_KEY` on the
+  machine no longer opts sessions into cloud LLM matching and extraction by
+  itself — completing the local-first posture already applied to embeddings
+  (where `auto` never selects OpenAI). Unset now means rule-based/BM25; cloud
+  LLM requires the explicit `TRACE_LLM_ENABLED=true` opt-in. To restore the
+  previous behavior everywhere, set `TRACE_LLM_ENABLED=true` once in
+  `~/.trace/.env`. When a key is present but the flag is unset, config load
+  logs an INFO pointing at the flag (suppressed when the flag is explicitly
+  `false` or `TRACE_LOCAL_ONLY` is set). The `LearnConfig.llm_enabled`
+  dataclass default flips to `False` to match, so directly-constructed
+  configs are safe-by-default too.
+
 ### Egress kill switch + point-of-use disclosure
 
 - **`TRACE_LOCAL_ONLY=1` — one switch, no egress anywhere.** Forces all three

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ Claude: -> trace_end_session(summary="Analyzed 47 passages...")
 
 ## Knowledge persistence (trace-learn)
 
-The default `trace-learn` extension surfaces relevant past learnings at session start, on-demand via `trace_learn_recall`, and when decisions are proposed — and auto-extracts new learnings at session end. Matching uses LLM scoring when `OPENAI_API_KEY` is configured, with BM25 fallback. Storage: `~/.trace/knowledge/{project}.json` (env: `TRACE_KNOWLEDGE_DIR`).
+The default `trace-learn` extension surfaces relevant past learnings at session start, on-demand via `trace_learn_recall`, and when decisions are proposed — and auto-extracts new learnings at session end. Matching uses cloud LLM scoring only when explicitly opted in (`TRACE_LLM_ENABLED=true` plus an `OPENAI_API_KEY`), with BM25 fallback otherwise. Storage: `~/.trace/knowledge/{project}.json` (env: `TRACE_KNOWLEDGE_DIR`).
 
 See [`docs/extensions/trace-learn.md`](https://github.com/Thru-Echoes/TRACE/blob/main/docs/extensions/trace-learn.md) for matching backends, BM25 stemming, per-backend thresholds, extraction details, and LLM configuration.
 
@@ -230,7 +230,7 @@ See [`docs/extensions/trace-learn.md`](https://github.com/Thru-Echoes/TRACE/blob
 | `OPENAI_API_KEY` | — | OpenAI API key for LLM matching and extraction |
 | `TRACE_LLM_MODEL` | `gpt-5.4-mini` | Model for LLM relevance scoring |
 | `TRACE_LLM_EXTRACTION_MODEL` | `gpt-5.4-mini` | Model for LLM learning extraction |
-| `TRACE_LLM_ENABLED` | `true` | Set `false` to force BM25/rule-based only |
+| `TRACE_LLM_ENABLED` | `false` | Cloud LLM matching/extraction is opt-in: set `true` (with `OPENAI_API_KEY`) to enable |
 | `TRACE_STRICT_LLM` | `true` if key set, else `false` | Fail loudly on LLM errors instead of silent BM25 fallback |
 | `TRACE_BM25_K1` | `1.5` | BM25 term frequency saturation parameter |
 | `TRACE_BM25_B` | `0.75` | BM25 document length normalization parameter |

--- a/docs/extensions/trace-learn.md
+++ b/docs/extensions/trace-learn.md
@@ -53,20 +53,23 @@ Learnings are extracted from session events via two backends:
 
 | Backend | When used | What it does |
 |---------|-----------|--------------|
-| **LLM-enhanced** (primary) | When configured | Sends all session events to an OpenAI model which identifies valuable, actionable learnings and generates quality tags. Avoids duplicating existing learnings. |
-| **Rule-based** (fallback) | When no API key | Processes annotations with category in {learning, correction, gotcha}, rejected/revised decisions (preserving rationale and revision notes), and collaborative contributions. |
+| **LLM-enhanced** (opt-in) | `TRACE_LLM_ENABLED=true` + API key | Sends all session events to an OpenAI model which identifies valuable, actionable learnings and generates quality tags. Avoids duplicating existing learnings. |
+| **Rule-based** (default) | Otherwise (no key, or LLM not enabled) | Processes annotations with category in {learning, correction, gotcha}, rejected/revised decisions (preserving rationale and revision notes), and collaborative contributions. |
 
 Both backends are **idempotent** — running extraction twice on the same session produces no duplicates.
 
 ## LLM configuration
 
-Place your OpenAI API key in `~/.trace/.env` (shared across all TRACE projects):
+Cloud LLM features are **off by default** (local-first): an API key on the
+machine does not, by itself, send any session content to OpenAI. To opt in,
+place your key in `~/.trace/.env` (shared across all TRACE projects) **and**
+set `TRACE_LLM_ENABLED=true`:
 
 ```bash
 OPENAI_API_KEY=sk-...
+TRACE_LLM_ENABLED=true                   # Opt-in: cloud LLM is OFF by default
 TRACE_LLM_MODEL=gpt-5.4-mini             # Model for matching/scoring
 TRACE_LLM_EXTRACTION_MODEL=gpt-5.4-mini  # Model for extraction (can be different)
-TRACE_LLM_ENABLED=true                   # Set false to force BM25-only
 TRACE_STRICT_LLM=true                    # Fail loudly on LLM errors (default: true when key set)
 ```
 

--- a/src/trace_mcp/extensions/learn/config.py
+++ b/src/trace_mcp/extensions/learn/config.py
@@ -86,7 +86,10 @@ class LearnConfig:
     openai_api_key: str | None = field(default=None, repr=False)
     llm_model: str = "gpt-5.4-mini"
     llm_extraction_model: str = "gpt-5.4-mini"
-    llm_enabled: bool = True
+    # Cloud LLM matching/extraction is OPT-IN (local-first): an OPENAI_API_KEY
+    # on the machine must not, by itself, route session content to a third
+    # party. Enable with TRACE_LLM_ENABLED=true (a key is still required).
+    llm_enabled: bool = False
     # Strict mode: if True, LLM failures raise instead of falling back to
     # BM25/rule-based. Auto-defaults to True when an API key is present — the
     # assumption being "if you configured it, you expect it to work."
@@ -118,6 +121,11 @@ def load_config() -> LearnConfig:
     The user puts their OpenAI key in ONE place — ``~/.trace/.env`` — and
     every TRACE project picks it up automatically.  Env vars take precedence
     so CI / containers can override.
+
+    The key alone activates nothing: cloud LLM matching/extraction also
+    requires the explicit ``TRACE_LLM_ENABLED=true`` opt-in, and cloud
+    embeddings require an explicit ``TRACE_EMBEDDING_BACKEND=openai``.
+    ``TRACE_LOCAL_ONLY=1`` overrides both (no egress anywhere).
     """
     # Low-priority → high-priority merge
     project_env = _parse_dotenv(Path.cwd() / ".env")
@@ -150,7 +158,13 @@ def load_config() -> LearnConfig:
             merged[key] = env_val
 
     api_key = merged.get("OPENAI_API_KEY") or None
-    llm_enabled = merged.get("TRACE_LLM_ENABLED", "true").lower() in ("true", "1", "yes")
+    local_only = merged.get("TRACE_LOCAL_ONLY", "false").lower() in ("true", "1", "yes")
+
+    # Cloud LLM matching/extraction is OPT-IN (local-first): unset means OFF,
+    # even when an API key is present. Distinguish "unset" from an explicit
+    # false so the informational nudge below never nags a user who opted out.
+    raw_llm_enabled = merged.get("TRACE_LLM_ENABLED")
+    llm_enabled = (raw_llm_enabled or "false").lower() in ("true", "1", "yes")
 
     # Strict mode: default ON when API key is present.
     # If the user bothered to configure an API key, fall-backs should fail
@@ -172,8 +186,13 @@ def load_config() -> LearnConfig:
             "Set TRACE_STRICT_LLM=false to allow silent fallback.",
             merged.get("TRACE_LLM_MODEL", "gpt-5.4-mini"),
         )
-
-    local_only = merged.get("TRACE_LOCAL_ONLY", "false").lower() in ("true", "1", "yes")
+    elif api_key and raw_llm_enabled is None and not local_only:
+        # A key exists but the user never chose: say so once at config load,
+        # instead of silently ignoring the key (the pre-opt-in default used it).
+        logger.info(
+            "OPENAI_API_KEY found, but cloud LLM matching/extraction is OFF by default "
+            "(local-first). Set TRACE_LLM_ENABLED=true to enable it."
+        )
     embedding_backend = merged.get("TRACE_EMBEDDING_BACKEND", "auto")
     if local_only:
         # One switch, all three egress paths: force cloud LLM features off and

--- a/tests/test_llm_optin_default.py
+++ b/tests/test_llm_optin_default.py
@@ -1,0 +1,116 @@
+"""Cloud LLM matching/extraction is opt-in (local-first default).
+
+Pins the full interaction matrix for the three settings that decide whether
+session content may reach a cloud LLM:
+
+    OPENAI_API_KEY  x  TRACE_LLM_ENABLED  x  TRACE_LOCAL_ONLY
+
+The load-bearing rule: an API key on the machine must not, by itself, enable
+cloud LLM features. ``TRACE_LLM_ENABLED`` unset means OFF; enabling requires
+the explicit ``true`` (and a key). ``TRACE_LOCAL_ONLY`` beats everything.
+
+Any new egress path must add its gating variable to this matrix.
+"""
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from trace_mcp.extensions.learn import config as _cfg
+from trace_mcp.extensions.learn.config import LearnConfig, load_config
+
+NUDGE_FRAGMENT = "OFF by default"
+
+
+@pytest.fixture(autouse=True)
+def _isolated_config_env(monkeypatch, tmp_path):
+    """Make load_config() see ONLY what each test sets.
+
+    Neutralizes the developer's real environment: the shell env vars, the
+    global ~/.trace/.env, and any ./.env in the checkout (load_config merges
+    Path.cwd()/.env).
+    """
+    for var in (
+        "OPENAI_API_KEY",
+        "TRACE_LLM_ENABLED",
+        "TRACE_LOCAL_ONLY",
+        "TRACE_STRICT_LLM",
+        "TRACE_EMBEDDING_BACKEND",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setattr(_cfg, "_TRACE_ENV_PATH", Path("/nonexistent/.env"))
+    monkeypatch.chdir(tmp_path)
+
+
+class TestLlmOptInMatrix:
+    def test_key_present_flag_unset_is_off(self, monkeypatch):
+        """THE flip: a mere API key must not enable cloud LLM features."""
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        cfg = load_config()
+        assert cfg.llm_enabled is False
+        assert cfg.openai_api_key == "sk-test"  # key still loaded (embeddings opt-in may use it)
+
+    def test_key_present_flag_true_is_on(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        monkeypatch.setenv("TRACE_LLM_ENABLED", "true")
+        assert load_config().llm_enabled is True
+
+    def test_key_present_flag_false_is_off(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        monkeypatch.setenv("TRACE_LLM_ENABLED", "false")
+        assert load_config().llm_enabled is False
+
+    def test_no_key_flag_unset_is_off(self):
+        assert load_config().llm_enabled is False
+
+    def test_no_key_flag_true_is_forced_off(self, monkeypatch):
+        """Opting in without a key cannot enable anything."""
+        monkeypatch.setenv("TRACE_LLM_ENABLED", "true")
+        assert load_config().llm_enabled is False
+
+    def test_local_only_beats_explicit_opt_in(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        monkeypatch.setenv("TRACE_LLM_ENABLED", "true")
+        monkeypatch.setenv("TRACE_LOCAL_ONLY", "1")
+        cfg = load_config()
+        assert cfg.local_only is True
+        assert cfg.llm_enabled is False
+
+    def test_dataclass_default_is_off(self):
+        """Directly-constructed configs are safe-by-default too — even with a key."""
+        assert LearnConfig().llm_enabled is False
+        assert LearnConfig(openai_api_key="sk-test").llm_enabled is False
+
+
+class TestOptInNudge:
+    """The one-time INFO nudge: shown only when the user never chose."""
+
+    def test_nudge_when_key_present_and_flag_unset(self, monkeypatch, caplog):
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        with caplog.at_level(logging.INFO, logger=_cfg.__name__):
+            load_config()
+        assert any(NUDGE_FRAGMENT in r.message for r in caplog.records)
+        assert any("TRACE_LLM_ENABLED=true" in r.message for r in caplog.records)
+
+    def test_no_nudge_when_explicitly_disabled(self, monkeypatch, caplog):
+        """A user who opted out must not be nagged to opt in."""
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        monkeypatch.setenv("TRACE_LLM_ENABLED", "false")
+        with caplog.at_level(logging.INFO, logger=_cfg.__name__):
+            load_config()
+        assert not any(NUDGE_FRAGMENT in r.message for r in caplog.records)
+
+    def test_no_nudge_when_local_only(self, monkeypatch, caplog):
+        """TRACE_LOCAL_ONLY states intent; suggesting cloud opt-in contradicts it."""
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        monkeypatch.setenv("TRACE_LOCAL_ONLY", "1")
+        with caplog.at_level(logging.INFO, logger=_cfg.__name__):
+            load_config()
+        assert not any(NUDGE_FRAGMENT in r.message for r in caplog.records)
+
+    def test_no_nudge_without_key(self, caplog):
+        """No key -> nothing to nudge about."""
+        with caplog.at_level(logging.INFO, logger=_cfg.__name__):
+            load_config()
+        assert not any(NUDGE_FRAGMENT in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary

`TRACE_LLM_ENABLED` now defaults to `false`: an `OPENAI_API_KEY` on the machine no longer opts sessions into cloud LLM matching and extraction by itself. Cloud LLM requires the explicit `TRACE_LLM_ENABLED=true` opt-in (a key is still required); `TRACE_LOCAL_ONLY=1` continues to override everything.

## Why

This completes the local-first posture: embeddings already refuse to auto-select OpenAI (a mere key must not route content off-machine), but extraction and matching still defaulted to cloud whenever a key existed — the last egress path that activated without explicit consent. Design choices:

- **No new gating variable.** Reusing `TRACE_LLM_ENABLED` avoids a second overlapping switch, which would recreate the off-switch-trap class (`disable one path, another still egresses`) that `TRACE_LOCAL_ONLY` closed.
- **Unset ≠ explicit false.** When a key is present but the flag is unset, config load logs a one-time INFO pointing at the flag. The nudge is suppressed when the user already chose: explicit `false`, or `TRACE_LOCAL_ONLY` set (suggesting cloud opt-in would contradict stated intent).
- **`LearnConfig.llm_enabled` dataclass default flips to `False`** so directly-constructed configs (library callers, tests) are safe-by-default too, matching the existing defensive guard in `get_embedding_provider`.

**Migration:** set `TRACE_LLM_ENABLED=true` once in `~/.trace/.env` to restore previous behavior for all projects on a machine. This is the behavior change that should motivate the next version being 0.5.0 rather than 0.4.x (version bump deferred to a release PR; no tag/publish here).

## Verification

- New `tests/test_llm_optin_default.py` pins the full `OPENAI_API_KEY` × `TRACE_LLM_ENABLED` × `TRACE_LOCAL_ONLY` matrix (7 cases) plus 4 nudge-suppression cases, isolated from the developer's real env/`.env` files.
- Full suite with `uv sync --all-extras`: 991 passed / 11 skipped; ruff, `ruff format --check`, pyright (0 errors), and the invariant guard all clean.
- No test outside the new file needed changes: existing tests either construct `LearnConfig` explicitly or set `TRACE_LLM_ENABLED` themselves — the suite never depended on the implicit default.

## Risks / rollback

Behavior change for configs that relied on the implicit default: with the flag unset, extraction/matching now run rule-based/BM25 even when a key is configured. Rollback = revert this commit, or per-machine `TRACE_LLM_ENABLED=true`.