### PR TITLE
fix(init): fail closed instead of writing a dependency-confused uvx source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **`trace-mcp init` no longer writes a dependency-confused `.mcp.json` from
+  an installed wheel.** When run from an installed copy (module under
+  `site-packages`) with no `TRACE_SOURCE_PATH` set, source resolution
+  previously fell back to writing `uvx --from trace-mcp` — but the name
+  `trace-mcp` on PyPI belongs to an unrelated package, so the next MCP server
+  start would have downloaded and executed third-party code. Resolution now
+  **fails closed** (`TraceSourceUnresolvedError`; `trace-mcp init` exits 1,
+  including on `--dry-run`) with the remedy in the message: set
+  `TRACE_SOURCE_PATH=/abs/path/to/your/TRACE/clone`. Source checkouts and the
+  `TRACE_SOURCE_PATH` override behave as before; the server entry is now built
+  lazily at write time so importing the module never raises.
+
 ### Egress kill switch + point-of-use disclosure
 
 - **`TRACE_LOCAL_ONLY=1` — one switch, no egress anywhere.** Forces all three

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Worked examples for logging decisions, corrections, contributions, and decision 
 | `TRACE_PROMPT_MIN_TURNS` | `3` | Minimum prompt turns before `prompt-reminder.sh` will nudge. |
 | `TRACE_PROMPT_COOLDOWN_SEC` | `300` | Wall-clock cooldown between nudges from `prompt-reminder.sh`. |
 | `TRACE_RUNTIME_DIR` | `~/.trace/runtime` | Per-project nudge state (`<project>.state.json`). Safe to delete to reset. |
-| `TRACE_SOURCE_PATH` | _unset_ | Override what `trace-mcp-init` writes into `.mcp.json` as `uvx --from <X>`. Pre-PyPI consumers can set to a local TRACE clone path. |
+| `TRACE_SOURCE_PATH` | _unset_ | Override what `trace-mcp-init` writes into `.mcp.json` as `uvx --from <X>`. Set to a local TRACE clone path. **Required when running init from an installed wheel** — with no override, init fails closed rather than writing the PyPI name `trace-mcp`, which belongs to an unrelated package (dependency confusion). |
 
 ### Run a first session
 

--- a/src/trace_mcp/init_project.py
+++ b/src/trace_mcp/init_project.py
@@ -18,35 +18,57 @@ from trace_mcp.adapters import detect_adapter, get_adapter, list_adapters
 from trace_mcp.adapters.base import Adapter
 
 
+class TraceSourceUnresolvedError(RuntimeError):
+    """No safe ``uvx --from <X>`` source could be determined for `.mcp.json`."""
+
+
 def _resolve_trace_source() -> str:
     """Pick the value to write into `.mcp.json`'s `uvx --from <X>` argument.
 
     Order:
-    1. ``TRACE_SOURCE_PATH`` env var (explicit override) — useful pre-PyPI to
-       point at a local clone, e.g. `TRACE_SOURCE_PATH=/abs/path/to/TRACE`.
-    2. If this module lives under a ``site-packages`` directory (i.e. it was
-       installed from a wheel / via ``uvx``), fall back to the published
-       package name ``"trace-mcp"`` — ``uvx --from trace-mcp`` resolves to
-       PyPI without baking in a per-machine cache path.
-    3. Otherwise (editable / source checkout), use the repo root, which is
-       three levels above this file (``src/trace_mcp/init_project.py``).
+    1. ``TRACE_SOURCE_PATH`` env var (explicit override) — point at a local
+       clone, e.g. `TRACE_SOURCE_PATH=/abs/path/to/TRACE`.
+    2. Editable / source checkout: the repo root, which is three levels above
+       this file (``src/trace_mcp/init_project.py``).
+    3. Installed wheel (module under ``site-packages``): **fail closed**
+       (raise ``TraceSourceUnresolvedError``). The PyPI distribution name
+       ``trace-mcp`` belongs to an unrelated project, so writing
+       ``uvx --from trace-mcp`` into `.mcp.json` would make the next MCP
+       server start download and execute a third party's code (dependency
+       confusion). Until this package is published under its own name, an
+       installed copy has no safe source to infer — the user must supply
+       ``TRACE_SOURCE_PATH``.
     """
     if env_override := os.environ.get("TRACE_SOURCE_PATH"):
         return env_override
     here = Path(__file__).resolve()
