### PR TITLE
feat(learn): egress-as-provenance ledger — every cloud call recorded, fail closed (INV-5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `trace_learn_recall`, and `trace_learn_add` tool docstrings now state, at the
   point of use, that content is sent to OpenAI when the OpenAI backend/LLM is
   configured, and how to stay local (`TRACE_LOCAL_ONLY=1`).
+- **Egress ledger (egress-as-provenance).** Every cloud call trace-learn makes
+  (LLM extraction, LLM matching, OpenAI embeddings) now appends one JSONL line
+  to `~/.trace/egress.jsonl` (override: `TRACE_EGRESS_LOG`) — recording the
+  FACT of the call (provider, endpoint, model, purpose, item count, and
+  project/session where the call site knows them), never the content. The
+  attestation is written **before** the request and **fails closed**: if the
+  ledger cannot be written, the cloud call does not happen — under permissive
+  config the caller falls back to the local path (BM25 / rule-based /
+  un-embedded), under strict config it raises. Registered as **INV-5** in
+  `docs/INVARIANTS.md` with an AST enumeration guard, so a new OpenAI call
+  site cannot merge without attesting. The test suite isolates the ledger the
+  same way it isolates the session/knowledge stores (`tests/conftest.py`).
 
 ### Local-strong embedding tier + local-first default
 

--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ See [`docs/extensions/trace-learn.md`](https://github.com/Thru-Echoes/TRACE/blob
 |----------|---------|-------------|
 | `TRACE_SESSIONS_DIR` | `~/.trace/sessions/` | Directory for session JSON files |
 | `TRACE_KNOWLEDGE_DIR` | `~/.trace/knowledge/` | Directory for trace-learn knowledge stores |
+| `TRACE_EGRESS_LOG` | `~/.trace/egress.jsonl` | Cloud-egress ledger: one JSONL line per cloud call trace-learn makes (the fact of the call — provider, endpoint, model, purpose, item count — never the content) |
 | `TRACE_LOG_LEVEL` | `INFO` | Logging verbosity |
 | `OPENAI_API_KEY` | — | OpenAI API key for LLM matching and extraction |
 | `TRACE_LLM_MODEL` | `gpt-5.4-mini` | Model for LLM relevance scoring |

--- a/docs/INVARIANTS.md
+++ b/docs/INVARIANTS.md
@@ -99,6 +99,38 @@ exact-match predicate as the hooks, so both layers resolve one session set.
 
 ---
 
+## INV-5 — No cloud egress without a pre-call ledger attestation  · ENFORCED
+
+**Statement.** Every OpenAI-SDK network call in the trace-learn extension
+(`…completions.create(...)` / `…embeddings.create(...)`) must be preceded, in
+the same function, by `attest_egress()` — one appended line in the egress
+ledger (`~/.trace/egress.jsonl`, override `TRACE_EGRESS_LOG`) recording the
+fact of the call (provider, endpoint, model, purpose, item count,
+project/session when known) and never the content. The attestation **fails
+closed**: if the ledger cannot be written, the cloud call must not happen —
+call sites sit inside the existing strict/permissive LLM handling, so a failed
+attestation degrades like a failed provider (strict raises, permissive falls
+back to the local path). An unattested call site is unrecorded egress, the
+exact failure mode the ledger exists to prevent.
+
+**Sites:** `src/trace_mcp/extensions/learn/extraction.py`
+(`extract_from_session_llm`); `src/trace_mcp/extensions/learn/matching.py`
+(`_llm_score`); `src/trace_mcp/extensions/learn/embeddings.py`
+(`OpenAIEmbeddingProvider.embed_texts`). Writer:
+`src/trace_mcp/extensions/learn/egress.py`.
+
+**Guard:** `tests/test_invariants.py :: test_inv5_every_openai_call_site_is_registered`
+(AST enumeration — a new `.create` site fails until registered in
+`INV5_EGRESS_CALL_SITES`, and stale registrations fail too, with a positive
+control against pattern rot) and `:: test_inv5_every_egress_site_attests_first`
+(each registered site must call `attest_egress`). Behavior pinned by
+`tests/test_egress_ledger.py` (pre-call ordering; no egress when the ledger is
+unwritable).
+
+**Status.** ENFORCED.
+
+---
+
 *To add an invariant: give it the next `INV-N`, state it, enumerate the
 exhaustive site-set, name the guard + test, and add a check to
 `tests/test_invariants.py` that fails when a new site violates it.*

--- a/docs/embeddings.md
+++ b/docs/embeddings.md
@@ -82,6 +82,31 @@ features regardless of whether a key is present. It closes the "off-switch trap"
 where disabling one path (`TRACE_LLM_ENABLED=false` **or**
 `TRACE_EMBEDDING_BACKEND=none`) still left the other egressing.
 
+## Egress ledger (egress-as-provenance)
+
+When cloud calls *are* enabled, every one of them is recorded: each LLM
+extraction, LLM matching, and OpenAI embedding request appends one JSON line to
+`~/.trace/egress.jsonl` (override the path with `TRACE_EGRESS_LOG`) **before**
+the request is made. A line records the *fact* of the call — timestamp,
+provider, endpoint, model, purpose, item count, and project/session where the
+call site knows them — never the content. A `base_url` field on embedding
+entries marks calls that target a user-configured OpenAI-compatible endpoint
+(e.g. a local Ollama) rather than api.openai.com.
+
+The attestation fails closed: if the ledger cannot be written, the cloud call
+does not happen. Under permissive config that degrades to the local path
+(BM25 / rule-based / un-embedded learnings) like any provider failure; under
+strict config (`TRACE_STRICT_LLM=true`) it raises. This is INV-5 in
+[docs/INVARIANTS.md](INVARIANTS.md): an enumeration guard fails CI when a new
+OpenAI call site appears without an attestation, so the ledger stays complete
+by construction.
+
+To inspect your machine's egress history:
+
+```bash
+cat ~/.trace/egress.jsonl | python3 -m json.tool --json-lines
+```
+
 ## Switching backends re-embeds your store
 
 Each learning records the model that produced its vector. When you change the

--- a/src/trace_mcp/extensions/learn/egress.py
+++ b/src/trace_mcp/extensions/learn/egress.py
@@ -1,0 +1,109 @@
+"""Egress-as-provenance: an append-only ledger of every cloud call trace-learn makes.
+
+Records the FACT of egress — provider, endpoint, model, purpose, item count,
+and project/session when known at the call site — never the content itself.
+One JSONL line is appended BEFORE each cloud call (an intent attestation):
+if the attestation cannot be written, the cloud call must not happen.
+Unrecorded egress is the exact failure mode this ledger exists to prevent, so
+the writer fails closed (``EgressAttestationError``) rather than warning and
+proceeding. Every call site sits inside the existing strict/permissive LLM
+error handling, so a failed attestation degrades exactly like a failed
+provider: strict mode raises, permissive mode falls back to the local path
+(BM25 / rule-based / un-embedded) — either way, nothing leaves the machine.
+
+The record is written pre-call on purpose: content reaches the provider even
+when the response later fails, so a post-call record could miss real egress.
+A ledger line therefore means "content was about to be sent", not "the call
+succeeded".
+
+Ledger location: ``~/.trace/egress.jsonl``; override with ``TRACE_EGRESS_LOG``.
+
+Exports: ``attest_egress`` (the pre-call writer), ``egress_log_path``
+(path resolution), ``EgressAttestationError``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import UTC, datetime
+from pathlib import Path
+
+__all__ = ["EgressAttestationError", "attest_egress", "egress_log_path"]
+
+
+class EgressAttestationError(RuntimeError):
+    """The egress ledger could not be written; the cloud call must not proceed."""
+
+
+def egress_log_path() -> Path:
+    """Resolve the ledger file path. No side effects.
+
+    ``TRACE_EGRESS_LOG`` (a file path) overrides the default
+    ``~/.trace/egress.jsonl``.
+    """
+    override = os.environ.get("TRACE_EGRESS_LOG")
+    if override:
+        return Path(override).expanduser()
+    return Path.home() / ".trace" / "egress.jsonl"
+
+
+def attest_egress(
+    *,
+    provider: str,
+    endpoint: str,
+    model: str,
+    purpose: str,
+    content_class: str,
+    item_count: int,
+    project: str | None = None,
+    session_id: str | None = None,
+    base_url: str | None = None,
+) -> None:
+    """Append one intent record to the egress ledger, BEFORE the cloud call.
+
+    Inputs describe the call about to be made: ``provider`` (e.g. "openai"),
+    ``endpoint`` ("chat.completions" | "embeddings"), ``model``, ``purpose``
+    ("extraction" | "matching" | "embedding"), ``content_class`` (what KIND of
+    content is being sent — never the content), ``item_count`` (events/texts/
+    learnings in the payload), and ``project``/``session_id``/``base_url``
+    when the call site knows them (``base_url`` set means the "cloud" call
+    targets a user-configured, possibly local, OpenAI-compatible endpoint).
+
+    Side effects: creates the ledger's parent directory if missing and appends
+    one JSON line to the ledger (file created with mode 0600 — it reveals
+    project names and usage patterns, so treat it like the session store).
+
+    Raises ``EgressAttestationError`` when the record cannot be appended —
+    callers MUST treat that as "the cloud call is not allowed to happen".
+    """
+    entry = {
+        "ts": datetime.now(UTC).isoformat(),
+        "provider": provider,
+        "endpoint": endpoint,
+        "model": model,
+        "purpose": purpose,
+        "content_class": content_class,
+        "item_count": item_count,
+        "project": project,
+        "session_id": session_id,
+        "base_url": base_url,
+    }
+    line = json.dumps(entry, separators=(",", ":")) + "\n"
+    path = egress_log_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        # O_APPEND + one write() call: concurrent writers (multiple MCP server
+        # processes share the ledger) cannot interleave within a line.
+        fd = os.open(path, os.O_WRONLY | os.O_APPEND | os.O_CREAT, 0o600)
+        try:
+            os.write(fd, line.encode("utf-8"))
+        finally:
+            os.close(fd)
+    except OSError as exc:
+        raise EgressAttestationError(
+            f"Cannot write the egress ledger at {path}: {exc}. Refusing to make "
+            f"the cloud call — egress without a provenance record defeats the "
+            f"ledger. Fix the path/permissions or point TRACE_EGRESS_LOG at a "
+            f"writable file."
+        ) from exc

--- a/src/trace_mcp/extensions/learn/embeddings.py
+++ b/src/trace_mcp/extensions/learn/embeddings.py
@@ -21,6 +21,8 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
+from trace_mcp.extensions.learn.egress import attest_egress
+
 if TYPE_CHECKING:
     import numpy as np
 
@@ -131,6 +133,22 @@ class OpenAIEmbeddingProvider:
         self.base_url = base_url
 
     async def embed_texts(self, texts: list[str]) -> list[list[float]]:
+        # Egress-as-provenance: record the fact of the cloud call before making
+        # it. Raising here is caught by the callers' strict/permissive handling
+        # (e.g. _embed_learnings) like any provider failure — and no content
+        # leaves the machine. This is the single true egress point for
+        # embeddings, so the attestation lives here rather than in each caller;
+        # project/purpose are unknown at this layer (base_url set = the call
+        # targets a user-configured, possibly local, OpenAI-compatible server).
+        attest_egress(
+            provider="openai",
+            endpoint="embeddings",
+            model=self.model_name,
+            purpose="embedding",
+            content_class="learning-or-query-text",
+            item_count=len(texts),
+            base_url=self.base_url,
+        )
         kwargs: dict = {"model": self.model_name, "input": texts}
         if self.dimensions > 0:
             kwargs["dimensions"] = self.dimensions

--- a/src/trace_mcp/extensions/learn/extraction.py
+++ b/src/trace_mcp/extensions/learn/extraction.py
@@ -16,6 +16,7 @@ import json
 import logging
 from typing import TYPE_CHECKING
 
+from trace_mcp.extensions.learn.egress import attest_egress
 from trace_mcp.extensions.learn.models import KnowledgeStore, Learning, LearningCategory
 from trace_mcp.extensions.learn.store import add_learning, add_learning_dedup
 from trace_mcp.schema import Session
@@ -310,6 +311,19 @@ async def extract_from_session_llm(
     )
 
     try:
+        # Egress-as-provenance: record the fact of the cloud call before making
+        # it. Attestation failure is handled by this try's strict/permissive
+        # logic like any LLM failure — and no content leaves the machine.
+        attest_egress(
+            provider="openai",
+            endpoint="chat.completions",
+            model=config.llm_extraction_model,
+            purpose="extraction",
+            content_class="session-events+existing-learnings",
+            item_count=len(session.events),
+            project=session.metadata.project,
+            session_id=session.id,
+        )
         client = AsyncOpenAI(api_key=config.openai_api_key)
         response = await client.chat.completions.create(
             model=config.llm_extraction_model,

--- a/src/trace_mcp/extensions/learn/matching.py
+++ b/src/trace_mcp/extensions/learn/matching.py
@@ -26,6 +26,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
+from trace_mcp.extensions.learn.egress import attest_egress
 from trace_mcp.extensions.learn.models import Learning
 
 if TYPE_CHECKING:
@@ -367,6 +368,19 @@ class LLMBackend:
             "to its relevance score (0.0–1.0)."
         )
 
+        # Egress-as-provenance: record the fact of the cloud call before making
+        # it. Raising here is caught by score_batch's strict/permissive
+        # handling like any LLM failure — and no content leaves the machine.
+        # (project is unknown at this layer; the matcher scores one store's
+        # learnings but is constructed from config alone.)
+        attest_egress(
+            provider="openai",
+            endpoint="chat.completions",
+            model=self._model,
+            purpose="matching",
+            content_class="learning-content+recall-query",
+            item_count=len(learnings),
+        )
         response = await self._client.chat.completions.create(
             model=self._model,
             messages=[

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,8 +2,9 @@
 
 Two mechanisms:
 
-1. **Data-directory isolation** — TRACE_KNOWLEDGE_DIR, TRACE_SESSIONS_DIR, and
-   TRACE_SCRATCHPAD_DIR point at a per-run temp directory, set in
+1. **Data-directory isolation** — TRACE_KNOWLEDGE_DIR, TRACE_SESSIONS_DIR,
+   TRACE_SCRATCHPAD_DIR, and TRACE_EGRESS_LOG point at a per-run temp
+   directory (the last is the egress-ledger file path), set in
    ``pytest_configure`` (NOT a fixture: ``server.py`` binds a module-level
    ``JsonFileStorage()`` at import, which happens during collection — before
    any session fixture runs). Subprocesses spawned by tests inherit the
@@ -36,7 +37,7 @@ from pathlib import Path
 
 import pytest
 
-_ISOLATED_VARS = ("TRACE_KNOWLEDGE_DIR", "TRACE_SESSIONS_DIR", "TRACE_SCRATCHPAD_DIR")
+_ISOLATED_VARS = ("TRACE_KNOWLEDGE_DIR", "TRACE_SESSIONS_DIR", "TRACE_SCRATCHPAD_DIR", "TRACE_EGRESS_LOG")
 _REAL_DATA_ENV = "TRACE_REAL_DATA_TESTS"
 _previous_env: dict[str, str | None] = {}
 
@@ -52,7 +53,10 @@ def pytest_configure(config: pytest.Config) -> None:
     Side effect: mutates os.environ (restored in pytest_unconfigure).
     """
     base = Path(tempfile.mkdtemp(prefix="trace-isolated-"))
-    for name, sub in zip(_ISOLATED_VARS, ("knowledge", "sessions", "scratchpads"), strict=True):
+    # The first three are directories; TRACE_EGRESS_LOG is a file path (the
+    # egress ledger). Same isolation contract either way: a test that forgets
+    # an explicit path must not be able to touch the developer's real ~/.trace.
+    for name, sub in zip(_ISOLATED_VARS, ("knowledge", "sessions", "scratchpads", "egress.jsonl"), strict=True):
         _previous_env[name] = os.environ.get(name)
         os.environ[name] = str(base / sub)
 

--- a/tests/test_egress_ledger.py
+++ b/tests/test_egress_ledger.py
@@ -1,0 +1,319 @@
+"""Egress ledger (egress-as-provenance) — behavior tests.
+
+Pins the two load-bearing properties of the ledger (INV-5, docs/INVARIANTS.md):
+
+1. **Pre-call attestation**: every cloud call site appends its ledger line
+   BEFORE the OpenAI-SDK request is made.
+2. **Fail closed**: when the ledger cannot be written, the cloud call does not
+   happen at all — and under permissive (non-strict) config the caller falls
+   back to the local path, so nothing leaves the machine and nothing breaks.
+
+The AST-level site enumeration lives in tests/test_invariants.py (INV-5).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+from typing import Literal
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from trace_mcp.extensions.learn.config import LearnConfig
+from trace_mcp.extensions.learn.egress import EgressAttestationError, attest_egress, egress_log_path
+from trace_mcp.extensions.learn.models import KnowledgeStore, Learning
+from trace_mcp.schema import Session
+from trace_mcp.schema.events import AnnotationData, TraceEvent
+from trace_mcp.schema.session import Actor, SessionMetadata
+
+# ── Helpers ───────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def ledger(tmp_path, monkeypatch):
+    """Point the egress ledger at a per-test file and return its path."""
+    path = tmp_path / "egress.jsonl"
+    monkeypatch.setenv("TRACE_EGRESS_LOG", str(path))
+    return path
+
+
+@pytest.fixture
+def blocked_ledger(tmp_path, monkeypatch):
+    """Point the ledger at an unwritable location (parent 'dir' is a file)."""
+    blocker = tmp_path / "blocker"
+    blocker.write_text("")
+    path = blocker / "nested" / "egress.jsonl"
+    monkeypatch.setenv("TRACE_EGRESS_LOG", str(path))
+    return path
+
+
+def _read_lines(path) -> list[dict]:
+    return [json.loads(line) for line in path.read_text().splitlines()]
+
+
+def _session(events: list[TraceEvent] | None = None) -> Session:
+    return Session(
+        id="egress_test_session",
+        metadata=SessionMetadata(
+            project="egress-test-project",
+            participants=[Actor(type="ai", id="ai-assistant")],
+        ),
+        events=events or [],
+    )
+
+
+def _annotation(event_id: str, category: Literal["learning", "correction"], content: str) -> TraceEvent:
+    return TraceEvent(
+        id=event_id,
+        session_id="egress_test_session",
+        type="annotation",
+        actor=Actor(type="ai", id="ai-assistant"),
+        annotation=AnnotationData(category=category, content=content),
+    )
+
+
+def _chat_response(payload: dict) -> MagicMock:
+    response = MagicMock()
+    response.choices = [MagicMock()]
+    response.choices[0].message.content = json.dumps(payload)
+    return response
+
+
+# ── The writer itself ─────────────────────────────────────────────────────
+
+
+class TestAttestEgress:
+    def test_appends_one_json_line_per_call(self, ledger):
+        attest_egress(
+            provider="openai",
+            endpoint="chat.completions",
+            model="gpt-5.4-mini",
+            purpose="extraction",
+            content_class="session-events",
+            item_count=7,
+            project="proj-a",
+            session_id="sess-1",
+        )
+        attest_egress(
+            provider="openai",
+            endpoint="embeddings",
+            model="text-embedding-3-small",
+            purpose="embedding",
+            content_class="learning-or-query-text",
+            item_count=3,
+        )
+        entries = _read_lines(ledger)
+        assert len(entries) == 2
+        first, second = entries
+        assert first["endpoint"] == "chat.completions"
+        assert first["project"] == "proj-a"
+        assert first["session_id"] == "sess-1"
+        assert first["item_count"] == 7
+        assert "ts" in first
+        assert second["endpoint"] == "embeddings"
+        assert second["project"] is None
+        # The FACT of egress is recorded — never the content.
+        for entry in entries:
+            assert "content" not in entry
+
+    def test_ledger_created_with_owner_only_mode(self, ledger):
+        attest_egress(
+            provider="openai",
+            endpoint="embeddings",
+            model="m",
+            purpose="embedding",
+            content_class="learning-or-query-text",
+            item_count=1,
+        )
+        mode = stat.S_IMODE(os.stat(ledger).st_mode)
+        assert mode == 0o600
+
+    def test_creates_parent_directories(self, tmp_path, monkeypatch):
+        path = tmp_path / "deep" / "nested" / "egress.jsonl"
+        monkeypatch.setenv("TRACE_EGRESS_LOG", str(path))
+        attest_egress(
+            provider="openai",
+            endpoint="embeddings",
+            model="m",
+            purpose="embedding",
+            content_class="learning-or-query-text",
+            item_count=1,
+        )
+        assert path.is_file()
+
+    def test_env_override_resolves_path(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("TRACE_EGRESS_LOG", str(tmp_path / "custom.jsonl"))
+        assert egress_log_path() == tmp_path / "custom.jsonl"
+
+    def test_default_path_is_trace_home(self, monkeypatch):
+        monkeypatch.delenv("TRACE_EGRESS_LOG", raising=False)
+        assert egress_log_path().name == "egress.jsonl"
+        assert egress_log_path().parent.name == ".trace"
+
+    def test_unwritable_ledger_fails_closed(self, blocked_ledger):
+        with pytest.raises(EgressAttestationError, match="TRACE_EGRESS_LOG"):
+            attest_egress(
+                provider="openai",
+                endpoint="embeddings",
+                model="m",
+                purpose="embedding",
+                content_class="learning-or-query-text",
+                item_count=1,
+            )
+
+
+# ── Embeddings call site ──────────────────────────────────────────────────
+
+_EMB = "trace_mcp.extensions.learn.embeddings"
+
+
+class TestOpenAIEmbeddingEgress:
+    def _provider_with_mock_client(self):
+        from trace_mcp.extensions.learn.embeddings import OpenAIEmbeddingProvider
+
+        with patch(f"{_EMB}._HAS_OPENAI", True):
+            with patch("openai.AsyncOpenAI") as MockClient:
+                mock_client = AsyncMock()
+                MockClient.return_value = mock_client
+                provider = OpenAIEmbeddingProvider(api_key="sk-test", model="text-embedding-3-small")
+        return provider, mock_client
+
+    async def test_attests_before_the_request(self, ledger):
+        provider, mock_client = self._provider_with_mock_client()
+
+        def _assert_ledger_written(**kwargs):
+            entries = _read_lines(ledger)
+            assert entries and entries[-1]["endpoint"] == "embeddings", (
+                "embeddings.create ran before the egress attestation was written"
+            )
+            response = MagicMock()
+            response.data = [MagicMock(embedding=[0.1, 0.2])]
+            return response
+
+        mock_client.embeddings.create = AsyncMock(side_effect=_assert_ledger_written)
+
+        vecs = await provider.embed_texts(["hello"])
+        assert vecs == [[0.1, 0.2]]
+        entry = _read_lines(ledger)[-1]
+        assert entry["purpose"] == "embedding"
+        assert entry["item_count"] == 1
+        assert entry["model"] == "text-embedding-3-small"
+
+    async def test_no_egress_when_ledger_unwritable(self, blocked_ledger):
+        """THE property: if the fact of egress cannot be recorded, no content
+        may leave the machine."""
+        provider, mock_client = self._provider_with_mock_client()
+        mock_client.embeddings.create = AsyncMock()
+
+        with pytest.raises(EgressAttestationError):
+            await provider.embed_texts(["secret content"])
+        mock_client.embeddings.create.assert_not_called()
+
+
+# ── Extraction call site ──────────────────────────────────────────────────
+
+
+class TestExtractionEgress:
+    async def test_llm_extraction_attests_with_project_and_session(self, ledger):
+        from trace_mcp.extensions.learn.extraction import extract_from_session_llm
+
+        config = LearnConfig(openai_api_key="sk-test", llm_enabled=True, strict_llm=False)
+        session = _session([_annotation("evt_001", "learning", "something worth keeping")])
+        ks = KnowledgeStore(project="egress-test-project")
+
+        with patch("trace_mcp.extensions.learn.extraction._HAS_OPENAI", True):
+            with patch("trace_mcp.extensions.learn.extraction.AsyncOpenAI") as MockClient:
+                mock_client = AsyncMock()
+                mock_client.chat.completions.create = AsyncMock(return_value=_chat_response({"learnings": []}))
+                MockClient.return_value = mock_client
+                await extract_from_session_llm(ks, session, config)
+
+        entry = _read_lines(ledger)[-1]
+        assert entry["purpose"] == "extraction"
+        assert entry["endpoint"] == "chat.completions"
+        assert entry["project"] == "egress-test-project"
+        assert entry["session_id"] == "egress_test_session"
+        assert entry["item_count"] == 1
+
+    async def test_blocked_ledger_falls_back_to_rule_based(self, blocked_ledger):
+        """Permissive mode + unwritable ledger: no cloud call, rule-based
+        extraction still delivers learnings."""
+        from trace_mcp.extensions.learn.extraction import extract_from_session_llm
+
+        config = LearnConfig(openai_api_key="sk-test", llm_enabled=True, strict_llm=False)
+        session = _session([_annotation("evt_001", "correction", "the model was wrong about X")])
+        ks = KnowledgeStore(project="egress-test-project")
+
+        with patch("trace_mcp.extensions.learn.extraction._HAS_OPENAI", True):
+            with patch("trace_mcp.extensions.learn.extraction.AsyncOpenAI") as MockClient:
+                mock_client = AsyncMock()
+                mock_client.chat.completions.create = AsyncMock()
+                MockClient.return_value = mock_client
+                new_ids = await extract_from_session_llm(ks, session, config)
+
+        mock_client.chat.completions.create.assert_not_called()
+        assert new_ids, "rule-based fallback should still extract the correction"
+
+    async def test_blocked_ledger_raises_in_strict_mode(self, blocked_ledger):
+        from trace_mcp.extensions.learn.config import LLMFallbackError
+        from trace_mcp.extensions.learn.extraction import extract_from_session_llm
+
+        config = LearnConfig(openai_api_key="sk-test", llm_enabled=True, strict_llm=True)
+        session = _session([_annotation("evt_001", "learning", "content")])
+        ks = KnowledgeStore(project="egress-test-project")
+
+        with patch("trace_mcp.extensions.learn.extraction._HAS_OPENAI", True):
+            with patch("trace_mcp.extensions.learn.extraction.AsyncOpenAI") as MockClient:
+                mock_client = AsyncMock()
+                mock_client.chat.completions.create = AsyncMock()
+                MockClient.return_value = mock_client
+                with pytest.raises(LLMFallbackError):
+                    await extract_from_session_llm(ks, session, config)
+        mock_client.chat.completions.create.assert_not_called()
+
+
+# ── Matching call site ────────────────────────────────────────────────────
+
+
+class TestMatchingEgress:
+    def _learnings(self) -> list[Learning]:
+        return [
+            Learning(id="lrn_001", content="use ml-dev conda env", tags=["conda"]),
+            Learning(id="lrn_002", content="pin numpy below 2.0", tags=["numpy"]),
+        ]
+
+    async def test_llm_matching_attests(self, ledger):
+        from trace_mcp.extensions.learn import matching
+
+        config = LearnConfig(openai_api_key="sk-test", llm_enabled=True, strict_llm=False)
+        with patch.object(matching, "_HAS_OPENAI", True):
+            with patch.object(matching, "AsyncOpenAI") as MockClient:
+                mock_client = AsyncMock()
+                mock_client.chat.completions.create = AsyncMock(return_value=_chat_response({"0": 0.9, "1": 0.1}))
+                MockClient.return_value = mock_client
+                backend = matching.LLMBackend(config)
+                scores = await backend.score_batch(self._learnings(), "conda environment setup")
+
+        assert scores
+        entry = _read_lines(ledger)[-1]
+        assert entry["purpose"] == "matching"
+        assert entry["endpoint"] == "chat.completions"
+        assert entry["item_count"] == 2
+
+    async def test_blocked_ledger_falls_back_to_bm25(self, blocked_ledger):
+        """Permissive mode + unwritable ledger: no cloud call, BM25 still scores."""
+        from trace_mcp.extensions.learn import matching
+
+        config = LearnConfig(openai_api_key="sk-test", llm_enabled=True, strict_llm=False)
+        with patch.object(matching, "_HAS_OPENAI", True):
+            with patch.object(matching, "AsyncOpenAI") as MockClient:
+                mock_client = AsyncMock()
+                mock_client.chat.completions.create = AsyncMock()
+                MockClient.return_value = mock_client
+                backend = matching.LLMBackend(config)
+                scores = await backend.score_batch(self._learnings(), "conda environment setup")
+
+        mock_client.chat.completions.create.assert_not_called()
+        assert scores, "BM25 fallback should still return scores"

--- a/tests/test_env_isolation.py
+++ b/tests/test_env_isolation.py
@@ -60,6 +60,16 @@ class TestSuiteEnvIsolation:
             "scratchpad would overwrite the developer's real .claude/SCRATCHPAD.md"
         )
 
+    def test_egress_log_points_at_tmp(self) -> None:
+        """Every mocked LLM/embedding test triggers a pre-call egress
+        attestation; unisolated, suite runs would append hundreds of
+        test-fixture lines to the developer's real ~/.trace/egress.jsonl."""
+        isolated = _assert_isolated("TRACE_EGRESS_LOG")
+        from trace_mcp.extensions.learn.egress import egress_log_path
+
+        resolved = egress_log_path().resolve()
+        assert resolved == isolated, f"egress ledger resolves to {resolved}, expected {isolated}"
+
     def test_default_knowledge_store_writes_land_in_tmp(self) -> None:
         """A store saved WITHOUT an explicit directory (the leak pattern that
         polluted the real ~/.trace/knowledge) must land in the isolated dir.

--- a/tests/test_invariants.py
+++ b/tests/test_invariants.py
@@ -120,3 +120,75 @@ def test_inv4_project_filter_is_exact_not_substring() -> None:
         "INV-4: both list_sessions and session_brief must filter by exact project "
         "match (proj != project) so core and hooks resolve one session set."
     )
+
+
+# ── INV-5: no cloud egress without a pre-call ledger attestation ───────────
+# Every OpenAI-SDK network call site in the trace-learn extension
+# (`...completions.create(...)` / `...embeddings.create(...)`) must call
+# attest_egress() in the SAME function, before the request. The egress ledger
+# (~/.trace/egress.jsonl) is only trustworthy if no call site can bypass it —
+# an unattested site is unrecorded egress, the exact failure mode the ledger
+# exists to prevent.
+#
+# Registered as (module-relative-path, function-name). The key is the function
+# NAME, not the qualified class method — good enough as a tripwire: a new
+# `.create` site in a new or existing function fails the first test until it is
+# registered AND attests.
+
+INV5_EGRESS_CALL_SITES = {
+    ("extensions/learn/extraction.py", "extract_from_session_llm"),
+    ("extensions/learn/matching.py", "_llm_score"),
+    ("extensions/learn/embeddings.py", "embed_texts"),
+}
+
+
+def _openai_network_call_sites() -> set[tuple[str, str]]:
+    """Every (relpath, function) under extensions/learn/ whose body makes an
+    OpenAI-SDK network call (an attribute call ``<x>.completions.create(...)``
+    or ``<x>.embeddings.create(...)``)."""
+    found: set[tuple[str, str]] = set()
+    learn = SRC / "extensions" / "learn"
+    for path in sorted(learn.rglob("*.py")):
+        tree = ast.parse(path.read_text(), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+                for sub in ast.walk(node):
+                    if (
+                        isinstance(sub, ast.Call)
+                        and isinstance(sub.func, ast.Attribute)
+                        and sub.func.attr == "create"
+                        and isinstance(sub.func.value, ast.Attribute)
+                        and sub.func.value.attr in ("completions", "embeddings")
+                    ):
+                        found.add((_rel(path), node.name))
+    return found
+
+
+def test_inv5_every_openai_call_site_is_registered() -> None:
+    """A new OpenAI network call site must be registered (and attest) before it
+    can merge; a registered site that disappears must be de-registered so the
+    registry cannot rot."""
+    sites = _openai_network_call_sites()
+    assert sites, (
+        "INV-5 positive control failed: no OpenAI call sites found at all — "
+        "the AST pattern in _openai_network_call_sites no longer matches the "
+        "codebase idiom and the guard is blind. Fix the pattern."
+    )
+    unregistered = sites - INV5_EGRESS_CALL_SITES
+    assert not unregistered, (
+        "INV-5 violation (docs/INVARIANTS.md): these functions make OpenAI "
+        f"network calls but are not registered egress sites: {sorted(unregistered)}. "
+        "Call attest_egress() before the request and add them to INV5_EGRESS_CALL_SITES."
+    )
+    stale = INV5_EGRESS_CALL_SITES - sites
+    assert not stale, f"INV-5 registry is stale — registered sites with no OpenAI call anymore: {sorted(stale)}."
+
+
+def test_inv5_every_egress_site_attests_first() -> None:
+    """Each registered egress site must actually call attest_egress()."""
+    attesters = _functions_calling("attest_egress")
+    missing = INV5_EGRESS_CALL_SITES - attesters
+    assert not missing, (
+        f"INV-5 violation: egress call sites that never call attest_egress(): {sorted(missing)} — "
+        "cloud content would leave the machine with no ledger record."
+    )


### PR DESCRIPTION
## Summary

Every cloud call trace-learn makes (LLM extraction, LLM matching, OpenAI embeddings) now appends one JSONL line to `~/.trace/egress.jsonl` (override: `TRACE_EGRESS_LOG`) **before** the request is made — recording the fact of the call (provider, endpoint, model, purpose, item count, project/session where the call site knows them), never the content. Registered as **INV-5** with an AST enumeration guard.

## Why

The kill switch (`TRACE_LOCAL_ONLY`) and the opt-in defaults control *whether* egress can happen; this ledger makes the egress that *does* happen auditable — a provenance tool should be able to answer "what left this machine, when, to which provider, on behalf of which project" from a local record. Design decisions:

- **Pre-call intent attestation.** Content reaches the provider even when the response later fails, so a post-call record could miss real egress. A ledger line therefore means "content was about to be sent", not "the call succeeded".
- **Fail closed.** If the ledger cannot be written, the cloud call must not happen — unrecorded egress is the exact failure mode the ledger exists to prevent. Call sites sit inside the existing strict/permissive LLM handling, so a failed attestation degrades exactly like a failed provider: strict raises, permissive falls back to the local path (BM25 / rule-based / un-embedded learnings). Either way, nothing leaves the machine.
- **Sidecar, not session mutation.** Extraction runs after `trace_end_session` finalizes the session record, so writing egress events into sessions would retroactively alter closed records (against the project's immutability discipline, INV-2). The ledger is an append-only sidecar instead — the same posture as the telemetry sidecar in docs/adr/004. Joining ledger lines to sessions at export time is possible later via the recorded `session_id`.
- **Guarded by construction (INV-5).** `tests/test_invariants.py` enumerates every OpenAI-SDK call site under `extensions/learn/` via AST; a new `.create` site fails CI until it is registered and calls `attest_egress` in the same function. Stale registrations fail too, and a positive control fails if the AST pattern rots.
- **Suite isolation.** `TRACE_EGRESS_LOG` joins the conftest-isolated env vars so mocked-LLM tests append to a per-run temp ledger, not the developer's real one (same leak class the knowledge/session isolation closed).

## Verification

- `tests/test_egress_ledger.py`: pre-call ordering (the mocked request asserts its ledger line already exists), the no-egress-without-ledger property (blocked ledger → provider mock never called) at all three call sites, strict raise vs permissive local fallback, 0600 file mode, parent-dir creation, path resolution.
- Invariant guard now runs 6 checks (INV-1/3/4 + 2×INV-5), all passing.
- Full suite with `uv sync --all-extras`: 996 passed / 11 skipped; ruff, `ruff format --check`, pyright (0 errors) clean.

## Risks / rollback

New failure surface: an unwritable `~/.trace` (or bad `TRACE_EGRESS_LOG`) now blocks cloud calls instead of letting them proceed unrecorded — intentional, and self-diagnosing (the error names the path and the env var). Ledger entries contain project names and usage patterns (file created 0600); no learning/session content is ever written. Rollback = revert; the ledger file is inert data.

## Follow-up (separate small PR)

`Learning.extraction_method` / `Learning.generated_by` fields so each learning records whether an LLM or the rule-based extractor produced it, and which model.