### PR TITLE
feat(learn): record each learning's creation path (extraction_method, generated_by)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   change is detected per learning); the `.npy` sidecar writer now tolerates
   mixed-dimension rows during that migration instead of erroring.
 
+### Learning creation-path provenance
+
+- **`Learning.extraction_method` and `Learning.generated_by`.** Every learning
+  now records how it was created: `"llm"` (cloud extraction — the content is
+  model output, so `generated_by` names the generating model), `"rule-based"`
+  (local extractor — the content is quoted from session events), or `"manual"`
+  (`trace_learn_add`). Records predating the fields load as `None`; tool
+  responses (`learning_to_dict`) expose both fields so clients can distinguish
+  model-generated from quoted content. This closes the gap where a paraphrased
+  LLM extraction was indistinguishable from a verbatim event quote in the
+  knowledge store.
+
 ### Diagnostics
 
 - **Offline self-cost report (`python -m trace_mcp.selfcost`).** A standalone,

--- a/src/trace_mcp/extensions/learn/__init__.py
+++ b/src/trace_mcp/extensions/learn/__init__.py
@@ -236,6 +236,7 @@ def register(mcp: FastMCP, storage: TraceStorage) -> None:
                         source_event=source_event,
                         tags=tags,
                         dedup_threshold=_config.dedup_threshold,
+                        extraction_method="manual",
                     )
                     if result.is_duplicate:
                         return json.dumps(
@@ -254,6 +255,7 @@ def register(mcp: FastMCP, storage: TraceStorage) -> None:
                         source_session=source_session,
                         source_event=source_event,
                         tags=tags,
+                        extraction_method="manual",
                     )
                 await _embed_learnings([lrn])
                 store.save_store(ks)

--- a/src/trace_mcp/extensions/learn/extraction.py
+++ b/src/trace_mcp/extensions/learn/extraction.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from trace_mcp.extensions.learn.models import KnowledgeStore, Learning, LearningCategory
 from trace_mcp.extensions.learn.store import add_learning, add_learning_dedup
@@ -74,6 +74,8 @@ def _add_with_optional_dedup(
     corrects_event_ids: list[str] | None = None,
     tags: list[str] | None = None,
     dedup_threshold: float | None = None,
+    extraction_method: Literal["llm", "rule-based", "manual"] | None = None,
+    generated_by: str | None = None,
 ) -> Learning | None:
     """Add a learning, optionally checking for content duplicates first.
 
@@ -89,6 +91,8 @@ def _add_with_optional_dedup(
             corrects_event_ids=corrects_event_ids,
             tags=tags,
             dedup_threshold=dedup_threshold,
+            extraction_method=extraction_method,
+            generated_by=generated_by,
         )
         if result.is_duplicate:
             logger.debug(
@@ -106,6 +110,8 @@ def _add_with_optional_dedup(
         source_event=source_event,
         corrects_event_ids=corrects_event_ids,
         tags=tags,
+        extraction_method=extraction_method,
+        generated_by=generated_by,
     )
 
 
@@ -148,6 +154,7 @@ def extract_from_session(
                     corrects_event_ids=list(ann.corrects_event_ids) if ann.corrects_event_ids else None,
                     tags=list(ann.tags),
                     dedup_threshold=dedup_threshold,
+                    extraction_method="rule-based",
                 )
                 if lrn is not None:
                     new_ids.append(lrn.id)
@@ -184,6 +191,7 @@ def extract_from_session(
                     source_event=evt.id,
                     tags=tags,
                     dedup_threshold=dedup_threshold,
+                    extraction_method="rule-based",
                 )
                 if lrn is not None:
                     new_ids.append(lrn.id)
@@ -203,6 +211,7 @@ def extract_from_session(
                     source_event=evt.id,
                     tags=list(contrib.tags),
                     dedup_threshold=dedup_threshold,
+                    extraction_method="rule-based",
                 )
                 if lrn is not None:
                     new_ids.append(lrn.id)
@@ -355,6 +364,8 @@ async def extract_from_session_llm(
                 corrects_event_ids=item.get("corrects_event_ids"),
                 tags=item.get("tags", []),
                 dedup_threshold=dedup_threshold,
+                extraction_method="llm",
+                generated_by=config.llm_extraction_model,
             )
             if lrn is not None:
                 new_ids.append(lrn.id)

--- a/src/trace_mcp/extensions/learn/models.py
+++ b/src/trace_mcp/extensions/learn/models.py
@@ -38,6 +38,13 @@ class Learning(BaseModel):
     last_surfaced: datetime | None = None
     embedding: list[float] | None = None
     embedding_model: str | None = None
+    # Creation-path provenance (egress-as-provenance): whether a cloud LLM,
+    # the local rule-based extractor, or a human-initiated trace_learn_add
+    # produced this learning's content. None on records predating the field.
+    extraction_method: Literal["llm", "rule-based", "manual"] | None = None
+    # Model id that generated the content when extraction_method == "llm"
+    # (the content is model output, not a verbatim quote of session events).
+    generated_by: str | None = None
 
 
 class KnowledgeStore(BaseModel):

--- a/src/trace_mcp/extensions/learn/store.py
+++ b/src/trace_mcp/extensions/learn/store.py
@@ -15,7 +15,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from trace_mcp.extensions.learn.models import KnowledgeStore, Learning
 
@@ -165,6 +165,8 @@ def add_learning(
     source_event: str | None = None,
     corrects_event_ids: list[str] | None = None,
     tags: list[str] | None = None,
+    extraction_method: Literal["llm", "rule-based", "manual"] | None = None,
+    generated_by: str | None = None,
 ) -> Learning:
     """Add a learning to the store and return it."""
     learning = Learning(
@@ -175,6 +177,8 @@ def add_learning(
         source_event=source_event,
         corrects_event_ids=corrects_event_ids or [],
         tags=tags or [],
+        extraction_method=extraction_method,
+        generated_by=generated_by,
     )
     store.learnings.append(learning)
     return learning
@@ -260,6 +264,8 @@ def add_learning_dedup(
     corrects_event_ids: list[str] | None = None,
     tags: list[str] | None = None,
     dedup_threshold: float = 0.85,
+    extraction_method: Literal["llm", "rule-based", "manual"] | None = None,
+    generated_by: str | None = None,
 ) -> DedupResult:
     """Add a learning with content deduplication.
 