-    if "site-packages" in here.parts:
-        return "trace-mcp"
-    return str(here.parent.parent.parent)
+    if "site-packages" not in here.parts:
+        return str(here.parent.parent.parent)
+    raise TraceSourceUnresolvedError(
+        "Cannot determine a safe source for `.mcp.json`'s `uvx --from <X>`: "
+        "trace-mcp init is running from an installed wheel, and the name "
+        "'trace-mcp' on PyPI belongs to an UNRELATED package — writing it "
+        "would make the next MCP server start download and run third-party "
+        "code (dependency confusion). Set "
+        "TRACE_SOURCE_PATH=/abs/path/to/your/TRACE/clone and re-run."
+    )
 
 
-_TRACE_ROOT = _resolve_trace_source()
+def _mcp_server_config() -> dict:
+    """Build the `.mcp.json` ``mcpServers`` entry for TRACE.
 
-MCP_CONFIG = {
-    "trace": {
-        "command": "uvx",
-        "args": ["--from", _TRACE_ROOT, "--refresh-package", "trace-mcp", "trace-mcp"],
+    Resolves the ``--from`` source lazily, at write time — not at import
+    time — so importing this module (tests, ``--help``) never raises;
+    only actually writing `.mcp.json` can surface
+    ``TraceSourceUnresolvedError``.
+    """
+    source = _resolve_trace_source()
+    return {
+        "trace": {
+            "command": "uvx",
+            "args": ["--from", source, "--refresh-package", "trace-mcp", "trace-mcp"],
+        }
     }
-}
 
 
 def _write_mcp_json(project_dir: Path) -> str:
@@ -62,7 +84,7 @@ def _write_mcp_json(project_dir: Path) -> str:
 
     config.setdefault("mcpServers", {})
     was_present = "trace" in config["mcpServers"]
-    config["mcpServers"]["trace"] = MCP_CONFIG["trace"]
+    config["mcpServers"]["trace"] = _mcp_server_config()["trace"]
 
     mcp_path.write_text(json.dumps(config, indent=2) + "\n")
     return f"  {'updated' if was_present else 'wrote'}: {mcp_path}"
