### PR TITLE
Decouple PyPI publish from tags and finish CITATION.cff for Zenodo DOI archival

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,25 @@
 name: Release
 
-# Tag-triggered publish to PyPI via Trusted Publishing (OIDC — no stored token).
-# Tag the release commit with `vX.Y.Z` (matching pyproject `version`) and push
-# the tag; this builds, runs the full quality gate + a leak guard, then publishes.
+# Manual-only release. PyPI publishing is intentionally PAUSED and MUST NOT be
+# automated. This workflow has no push or tag trigger, so creating a git tag or
+# a GitHub Release (e.g. for Zenodo DOI archival) can never trigger a PyPI
+# upload.
+#
+# Fail-closed, two-step flow via "Run workflow":
+#   1. Dispatch with the `confirm` input left blank to build and run the full
+#      quality gate + packaging/leak guards against the selected ref (a safe
+#      dry run; nothing is published).
+#   2. Only a dispatch with `confirm: PUBLISH` runs the publish job, uploading
+#      to PyPI via Trusted Publishing (OIDC — no stored token).
+# Publishing stays paused until the distribution name is resolved and a release
+# is deliberately initiated.
 on:
-  push:
-    tags: ["v*"]
   workflow_dispatch:
+    inputs:
+      confirm:
+        description: "Type PUBLISH to release to PyPI. Leave blank to build & verify only (no publish)."
+        required: false
+        default: ""
 
 permissions:
   contents: read
@@ -62,10 +75,13 @@ jobs:
     name: Publish to PyPI
     needs: build
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
+    # Fail closed: publish only on an explicit, typed confirmation. No git tag
+    # or GitHub Release reaches this job — the workflow has no push trigger.
+    if: ${{ inputs.confirm == 'PUBLISH' }}
+    # Trusted Publishing binds to this environment; the PyPI project mapping and
+    # the distribution name are finalized when the publication pause is lifted.
     environment:
       name: pypi
-      url: https://pypi.org/p/trace-mcp
     permissions:
       id-token: write # OIDC for PyPI Trusted Publishing
     steps:

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,8 +11,9 @@ type: software
 authors:
   - given-names: Oliver
     family-names: Muellerklein
+    email: omuellerklein@berkeley.edu
     affiliation: "Department of Environmental Science, Policy, and Management, University of California, Berkeley"
-    # orcid: "https://orcid.org/<ORCID-TBD>"   # TODO(PI): add ORCID before release/JOSS
+    orcid: "https://orcid.org/0000-0002-5967-1314"
 license: Apache-2.0
 repository-code: "https://github.com/Thru-Echoes/TRACE"
 version: 0.4.2
@@ -22,5 +23,8 @@ keywords:
   - reproducibility
   - Model Context Protocol
   - research integrity
+  - human-AI collaboration
+  - audit trail
+  - W3C PROV
 # DOI is minted on archival (Zenodo) at release; add here once available:
 # doi: "10.5281/zenodo.<TBD>"

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -38,13 +38,14 @@ In short: self-contained, durable prose; preferred subject shape
   release commit at release time (not retroactively).
 - Versioning follows [SemVer](https://semver.org); the changelog follows
   [Keep a Changelog](https://keepachangelog.com).
-- `release.yml` builds and verifies the shipped distribution. **PyPI
-  publication is paused** pending finalization of the published distribution
-  name, so a release is currently "tagged + built + verified", not "published".
-  Because a pushed `vX.Y.Z` tag currently triggers the publish job, version
-  tags are not pushed to the remote while the publication pause is in effect;
-  the tag/publish coupling will be made safe (publish gated to a deliberate
-  action) before remote tagging resumes.
+- `release.yml` is **manual-only** (`workflow_dispatch`); it has no push or tag
+  trigger. Dispatching it with the `confirm` input left blank builds and
+  verifies the shipped distribution (a safe dry run); only a dispatch with
+  `confirm: PUBLISH` uploads to PyPI. **PyPI publication remains paused**
+  pending finalization of the distribution name, so a release is currently
+  "built + verified", not "published". Because no tag or GitHub Release can
+  trigger a publish, version tags and Releases are safe to create — e.g. for
+  Zenodo DOI archival — while the pause is in effect.
 
 ## Maintenance backlog
 


### PR DESCRIPTION
## Summary

Two changes that prepare the repository for a Zenodo DOI while keeping PyPI
publication paused:

- **`release.yml` is now manual-only.** The workflow no longer publishes on a
  pushed tag. It runs only via `workflow_dispatch` with a typed `confirm`
  input: a blank `confirm` builds and verifies the distribution (dry run), and
  only `confirm: PUBLISH` uploads to PyPI (Trusted Publishing / OIDC).
  `docs/maintenance.md` is updated to match.
- **`CITATION.cff` is finished.** Adds the author ORCID and contact email,
  removes the pre-release ORCID placeholder, and adds keywords. Valid against
  CFF schema 1.2.0.

## Why

Publishing on any `v*` tag couples version tagging to publication. Creating a
version tag or GitHub Release is exactly what Zenodo needs for DOI archival, so
the old trigger meant a citation tag would attempt a PyPI upload — while the
distribution name is unresolved and publication is deliberately paused. Making
the publish path a deliberate, confirmed, manual action removes that footgun
and lets tags and Releases be created safely. Zenodo reads CITATION.cff to
populate the deposit, so the citation metadata must be complete and
schema-valid before archival.

## Verification

- `release.yml` parses; it has no `push`/`tags` trigger, and the publish job
  is gated on `inputs.confirm == 'PUBLISH'`.
- `CITATION.cff` validates against Citation File Format schema 1.2.0
  (`cffconvert --validate`).

## Follow-up (not in this PR)

`repository-code` in CITATION.cff still points at the current repository URL;
it is updated together with the other repository-URL references (the
`.mcp.json` generators, README) when the repository is relocated. A
required-reviewer rule on the `pypi` deployment environment can be added as a
second lock once the repository move is complete.