@@ -278,6 +284,8 @@ def add_learning_dedup(
         source_event=source_event,
         corrects_event_ids=corrects_event_ids,
         tags=tags,
+        extraction_method=extraction_method,
+        generated_by=generated_by,
     )
     return DedupResult(learning=lrn, is_duplicate=False)
 

--- a/tests/test_learning_extraction_provenance.py
+++ b/tests/test_learning_extraction_provenance.py
@@ -1,0 +1,125 @@
+"""Learning creation-path provenance (extraction_method / generated_by).
+
+Every Learning records HOW it was created: "llm" (cloud extraction — content
+is model output, so generated_by names the model), "rule-based" (local
+extractor — content is quoted from session events), or "manual"
+(trace_learn_add). Old stores predating the fields load as None.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Literal
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from trace_mcp.extensions.learn.config import LearnConfig
+from trace_mcp.extensions.learn.models import KnowledgeStore
+from trace_mcp.extensions.learn.store import add_learning, learning_to_dict
+from trace_mcp.schema import Session
+from trace_mcp.schema.events import AnnotationData, TraceEvent
+from trace_mcp.schema.session import Actor, SessionMetadata
+
+
+def _session(events: list[TraceEvent]) -> Session:
+    return Session(
+        id="prov_test_session",
+        metadata=SessionMetadata(
+            project="prov-test-project",
+            participants=[Actor(type="ai", id="ai-assistant")],
+        ),
+        events=events,
+    )
+
+
+def _annotation(event_id: str, category: Literal["learning", "correction"], content: str) -> TraceEvent:
+    return TraceEvent(
+        id=event_id,
+        session_id="prov_test_session",
+        type="annotation",
+        actor=Actor(type="ai", id="ai-assistant"),
+        annotation=AnnotationData(category=category, content=content),
+    )
+
+
+class TestExtractionMethodProvenance:
+    def test_rule_based_extraction_marks_rule_based(self):
+        from trace_mcp.extensions.learn.extraction import extract_from_session
+
+        ks = KnowledgeStore(project="prov-test-project")
+        session = _session([_annotation("evt_001", "learning", "quoted insight from events")])
+        new_ids = extract_from_session(ks, session)
+        assert new_ids
+        lrn = ks.learnings[0]
+        assert lrn.extraction_method == "rule-based"
+        assert lrn.generated_by is None
+
+    async def test_llm_extraction_marks_llm_and_model(self):
+        from trace_mcp.extensions.learn.extraction import extract_from_session_llm
+
+        config = LearnConfig(
+            openai_api_key="sk-test",
+            llm_extraction_model="gpt-5.4-mini",
+            llm_enabled=True,
+            strict_llm=False,
+        )
+        ks = KnowledgeStore(project="prov-test-project")
+        session = _session([_annotation("evt_001", "learning", "raw event content")])
+
+        llm_payload = {
+            "learnings": [
+                {
+                    "content": "Synthesized insight (model output, not a quote)",
+                    "category": "learning",
+                    "tags": ["synthesized"],
+                    "source_event": "evt_001",
+                    "corrects_event_ids": [],
+                }
+            ]
+        }
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = json.dumps(llm_payload)
+
+        with patch("trace_mcp.extensions.learn.extraction._HAS_OPENAI", True):
+            with patch("trace_mcp.extensions.learn.extraction.AsyncOpenAI") as MockClient:
+                mock_client = AsyncMock()
+                mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
+                MockClient.return_value = mock_client
+                new_ids = await extract_from_session_llm(ks, session, config)
+
+        assert new_ids
+        lrn = ks.learnings[0]
+        assert lrn.extraction_method == "llm"
+        assert lrn.generated_by == "gpt-5.4-mini"
+
+    def test_manual_add_marks_manual(self):
+        ks = KnowledgeStore(project="prov-test-project")
+        lrn = add_learning(ks, content="hand-entered insight", extraction_method="manual")
+        assert lrn.extraction_method == "manual"
+        assert lrn.generated_by is None
+
+    def test_old_store_records_load_as_none(self):
+        """Stores written before the fields existed must load unchanged."""
+        raw = {
+            "project": "prov-test-project",
+            "learnings": [
+                {
+                    "id": "lrn_001",
+                    "content": "pre-existing learning",
+                    "category": "learning",
+                }
+            ],
+        }
+        ks = KnowledgeStore.model_validate(raw)
+        lrn = ks.learnings[0]
+        assert lrn.extraction_method is None
+        assert lrn.generated_by is None
+
+    def test_tool_response_exposes_provenance_fields(self):
+        """learning_to_dict (tool/API serialization) must carry the fields so
+        clients can distinguish model-generated from quoted content."""
+        ks = KnowledgeStore(project="prov-test-project")
+        lrn = add_learning(ks, content="x", extraction_method="llm", generated_by="gpt-5.4-mini")
+        d = learning_to_dict(lrn)
+        assert d["extraction_method"] == "llm"
+        assert d["generated_by"] == "gpt-5.4-mini"


### PR DESCRIPTION
## Summary

Adds `Learning.extraction_method` (`"llm"` | `"rule-based"` | `"manual"`) and `Learning.generated_by` (model id when `"llm"`), set at all three creation paths and exposed in tool responses. Companion to the egress ledger (#28): the ledger records what left the machine; these fields record which stored content is model output.

## Why

A learning produced by cloud LLM extraction is a synthesis — model output — while a rule-based extraction is a quote of session events. The store previously could not tell them apart, so paraphrase bleed-through in bulk re-extraction runs could not be traced to the generating model, and audits could not tell generated from quoted content. Design:

- Additive and backward-compatible: records predating the fields load as `None`; no migration.
- Threaded through `add_learning` / `add_learning_dedup` / `_add_with_optional_dedup` rather than set post-hoc, so no creation path can forget it.
- `learning_to_dict` (tool/API serialization) carries both fields.

## Verification

- `tests/test_learning_extraction_provenance.py`: rule-based marks `"rule-based"`, mocked LLM extraction marks `"llm"` + the extraction model, manual add marks `"manual"`, old-store JSON loads with `None`, tool response exposes both fields.
- Full suite with `uv sync --all-extras`: 985 passed / 11 skipped; ruff, `ruff format --check`, pyright (0 errors), invariant guard clean.

## Risks / rollback

Purely additive fields with `None` defaults; older code reading a new store ignores unknown keys. Rollback = revert.