@@ -101,11 +123,17 @@ def init_project(
 
     print(f"Initializing TRACE in {project_dir}")
 
-    # 1. .mcp.json (host-independent)
-    if not dry_run:
-        print(_write_mcp_json(project_dir))
-    else:
-        print(f"  [dry-run] would write: {project_dir / '.mcp.json'}")
+    # 1. .mcp.json (host-independent). A dry run resolves the source too, so
+    # an unresolvable source is discovered before a real run, not during it.
+    try:
+        if not dry_run:
+            print(_write_mcp_json(project_dir))
+        else:
+            entry = _mcp_server_config()["trace"]
+            print(f"  [dry-run] would write: {project_dir / '.mcp.json'} (uvx --from {entry['args'][1]})")
+    except TraceSourceUnresolvedError as exc:
+        print(f"Error: {exc}")
+        sys.exit(1)
 
     # 2. Host adapter
     adapter = _pick_adapter(project_dir, client)

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -273,9 +273,14 @@ class TestResolveTraceSource:
 
         assert ip._resolve_trace_source() == "/override"
 
-    def test_falls_back_to_package_name_when_inside_site_packages(
-        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-    ) -> None:
+    def test_site_packages_without_override_fails_closed(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """An installed wheel must NEVER fall back to the PyPI name 'trace-mcp'.
+
+        That name belongs to an unrelated package, so writing
+        `uvx --from trace-mcp` into .mcp.json would make the next MCP server
+        start download and execute third-party code (dependency confusion).
+        With no TRACE_SOURCE_PATH, resolution must raise — never guess.
+        """
         from trace_mcp import init_project as ip
 
         fake = tmp_path / "lib" / "python3.13" / "site-packages" / "trace_mcp" / "init_project.py"
@@ -284,7 +289,31 @@ class TestResolveTraceSource:
         monkeypatch.setattr(ip, "__file__", str(fake))
         monkeypatch.delenv("TRACE_SOURCE_PATH", raising=False)
 
-        assert ip._resolve_trace_source() == "trace-mcp"
+        with pytest.raises(ip.TraceSourceUnresolvedError, match="TRACE_SOURCE_PATH"):
+            ip._resolve_trace_source()
+
+    def test_init_project_surfaces_unresolvable_source_as_exit_1(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """`trace-mcp init` (even --dry-run) exits 1 with the remedy in the message,
+        instead of writing a dependency-confused .mcp.json."""
+        from trace_mcp import init_project as ip
+
+        fake = tmp_path / "lib" / "python3.13" / "site-packages" / "trace_mcp" / "init_project.py"
+        fake.parent.mkdir(parents=True)
+        fake.touch()
+        monkeypatch.setattr(ip, "__file__", str(fake))
+        monkeypatch.delenv("TRACE_SOURCE_PATH", raising=False)
+
+        project = tmp_path / "some-project"
+        project.mkdir()
+
+        with pytest.raises(SystemExit) as excinfo:
+            ip.init_project(str(project), client="none", dry_run=True)
+        assert excinfo.value.code == 1
+        out = capsys.readouterr().out
+        assert "TRACE_SOURCE_PATH" in out
+        assert not (project / ".mcp.json").exists()
 
     def test_uses_repo_root_for_editable_install(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
         from trace_mcp import init_project as ip

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -31,10 +31,15 @@ def active() -> dict[str, Session]:
 
 class TestInitProjectMCPConfig:
     def test_init_project_mcp_config_uses_uvx(self) -> None:
-        """MCP_CONFIG should use 'uvx --from ... --refresh-package trace-mcp trace-mcp'."""
-        from trace_mcp.init_project import MCP_CONFIG
+        """The server entry should use 'uvx --from ... --refresh-package trace-mcp trace-mcp'.
 
-        trace_config = MCP_CONFIG["trace"]
+        (Runs from a source checkout here, so the lazily-resolved --from source
+        is this repo's root; the wheel-installed case is covered by the
+        fail-closed tests in test_adapters.py.)
+        """
+        from trace_mcp.init_project import _mcp_server_config
+
+        trace_config = _mcp_server_config()["trace"]
         assert trace_config["command"] == "uvx"
         args = trace_config["args"]
         assert "--from" in args


### PR DESCRIPTION
## Summary

`trace-mcp init`, when run from an installed wheel with no `TRACE_SOURCE_PATH` set, used to write `uvx --from trace-mcp` into `.mcp.json`. The name `trace-mcp` on PyPI belongs to an unrelated package, so the next MCP server start would have downloaded and executed a third party's code. Source resolution now fails closed with a clear remedy instead of guessing.

## Why

This is a dependency-confusion / arbitrary-code-execution path: `.mcp.json` is trusted launch configuration, and writing a PyPI reference this project does not own hands that trust to whoever holds the name. Until the package is published under its own (settled) name, an installed copy has no safe source to infer — so it must refuse:

- `_resolve_trace_source()` raises `TraceSourceUnresolvedError` in the installed-wheel case; `trace-mcp init` exits 1 with the message pointing at `TRACE_SOURCE_PATH=/abs/path/to/your/TRACE/clone`.
- `--dry-run` resolves the source too, so the failure surfaces before a real run — and dry-run output now shows the resolved `--from` value.
- The server entry is built lazily at write time (module-level `MCP_CONFIG` removed), so importing the module never raises and `--help` still works from an installed wheel.
- Source checkouts and the `TRACE_SOURCE_PATH` override behave exactly as before.

## Verification

- The test that pinned the PyPI-name fallback is replaced by fail-closed tests: resolution raises with the remedy in the message; `init_project` (dry-run, wheel context) exits 1 and writes no `.mcp.json`.
- Full suite: 981 passed / 11 skipped; ruff, `ruff format --check`, pyright (0 errors), invariant guard 4/4.

## Risks / rollback

Behavior change only for wheel-installed `init` runs without `TRACE_SOURCE_PATH` — previously they silently produced a broken/dangerous `.mcp.json`; now they exit 1 with instructions. Revert restores the old fallback (not recommended while the PyPI name is unowned).