### PR TITLE
feat(identity): canonical project identity and fail-closed cross-project isolation

### DIFF
--- a/docs/INVARIANTS.md
+++ b/docs/INVARIANTS.md
@@ -131,6 +131,32 @@ unwritable).
 
 ---
 
+## INV-7 — Every project-registry write is fail-closed, locked, and atomic  · ENFORCED
+
+**Statement.** All mutations of the project registry (`~/.trace/projects.json`,
+override `TRACE_REGISTRY_PATH`) go through `project_identity.locked_registry`,
+which acquires the fail-closed exclusive lock (`O_EXCL` + PID-liveness steal,
+raising `TimeoutError` rather than writing unlocked), yields the freshest
+disk-truth registry, validates alias uniqueness, and persists atomically
+(temp + `os.replace`) only on clean exit. A corrupt or unknown-major registry
+raises `RegistryUnavailableError` on load and is **never** overwritten — an
+unreadable registry is fail-closed, not silently reset (the same reasoning as
+INV-1). The single serializer is `project_identity._atomic_write_registry`.
+
+**Sites:** writer `src/trace_mcp/project_identity.py` (`_atomic_write_registry`,
+called only by `locked_registry`).
+
+**Guard:** `tests/test_invariants.py :: test_inv7_registry_write_only_via_locked_registry`
+(AST enumeration — a new caller of `_atomic_write_registry` outside
+`locked_registry` fails until registered, with a positive control against
+pattern rot). Behavior pinned by `tests/test_project_identity.py` (lock timeout
+raises, dead-holder steal, corrupt/unknown-major refusal, atomic write leaves no
+temp file, a caller exception writes nothing).
+
+**Status.** ENFORCED.
+
+---
+
 *To add an invariant: give it the next `INV-N`, state it, enumerate the
 exhaustive site-set, name the guard + test, and add a check to
 `tests/test_invariants.py` that fails when a new site violates it.*

--- a/docs/INVARIANTS.md
+++ b/docs/INVARIANTS.md
@@ -78,24 +78,29 @@ the parameter as a `Literal`.
 
 ---
 
-## INV-4 — Project scoping uses ONE comparison rule across core and hooks  · CLOSED
+## INV-4 — Project scoping matches by canonical key in the core query filters  · ENFORCED
 
-**Statement.** A project name must resolve to the **same** session set in the
-core query layer and in the adapter hooks. The single shared predicate is
-**exact, case-sensitive** match (`metadata.project == project`). A
-case-insensitive **substring** match must never be used, as it silently merges
-distinct projects (e.g. `trace_project_summary("trace")` pulling in `trace-mcp`
-and `TRACE-research`).
+**Statement.** The core query filters (`list_sessions`, `session_brief`) resolve
+a project by **canonical key** (`project_identity.session_project_key`), so
+drifted display labels resolve to one project: case variants
+(`coeqwal`/`COEQWAL`) merge via `canonical_project_key`, and rename aliases
+(`TRACE`→`trace-mcp`) merge via the registry alias table. Two predicates are
+forbidden — a case-insensitive **substring** match (merges distinct projects)
+and **raw case-sensitive label equality** (splits one project across drifted
+labels). The adapter hooks are aligned to the same canonical rule in the
+surfaces step (ADR-006 S5); until then they still match the raw label (a
+narrower pre-migration session set, not a core-tool correctness gap).
 
 **Sites:** `src/trace_mcp/storage/json_file.py` (`list_sessions`,
-`session_brief`); `src/trace_mcp/adapters/claude_code/assets/hooks/*.sh`.
+`session_brief`); `src/trace_mcp/adapters/claude_code/assets/hooks/*.sh`
+(aligned in S5).
 
-**Guard:** `tests/test_invariants.py :: test_inv4_project_filter_is_exact_not_substring`
-fails if the substring idiom reappears at either core filter site; the exact
-semantics are pinned by `tests/test_storage.py :: test_list_filter_by_project`.
+**Guard:** `tests/test_invariants.py :: test_inv4_project_filter_uses_canonical_key`
+fails if the substring idiom or raw-label equality reappears at either core
+filter site, and requires the canonical predicate. Behavior pinned by
+`tests/test_storage.py`.
 
-**Status.** CLOSED — core (`list_sessions`, `session_brief`) now uses the same
-exact-match predicate as the hooks, so both layers resolve one session set.
+**Status.** ENFORCED (core query filters; hooks aligned in S5).
 
 ---
 

--- a/docs/INVARIANTS.md
+++ b/docs/INVARIANTS.md
@@ -205,6 +205,26 @@ temp file, a caller exception writes nothing).
 
 ---
 
+## INV-9 — Every learn tool guards its free-form project label  · ENFORCED
+
+**Statement.** Each `@mcp.tool` in `extensions/learn` that takes a `project`
+parameter calls `_reserved_project_error` at entry, so a reserved-key
+(`auto`/`shared`) or degenerate label returns an error and never reaches a
+knowledge store. Combined with the canonical `_store_path`, a free-form label
+can neither open a quarantine store nor create a mis-keyed one.
+
+**Sites:** `src/trace_mcp/extensions/learn/__init__.py` (`trace_learn_recall`,
+`trace_learn_add`, `trace_learn_list`, `trace_learn_forget`,
+`trace_learn_extract`).
+
+**Guard:** `tests/test_invariants.py :: test_inv9_learn_tools_guard_reserved_projects`
+(AST enumeration — a new learn tool with a `project` param that does not call
+`_reserved_project_error` fails, with a positive control against pattern rot).
+
+**Status.** ENFORCED.
+
+---
+
 *To add an invariant: give it the next `INV-N`, state it, enumerate the
 exhaustive site-set, name the guard + test, and add a check to
 `tests/test_invariants.py` that fails when a new site violates it.*

--- a/docs/INVARIANTS.md
+++ b/docs/INVARIANTS.md
@@ -136,6 +136,49 @@ unwritable).
 
 ---
 
+## INV-6 — (project, session) coherence before a learn extraction  · ENFORCED
+
+**Statement.** Every function in `extensions/learn` whose signature carries both
+a `project` and a `session_id` (it extracts a session into a project's store)
+MUST call `project_identity.validate_project_session` first. Otherwise a session
+belonging to project A can be extracted into project B's knowledge store — and,
+under a cloud backend, project B's entire store leaves the machine as
+de-duplication context alongside project A's events (the worst cross-project
+bleed). The check fails closed (`ProjectMismatchError` / `ProjectKeyError`).
+
+**Sites:** `src/trace_mcp/extensions/learn/__init__.py` (`_extract_hook`,
+`trace_learn_extract`).
+
+**Guard:** `tests/test_invariants.py :: test_inv6_project_session_sites_validate_coherence`
+(AST enumeration — a new `(project, session_id)` learn function that does not
+call `validate_project_session` fails, with a positive control against pattern
+rot). Behavior pinned by `tests/test_learn_containment.py`.
+
+**Status.** ENFORCED.
+
+---
+
+## INV-8 — The knowledge-store lock is fail-closed and dependency-free  · ENFORCED
+
+**Statement.** `extensions/learn/store.py :: project_lock` acquires the
+dependency-free O_EXCL + PID-liveness lock (`project_identity.exclusive_file_lock`),
+keyed by the canonical store path, and raises `TimeoutError` rather than
+proceeding unlocked. The previous behavior — a silent no-op when the optional
+`filelock` package was absent, and proceed-on-timeout — reopened the lost-update
+window the lock exists to close, violating the same fail-closed standard as the
+session lock (INV-1).
+
+**Sites:** `src/trace_mcp/extensions/learn/store.py` (`project_lock`, keyed by
+`_store_path`, the canonical store path).
+
+**Guard:** `tests/test_invariants.py :: test_inv8_knowledge_lock_is_fail_closed_and_dependency_free`
+(no `filelock` import; `project_lock` uses `exclusive_file_lock`). Behavior
+pinned by `tests/test_learn_containment.py` (lock timeout raises).
+
+**Status.** ENFORCED.
+
+---
+
 ## INV-7 — Every project-registry write is fail-closed, locked, and atomic  · ENFORCED
 
 **Statement.** All mutations of the project registry (`~/.trace/projects.json`,

--- a/docs/adr/006-project-identity-and-isolation.md
+++ b/docs/adr/006-project-identity-and-isolation.md
@@ -1,0 +1,272 @@
+# ADR 006: Project identity and cross-project isolation
+
+**Status**: proposed
+**Date**: 2026-07-17
+
+## Context
+
+TRACE stores every session in one flat directory (`~/.trace/sessions/`), with a
+session's project identity held only in a free-text `metadata.project` string.
+Segregation between projects is cooperative labeling, not enforcement. On a
+real deployment holding 500+ sessions across 30+ project labels — client
+work, academic research, and personal projects in one store — this produced
+concrete failure modes:
+
+- **Label drift with inconsistent identity semantics.** The same project
+  accumulates multiple labels (case variants, pre/post-rename names). Session
+  queries compare labels with exact case-sensitive equality, so drifted labels
+  read as *distinct* projects — while the knowledge store's filename
+  derivation (`sanitize_name` + a case-insensitive filesystem) *merges* some
+  of the same pairs, so learnings silently commingle. Storage identity and
+  query identity are two inconsistent equivalence relations over the same
+  labels.
+- **Drift originates at the producers.** Labels are minted by heuristics — a
+  CLAUDE.md marker regex, git/directory basenames, env defaults, free-form
+  tool parameters — with no normalization or validation anywhere. One
+  verified mechanical cause: the adapter hooks' pin-line regex does not
+  tolerate markdown bold, so hooks fall back to the git basename while a model
+  reading the same file sees the bolded marker's value — deterministically
+  producing a drift pair for the same repository.
+- **Cross-project bleed paths.** The current-session pointer can be captured
+  by any active session regardless of project; `trace_learn_extract` accepts a
+  mismatched `(project, session_id)` pair, wiring one project's events into
+  another's knowledge store — and sending the second store to a cloud LLM as
+  dedup context interleaved with the first project's events, while the egress
+  ledger row names only the session's project; auto-created sessions pool all
+  projects' extracted learnings in one `auto` store; the decision-audit hook
+  reads the globally newest session with no project filter; id-only
+  read/export tools are label-blind. A store's save path derives from the
+  label embedded *inside* the file rather than the requested label, so a
+  mislabeled file silently migrates content on the next load→save, and the
+  store lock can guard a different path than the file actually written.
+- **Sequencing pressure from ADR 005.** The capture-time-integrity design
+  binds the project label into hashed genesis records (ADR 005 §2). If
+  hash-chaining lands before identity is repaired, today's drift is
+  cryptographically frozen: a later relabel becomes indistinguishable from
+  tampering. Identity must land first.
+- **Config is machine-global.** Privacy posture (`TRACE_LOCAL_ONLY`,
+  `TRACE_LLM_ENABLED`, embedding backend) cannot differ per project, so a
+  confidentiality-bound client project cannot be forced local-only while a
+  personal project allows cloud calls.
+
+The project's provenance rule — never retroactively alter TRACE data —
+constrains the repair itself: bulk-rewriting existing capture records to fix
+labels is the same class of alteration the rule forbids, and the session store
+doubles as study data for the companion research repository.
+
+## Decision
+
+### 1. Two-layer identity: canonical key + display labels
+
+A new core module `src/trace_mcp/project_identity.py` (stdlib + pydantic only)
+provides `canonical_project_key(label)`: NFC-normalize, strip, casefold, fold
+separator/invalid-character runs to `-`, collapse repeats, reject empty. Two
+mechanically guarded properties make filename identity equal semantic identity
+on every filesystem, including case-insensitive APFS:
+
+- idempotence: `key(key(x)) == key(x)`
+- `sanitize_name` fixed point: `sanitize_name(key) == key`
+
+`metadata.project` keeps its existing meaning (human display label, schema
+unchanged and unconstrained). A new **additive, optional**
+`metadata.project_key` carries the canonical key on new sessions
+(authoritative-if-present; version-skewed writers preserve it via
+`extra="allow"` but do not re-derive it).
+
+### 2. Alias registry
+
+`~/.trace/projects.json`: a versioned Pydantic model (own format version,
+independent of `SCHEMA_VERSION`; unknown-major fails closed and is never
+rewritten) mapping canonical keys to entries `{display_label, aliases, status,
+config, history}`. Every historical drifted label is recorded as an alias —
+required forever, because legacy sessions and already-exported PROV artifacts
+resolve through this table. Writes are atomic (temp + `os.replace`) under a
+fail-closed `O_EXCL` + PID-liveness lock (the session-lock pattern), with an
+append-only in-file history. No alias may resolve to two entries. Alias and
+enrollment minting is CLI-only; pinned server processes never auto-enroll,
+and unpinned processes may auto-enroll unknown labels as *new* keys only —
+never as aliases of existing keys.
+
+### 3. Process pin: `TRACE_PROJECT`
+
+One server process per project is already true for every real launch config;
+this is upgraded from convention to enforcement. `trace-mcp init` enrolls the
+project and writes `TRACE_PROJECT=<key>` into the consumer's `.mcp.json` env
+block (and a `.claude/trace.project` pin file for hooks). Precedence:
+`TRACE_PROJECT` (hard pin) > `TRACE_DEFAULT_PROJECT` (retained, soft default
+for auto-created sessions) > the reserved `auto` sentinel. Unpinned processes
+keep legacy behavior with loud warnings and `pinned:false` in health output;
+`TRACE_REQUIRE_PIN=1` (default off until the fleet is swept) fails closed.
+Wrong-pin risk is mitigated by init-derived pins, a bootstrap echo of the
+bound identity on every session start, and a startup/health cross-check of
+the pin against repository heuristics.
+
+### 4. Enforcement points
+
+- **Pointer adoption**: promoting an explicit `session_id` to the current
+  session requires the session's resolved key to equal the pin.
+- **(project, session) coherence**: a single core validator
+  `validate_project_session(storage, project, session_id)` must run before
+  any pair touches a store — mandatory for `trace_learn_extract` and the
+  extraction hook. Registered as an invariant with an AST enumeration guard
+  (the egress-attestation guard pattern), spanning core and the extension
+  without imports.
+- **Cross-project reads**: id-only read/export tools on a pinned process
+  hard-deny foreign sessions by default. Escape hatch:
+  `TRACE_ALLOW_CROSS_PROJECT_READS=1`, with responses stamped
+  `cross_project:true` and both keys named. Operator-level cross-project
+  auditing moves to the CLI, whose output is dual-key stamped.
+- **Tool parameters**: `project` on `trace_start_session` and all
+  `trace_learn_*` tools becomes optional; under a pin, `None` resolves to the
+  pin and any supplied label must resolve to it or the call errors naming
+  both keys. Every project parameter passes registry resolution at tool
+  entry (invariant-guarded).
+- **Hooks**: all four adapter hooks share one byte-identical detection block
+  (pin file first, then a bold-tolerant CLAUDE.md regex, then git/dirname),
+  match sessions by canonical key, and emit a version stamp so stale fleet
+  copies self-identify. The decision-audit hook gains the same detection and
+  a project filter.
+- **Honest orientation**: `session_brief` becomes a bounded per-project scan
+  (newest-first, read ceiling, canonical-key matching) that reports window
+  exhaustion instead of falsely asserting that no prior sessions exist.
+
+### 5. Knowledge and embeddings containment
+
+A knowledge store, its `.embeddings.npy` sidecar (a write-only derived
+artifact — regenerated, never migrated), and its lock form one unit keyed by
+the canonical key. `load_store` fails closed when the in-file label disagrees
+with the requested key (closing silent relabel-on-save); `save_store` derives
+its path from the requested key; the lock keys on the same path it guards.
+The store lock is rewritten on the core dependency-free fail-closed pattern
+(raise on timeout; the optional `filelock` dependency and all warn-and-proceed
+branches are removed). Cloud payloads become structurally single-project:
+extraction, LLM matching, and embedding batches can never interleave two
+projects, and all three egress-attestation sites gain a `project_key` column
+(two are attributable for the first time). The egress ledger stays one global
+append-only file; historical rows are never rewritten.
+
+### 6. Per-project config: restrict-only ratchet
+
+Registry entries carry `{local_only, llm_enabled, embedding_backend_max}`,
+applied at the three egress decision points as a ratchet: a project entry can
+force a client project local-only against a permissive global config, but can
+never loosen a global restriction. The `.env` precedence order is untouched.
+If the registry is unreadable while pinned, knowledge and egress paths fail
+closed; session *capture* degrades to canonicalization-only with loud
+warnings — isolation is the learn/egress contract, capture-over-attribution
+is the standing auto-session commitment, and the split honors both.
+
+### 7. Reserved keys, the `auto` quarantine, and `adopt`
+
+`auto` and `shared` are reserved registry keys. Explicit session starts and
+learn tools reject labels resolving to them. End-session extraction and
+recall are gated off for `auto` sessions (no recorded policy mandates
+extraction from unattributed sessions), freezing the commingled
+`knowledge/auto.json` as quarantined data. Auto-creation itself is preserved:
+capture never fails closed on a missing session, and the sentinel's
+documented no-disk-inference role stands for unpinned servers. A
+provenance-honest `adopt` operation (auto → real project only) appends a
+`state_change` event recording old→new/actor/reason through the locked write
+path and stamps the additive `project_key` — append-shaped, so it survives
+ADR 005 as a journal record.
+
+### 8. Alias-table-first repair — capture records are never bulk-rewritten
+
+Legacy sessions keep their raw labels verbatim forever and are interpreted
+through the alias table. There is no bulk `project_key` stamping sweep;
+`adopt` is the only sanctioned in-place touch. Knowledge stores (mutable,
+derived-adjacent data) *are* consolidated per alias group — Jaccard-dedup
+union under a live-writer preflight gate, originals kept as
+`*.premerge-<date>` files, every merge ledgered with content hashes in an
+append-only `migrations.jsonl` — after a mandatory full-store snapshot and a
+human-signed label→key plan. Semantically distinct labels (pre/post-rename
+pairs) are never auto-merged; the human decides. Migration execution is an
+operator runbook, strictly separated from the PRs that land the tooling.
+Rollback is bit-identical for capture records by construction.
+
+### 9. Versioning and spec impact
+
+`SCHEMA_VERSION` 0.4.1 → 0.5.0 (additive `project_key` is an on-disk format
+change); schema `$id` moves to `trace-v0.5.json` via the established rename
+cascade. `project` remains unconstrained in the emitted schema (a pattern
+would retroactively invalidate live documents). The spec gains: Terminology
+entries (Project, Canonical Project Key, Alias); a normative §3.2.x canonical
+key algorithm (spec-defined, explicitly independent of any implementation's
+filename sanitization); a §4.5 rule that consumers must not treat equal-key
+labels as distinct projects; `trace:projectKey` (and an optional reified
+project entity with alias labels) added to PROV exports under the frozen
+`ns/v0.3#` namespace — `trace:project` keeps its display-label meaning
+forever, so the already-exported corpus is never reinterpreted. The registry
+gets a published interchange schema (`trace-projects-v1.json`), since
+interpreting historical exports depends on the alias table.
+
+### 10. Adaptive-learning cross-project sharing is foreclosed
+
+Ambient cross-project knowledge (a shared corpus, cross-store search,
+background sync) is incompatible with the containment invariant and with
+per-project `local_only`, and is foreclosed. The only sanctioned future
+replacement is explicit per-learning transfer — a deliberate, logged,
+lineage-stamped copy between named stores, blocked out of `local_only`
+projects — recorded here so a future roadmap cannot resurrect the
+shared-corpus design by accident. Not implemented in this workstream.
+
+### 11. ADR 005 inheritance contract
+
+Everything above lands before ADR 005 P1. Genesis records will bind the
+already-canonical, registry-stable `project_key` (display label carried as a
+non-identity field), so drift can never be cryptographically frozen and
+repair stays distinguishable from tampering. The planned flat journal layout
+needs no amendment — canonical keys make physical per-project directories
+permanently unnecessary. The heads registry adopts the projects-registry
+conventions (versioned model, fail-closed lock, invariant-registered writers)
+and is keyed by `(project_key, session_id)`; the first chained record may
+commit a hash of the pre-P1 registry and `migrations.jsonl`, sealing the
+repair audit trail.
+
+## Alternatives considered
+
+- **Physical per-project directories now** — rejected: session-file moves
+  during live multi-process operation require tombstones that convert laggard
+  capture into permanent provenance loss, a lockstep fleet sweep with the
+  worst blast radius, and dual-layout code that ADR 005 P1 would rewrite
+  anyway. The one unique payoff (per-project handover) is captured at export
+  time by a project bundle command instead.
+- **Capability-style storage wrapper** (project-scoped handles replacing the
+  storage ABC) — rejected: contradicted the existing storage interface
+  contract and added construction machinery; a single AST-guarded validator
+  achieves the same non-bypassability with far less surface.
+- **Bulk `project_key` stamping of legacy sessions** — rejected as
+  retroactive alteration of capture records; alias-table-first is the
+  conservative reading of the provenance rule.
+- **Warn-and-stamp cross-project reads** (instead of hard-deny) — rejected:
+  leaves a laundering path where foreign content is pulled into a pinned
+  context and re-persisted into the pinned store.
+- **Per-project egress ledger files** — rejected: the ledger is
+  cross-project metadata by design; a `project_key` column suffices, and the
+  single-file audit workflow is documented and taught.
+- **Fail-closing all tools on registry damage** — rejected: one damaged file
+  must not stop provenance capture machine-wide; only isolation-bearing
+  paths (knowledge, egress) fail closed.
+
+## Consequences
+
+- Five invariants are added or rewritten (project-match predicate on
+  canonical keys; (project, session) coherence; registry integrity;
+  fail-closed dependency-free knowledge lock; no free-form label reaches a
+  store path), each with an enumeration guard in `tests/test_invariants.py`
+  and a row in `docs/INVARIANTS.md`.
+- Previously silent states become visible errors: corrupt knowledge stores
+  raise instead of silently resetting; lock timeouts raise instead of
+  proceeding; cross-project reads deny instead of succeeding quietly. An
+  adjustment period of new error surfaces is expected and intended.
+- Enforcement completeness is coupled to the fleet sweep: until every
+  consumer config carries the pin, unpinned processes retain legacy behavior
+  (loudly). The coupling is time-boxed and terminates in a fail-closed
+  default (`TRACE_REQUIRE_PIN`, registry strict mode).
+- The knowledge history already merged by case-insensitive filesystems is
+  unrecoverable per-learning; consolidation records the merge rather than
+  reconstructing attribution, and the limitation is documented for research
+  use of the store.
+- Implementation is sliced into seven independently landable PRs, one
+  operator runbook, and one post-observation hardening step; the detailed
+  sequence lives with the implementation plan, not this ADR.

--- a/src/trace_mcp/extensions/learn/__init__.py
+++ b/src/trace_mcp/extensions/learn/__init__.py
@@ -32,6 +32,22 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _reserved_project_error(project: str) -> str | None:
+    """JSON error if *project* is degenerate or resolves to a reserved key, else None.
+
+    The usage-ban half of ADR-006 (INV-9): reserved keys (auto/shared) are
+    quarantine stores, not projects a learn tool may operate on. Every learn
+    tool calls this at entry so a free-form label cannot reach a reserved store.
+    """
+    try:
+        key = pident.canonical_project_key(project)
+    except pident.ProjectKeyError as exc:
+        return json.dumps({"error": str(exc), "project": project})
+    if key in pident.RESERVED_KEYS:
+        return json.dumps({"error": f"'{project}' is a reserved project key and cannot be used", "project": project})
+    return None
+
+
 def register(mcp: FastMCP, storage: TraceStorage) -> None:
     """Register trace-learn tools and hooks on the MCP server."""
 
@@ -164,6 +180,9 @@ def register(mcp: FastMCP, storage: TraceStorage) -> None:
         keep recall fully local.
         """
         try:
+            guard = _reserved_project_error(project)
+            if guard:
+                return guard
             # Lock the full span (recall may backfill
             # embeddings and save — a read-modify-write).
             with store.project_lock(project):
@@ -221,6 +240,9 @@ def register(mcp: FastMCP, storage: TraceStorage) -> None:
         content is embedded via OpenAI. Set ``TRACE_LOCAL_ONLY=1`` for local-only.
         """
         try:
+            guard = _reserved_project_error(project)
+            if guard:
+                return guard
             if category not in _VALID_CATEGORIES:
                 return json.dumps(
                     {
@@ -290,6 +312,9 @@ def register(mcp: FastMCP, storage: TraceStorage) -> None:
         Optionally filter by category (learning, correction, gotcha, decision).
         """
         try:
+            guard = _reserved_project_error(project)
+            if guard:
+                return guard
             ks = store.load_store(project)
             results = store.list_learnings(ks, category=category)
             return json.dumps({"project": project, "learnings": results, "total": len(results)})
@@ -307,6 +332,9 @@ def register(mcp: FastMCP, storage: TraceStorage) -> None:
         Use this when a learning is outdated, wrong, or no longer relevant.
         """
         try:
+            guard = _reserved_project_error(project)
+            if guard:
+                return guard
             with store.project_lock(project):  # lock the full read-modify-write span
                 ks = store.load_store(project)
                 removed = store.remove_learning(ks, learning_id)
@@ -341,9 +369,9 @@ def register(mcp: FastMCP, storage: TraceStorage) -> None:
         Otherwise, extracts from all sessions for the project.
         """
         try:
-            # Reserved keys (auto/shared) are not usable projects (ADR-006 D14).
-            if pident.canonical_project_key(project) in pident.RESERVED_KEYS:
-                return json.dumps({"error": f"'{project}' is a reserved project key", "project": project})
+            guard = _reserved_project_error(project)
+            if guard:
+                return guard
             # INV-6: when extracting a specific session, refuse if it belongs to a
             # different project — the cross-wired-extract bleed (would send this
             # project's whole store to the cloud alongside another's events).

--- a/src/trace_mcp/extensions/learn/__init__.py
+++ b/src/trace_mcp/extensions/learn/__init__.py
@@ -14,6 +14,7 @@ import json
 import logging
 from typing import TYPE_CHECKING, cast, get_args
 
+from trace_mcp import project_identity as pident
 from trace_mcp.extension_hooks import register_extract_hook, register_recall_hook
 from trace_mcp.extensions.learn import extraction, matching, store
 from trace_mcp.extensions.learn.config import load_config
@@ -125,6 +126,10 @@ def register(mcp: FastMCP, storage: TraceStorage) -> None:
             return results
 
     async def _extract_hook(project: str, session_id: str) -> list[str]:
+        # INV-6: refuse to extract a session into a DIFFERENT project's store
+        # (closes the cross-wired-extract bleed, which would also send one
+        # project's store to the cloud as another's dedup context).
+        await pident.validate_project_session(storage, project, session_id)
         with store.project_lock(project):  # lock the full read-modify-write span
             ks = store.load_store(project)
             sess = await storage.get_session(session_id)
@@ -336,6 +341,14 @@ def register(mcp: FastMCP, storage: TraceStorage) -> None:
         Otherwise, extracts from all sessions for the project.
         """
         try:
+            # Reserved keys (auto/shared) are not usable projects (ADR-006 D14).
+            if pident.canonical_project_key(project) in pident.RESERVED_KEYS:
+                return json.dumps({"error": f"'{project}' is a reserved project key", "project": project})
+            # INV-6: when extracting a specific session, refuse if it belongs to a
+            # different project — the cross-wired-extract bleed (would send this
+            # project's whole store to the cloud alongside another's events).
+            if session_id:
+                await pident.validate_project_session(storage, project, session_id)
             # Lock the full multi-session extract→embed→save span.
             with store.project_lock(project):
                 ks = store.load_store(project)
@@ -370,6 +383,10 @@ def register(mcp: FastMCP, storage: TraceStorage) -> None:
                         "total_learnings": len(ks.learnings),
                     }
                 )
+        except (pident.ProjectMismatchError, pident.ProjectKeyError) as exc:
+            return json.dumps(
+                {"error": "project/session coherence check failed", "detail": str(exc), "project": project}
+            )
         except Exception as exc:
             from trace_mcp.extensions.learn.config import LLMFallbackError
 

--- a/src/trace_mcp/extensions/learn/store.py
+++ b/src/trace_mcp/extensions/learn/store.py
@@ -34,57 +34,37 @@ def _get_directory(directory: str | None = None) -> Path:
 
 
 def _store_path(project: str, directory: str | None = None) -> Path:
-    from trace_mcp.storage.json_file import sanitize_name
+    # Key the store file by the CANONICAL project key, so case/separator variants
+    # (TRACE vs trace, proj a vs proj_a) resolve to ONE file and a case-insensitive
+    # filesystem cannot silently merge two distinct projects (ADR-006). Extensions
+    # may import core (ADR-003); core never imports back.
+    from trace_mcp.project_identity import canonical_project_key
 
-    return _get_directory(directory) / f"{sanitize_name(project)}.json"
-
-
-_warned_no_filelock = False
+    return _get_directory(directory) / f"{canonical_project_key(project)}.json"
 
 
 @contextmanager
 def project_lock(project: str, directory: str | None = None) -> Iterator[None]:
-    """Per-project cross-process lock around a load→mutate→save span.
+    """Fail-closed per-project cross-process lock around a load→mutate→save span.
 
-    The shared knowledge store is
-    read-modify-write; without a lock, two TRACE sessions mutating the
-    SAME project concurrently silently lose one update (last-writer-wins).
-    The lock is keyed per-project (not whole-directory) so unrelated
-    projects never contend — important with many concurrent sessions.
+    The shared knowledge store is read-modify-write; without a lock, two TRACE
+    sessions mutating the SAME project concurrently silently lose one update
+    (last-writer-wins). The lock is keyed by the canonical store path so
+    case/separator variants of a project contend on ONE lock (matching the one
+    store file), and unrelated projects never contend.
 
-    Degrades gracefully: if the optional ``filelock`` dependency is not
-    installed, this is a no-op (with a one-time warning) rather than a
-    hard failure — a missing lock lib must not break the extension. On
-    lock-acquire timeout it proceeds (warned) rather than blocking an
-    interactive tool indefinitely.
+    **Fail closed** (INV-8): uses the dependency-free O_EXCL + PID-liveness lock
+    (``project_identity.exclusive_file_lock``), which raises ``TimeoutError``
+    rather than proceeding unlocked. The previous behavior — a no-op when the
+    optional ``filelock`` package was absent, and proceed-on-timeout — silently
+    reopened the lost-update window the lock exists to close, violating the
+    repo's own fail-closed standard.
     """
-    global _warned_no_filelock
-    try:
-        from filelock import FileLock, Timeout
-    except Exception:
-        if not _warned_no_filelock:
-            logger.warning(
-                "filelock not installed — knowledge-store writes are not "
-                "cross-process locked; concurrent multi-session writes to the "
-                "same project can lose updates. Install the trace-mcp 'all' or "
-                "'embeddings' extra (or `pip install filelock`) to enable."
-            )
-            _warned_no_filelock = True
-        yield
-        return
+    from trace_mcp.project_identity import exclusive_file_lock
 
     timeout = float(os.environ.get("TRACE_LOCK_TIMEOUT", "15"))
     lock_path = str(_store_path(project, directory)) + ".lock"
-    try:
-        with FileLock(lock_path, timeout=timeout):
-            yield
-    except Timeout:
-        logger.warning(
-            "Timed out after %.0fs acquiring knowledge-store lock for "
-            "project %r; proceeding without the lock to avoid blocking.",
-            timeout,
-            project,
-        )
+    with exclusive_file_lock(lock_path, timeout=timeout):
         yield
 
 

--- a/src/trace_mcp/extensions/learn/store.py
+++ b/src/trace_mcp/extensions/learn/store.py
@@ -72,6 +72,24 @@ class StoreLoadError(Exception):
     """Raised when a knowledge store file exists but cannot be parsed."""
 
 
+def _assert_store_identity(ks: KnowledgeStore, project: str, path: Path) -> None:
+    """Fail closed if a store's own project disagrees with the key it loaded as.
+
+    With canonical store paths a file should only ever be reached by a label that
+    canonicalizes to the same key. A mismatch means the file is misplaced or
+    tampered — it must not silently answer for another project.
+    """
+    from trace_mcp.project_identity import StoreIdentityError, canonical_project_key
+
+    if not ks.project:
+        return
+    if canonical_project_key(ks.project) != canonical_project_key(project):
+        raise StoreIdentityError(
+            f"knowledge store {path} declares project {ks.project!r} but was loaded as {project!r} "
+            "(different canonical keys) — refusing to answer for another project."
+        )
+
+
 def load_store(
     project: str,
     directory: str | None = None,
@@ -88,7 +106,7 @@ def load_store(
         return KnowledgeStore(project=project)
     try:
         raw = json.loads(path.read_text(encoding="utf-8"))
-        return KnowledgeStore.model_validate(raw)
+        ks = KnowledgeStore.model_validate(raw)
     except json.JSONDecodeError as exc:
         msg = f"Corrupt JSON in knowledge store {path}: {exc}"
         logger.warning(msg)
@@ -101,6 +119,8 @@ def load_store(
         if strict:
             raise StoreLoadError(msg) from exc
         return KnowledgeStore(project=project)
+    _assert_store_identity(ks, project, path)
+    return ks
 
 
 def save_store(store: KnowledgeStore, directory: str | None = None) -> Path:

--- a/src/trace_mcp/init_project.py
+++ b/src/trace_mcp/init_project.py
@@ -22,6 +22,15 @@ class TraceSourceUnresolvedError(RuntimeError):
     """No safe ``uvx --from <X>`` source could be determined for `.mcp.json`."""
 
 
+class TraceInitError(RuntimeError):
+    """`.mcp.json` cannot be safely updated (e.g. the existing file is not valid JSON).
+
+    Raised instead of silently discarding and replacing a file we could not
+    parse — overwriting it would destroy sibling MCP servers and any hand-added
+    configuration the user could not have intended to lose.
+    """
+
+
 def _resolve_trace_source() -> str:
     """Pick the value to write into `.mcp.json`'s `uvx --from <X>` argument.
 
@@ -71,20 +80,102 @@ def _mcp_server_config() -> dict:
     }
 
 
+def _extract_with_packages(args: object) -> list[str]:
+    """Return the ordered, de-duplicated ``--with <pkg>`` names present in *args*.
+
+    Tolerant of malformed input: a non-list ``args``, a trailing ``--with`` with
+    no value, or a non-string value are all skipped rather than raising.
+    """
+    if not isinstance(args, list):
+        return []
+    packages: list[str] = []
+    i = 0
+    while i < len(args):
+        if args[i] == "--with" and i + 1 < len(args) and isinstance(args[i + 1], str):
+            if args[i + 1] not in packages:
+                packages.append(args[i + 1])
+            i += 2
+        else:
+            i += 1
+    return packages
+
+
+def _rebuild_args(fresh_args: list[str], with_packages: list[str]) -> list[str]:
+    """Canonical fresh ``args`` with preserved ``--with`` pairs inserted before the command.
+
+    ``fresh_args`` ends with the tool name (the uvx command); preserved
+    ``--with`` flags are inserted just before it so uvx option order stays valid.
+    """
+    if not with_packages:
+        return list(fresh_args)
+    with_flags: list[str] = []
+    for pkg in with_packages:
+        with_flags += ["--with", pkg]
+    return fresh_args[:-1] + with_flags + fresh_args[-1:]
+
+
+def _merge_trace_entry(existing: object, fresh: dict) -> dict:
+    """Merge the freshly-built ``trace`` entry over an existing one.
+
+    Preserves hand-added ``--with`` extras, any ``env`` block, and unknown keys
+    from *existing* while adopting the freshly-resolved ``command`` and
+    ``--from``/``--refresh-package`` source. If *existing* is not a dict (a
+    malformed entry), the fresh entry replaces it wholesale.
+    """
+    if not isinstance(existing, dict):
+        return fresh
+    merged = dict(existing)
+    merged["command"] = fresh["command"]
+    merged["args"] = _rebuild_args(fresh["args"], _extract_with_packages(existing.get("args")))
+    env: dict = {}
+    if isinstance(existing.get("env"), dict):
+        env.update(existing["env"])
+    if isinstance(fresh.get("env"), dict):
+        env.update(fresh["env"])
+    if env:
+        merged["env"] = env
+    return merged
+
+
 def _write_mcp_json(project_dir: Path) -> str:
-    """Write or merge the TRACE entry into ``.mcp.json``. Returns a one-line status."""
+    """Write or merge the TRACE entry into ``.mcp.json``. Returns a one-line status.
+
+    Re-running is non-destructive: an existing ``trace`` entry's ``--with``
+    extras, ``env`` block, and unknown keys are preserved, and sibling servers
+    are left untouched. A pre-existing ``.mcp.json`` that is not valid JSON (or
+    not a JSON object) is left on disk and raises ``TraceInitError`` (fail
+    closed) rather than being silently discarded and replaced.
+    """
     mcp_path = project_dir / ".mcp.json"
     if mcp_path.exists():
         try:
             config = json.loads(mcp_path.read_text())
-        except json.JSONDecodeError:
-            config = {"mcpServers": {}}
+        except json.JSONDecodeError as exc:
+            raise TraceInitError(
+                f"{mcp_path} is not valid JSON ({exc}); refusing to overwrite it. "
+                "Fix or remove the file and re-run."
+            ) from exc
+        if not isinstance(config, dict):
+            raise TraceInitError(
+                f"{mcp_path} does not contain a JSON object; refusing to overwrite it. "
+                "Fix or remove the file and re-run."
+            )
+        servers = config.get("mcpServers")
+        if servers is None:
+            servers = {}
+            config["mcpServers"] = servers
+        elif not isinstance(servers, dict):
+            raise TraceInitError(
+                f"{mcp_path} has a non-object 'mcpServers'; refusing to overwrite it. "
+                "Fix or remove the file and re-run."
+            )
     else:
         config = {"mcpServers": {}}
+        servers = config["mcpServers"]
 
-    config.setdefault("mcpServers", {})
-    was_present = "trace" in config["mcpServers"]
-    config["mcpServers"]["trace"] = _mcp_server_config()["trace"]
+    was_present = "trace" in servers
+    fresh_entry = _mcp_server_config()["trace"]
+    servers["trace"] = _merge_trace_entry(servers.get("trace"), fresh_entry) if was_present else fresh_entry
 
     mcp_path.write_text(json.dumps(config, indent=2) + "\n")
     return f"  {'updated' if was_present else 'wrote'}: {mcp_path}"
@@ -131,7 +222,7 @@ def init_project(
         else:
             entry = _mcp_server_config()["trace"]
             print(f"  [dry-run] would write: {project_dir / '.mcp.json'} (uvx --from {entry['args'][1]})")
-    except TraceSourceUnresolvedError as exc:
+    except (TraceSourceUnresolvedError, TraceInitError) as exc:
         print(f"Error: {exc}")
         sys.exit(1)
 

--- a/src/trace_mcp/init_project.py
+++ b/src/trace_mcp/init_project.py
@@ -152,8 +152,7 @@ def _write_mcp_json(project_dir: Path) -> str:
             config = json.loads(mcp_path.read_text())
         except json.JSONDecodeError as exc:
             raise TraceInitError(
-                f"{mcp_path} is not valid JSON ({exc}); refusing to overwrite it. "
-                "Fix or remove the file and re-run."
+                f"{mcp_path} is not valid JSON ({exc}); refusing to overwrite it. Fix or remove the file and re-run."
             ) from exc
         if not isinstance(config, dict):
             raise TraceInitError(

--- a/src/trace_mcp/project_identity.py
+++ b/src/trace_mcp/project_identity.py
@@ -493,17 +493,15 @@ def _meta_get(meta: Any, name: str) -> Any:
     return value
 
 
-def session_project_key(meta: Any) -> str:
-    """The canonical key a session record belongs to.
+def key_for_label(label: str) -> str:
+    """Resolve a plain project *label* to a canonical key for read-side matching.
 
-    Uses ``project_key`` when present (authoritative), else resolves the
-    display ``project`` label through the registry, else canonicalizes it.
-    Returns ``""`` for a degenerate/empty label (which then matches no real key).
+    Registry alias/canonical resolution when a registry exists, else the bare
+    canonical key. **Non-raising**: returns ``""`` for a degenerate/empty label
+    (which then matches no real key). Unlike ``resolve_project_key`` this never
+    enrolls and never raises on an unknown label — it is for query filtering,
+    not project creation.
     """
-    project_key = _meta_get(meta, "project_key")
-    if isinstance(project_key, str) and project_key:
-        return project_key
-    label = _meta_get(meta, "project")
     if not isinstance(label, str) or not label.strip():
         return ""
     registry = get_registry_cached()
@@ -515,6 +513,20 @@ def session_project_key(meta: Any) -> str:
         return canonical_project_key(label)
     except ProjectKeyError:
         return ""
+
+
+def session_project_key(meta: Any) -> str:
+    """The canonical key a session record belongs to.
+
+    Uses ``project_key`` when present (authoritative), else resolves the
+    display ``project`` label through the registry / canonicalization.
+    Returns ``""`` for a degenerate/empty label (which then matches no real key).
+    """
+    project_key = _meta_get(meta, "project_key")
+    if isinstance(project_key, str) and project_key:
+        return project_key
+    label = _meta_get(meta, "project")
+    return key_for_label(label if isinstance(label, str) else "")
 
 
 def session_matches_project(meta: Any, key: str) -> bool:

--- a/src/trace_mcp/project_identity.py
+++ b/src/trace_mcp/project_identity.py
@@ -236,8 +236,7 @@ class ProjectRegistry(BaseModel):
                 owner = seen.get(ident)
                 if owner is not None and owner != key:
                     raise ValueError(
-                        f"registry inconsistency: identifier {ident!r} resolves to both "
-                        f"'{owner}' and '{key}'"
+                        f"registry inconsistency: identifier {ident!r} resolves to both '{owner}' and '{key}'"
                     )
                 seen[ident] = key
 

--- a/src/trace_mcp/project_identity.py
+++ b/src/trace_mcp/project_identity.py
@@ -1,0 +1,584 @@
+"""Canonical project identity and the fail-closed alias registry (ADR-006).
+
+Core module — stdlib + pydantic only, with **zero imports from
+``extensions/``** (it may be imported by both core and extensions; extensions
+import core, never the reverse, per ADR-003). It gives every layer of TRACE one
+authoritative notion of "same project", replacing today's two inconsistent
+relations (exact case-sensitive label equality in session queries vs. a
+lossy, case-folding filename derivation in the knowledge store).
+
+Exports
+-------
+Identity:
+    ``canonical_project_key`` — the single normalization every layer compares by.
+    ``session_project_key`` / ``session_matches_project`` — a session record's key.
+    ``resolve_project_key`` — label → key via the registry (with enrollment).
+    ``validate_project_session`` — fail-closed (project, session) coherence (INV-6).
+    ``get_bound_project`` — the process's ``TRACE_PROJECT`` pin, if any.
+    ``RESERVED_KEYS`` — ``{"auto", "shared"}``.
+
+Registry (``~/.trace/projects.json``, overridable via ``TRACE_REGISTRY_PATH``):
+    ``ProjectRegistry`` / ``ProjectEntry`` / ``ProjectConfig`` / ``RegistryChange``.
+    ``load_registry`` / ``get_registry_cached`` / ``registry_path``.
+    ``locked_registry`` — fail-closed read-modify-write of the registry (INV-7).
+    ``exclusive_file_lock`` — the reusable sync O_EXCL + PID-liveness lock.
+
+Exceptions:
+    ``ProjectKeyError`` — a label cannot form a valid canonical key.
+    ``ProjectMismatchError`` — a (project, session) pair names two projects.
+    ``RegistryUnavailableError`` — the registry is missing/corrupt/unknown-major.
+    ``StoreIdentityError`` — a knowledge store's on-disk label ≠ its key (used in S4).
+
+Side effects: reads/writes ``~/.trace/projects.json`` and a sibling
+``projects.json.lock``; reads the ``TRACE_PROJECT`` / ``TRACE_REGISTRY_PATH``
+environment variables.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import re
+import tempfile
+import time
+import unicodedata
+from collections.abc import Iterator, Mapping
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+# Core → core import. ``_holder_status`` is the single PID-liveness policy behind
+# the session lock; reusing it (rather than re-deriving it) keeps lock-steal
+# safety a single implementation — the same reasoning as INV-1.
+from trace_mcp.storage.json_file import _holder_status
+
+if TYPE_CHECKING:
+    from trace_mcp.storage.base import TraceStorage
+
+
+# ── Exceptions ────────────────────────────────────────────────────────────
+
+
+class ProjectKeyError(ValueError):
+    """A project label cannot be reduced to a non-empty canonical key."""
+
+
+class ProjectMismatchError(Exception):
+    """A (project, session) pair names two different canonical projects (INV-6)."""
+
+
+class RegistryUnavailableError(Exception):
+    """The project registry exists but is corrupt or an unknown major version.
+
+    Distinct from "absent" (no file yet): absence is a normal pre-migration
+    state that degrades gracefully, whereas an unreadable file must fail closed
+    and MUST NOT be silently overwritten.
+    """
+
+
+class StoreIdentityError(Exception):
+    """A knowledge store's on-disk project label disagrees with its key (used in S4)."""
+
+
+# ── Canonical key ─────────────────────────────────────────────────────────
+
+RESERVED_KEYS: frozenset[str] = frozenset({"auto", "shared"})
+"""Keys that may exist as pre-seeded registry entries but can never be enrolled
+from a user-supplied label: ``auto`` (unattributed-session quarantine) and
+``shared`` (reserved against a future cross-project channel)."""
+
+_SEP_RUN = re.compile(r"[\s/_]+")
+_NON_KEY_RUN = re.compile(r"[^\w.-]+")
+_DOT_RUN = re.compile(r"\.{2,}")
+_DASH_RUN = re.compile(r"-{2,}")
+
+
+def canonical_project_key(label: str) -> str:
+    """Return the stable canonical key for a project display *label*.
+
+    Algorithm: Unicode NFC-normalize → strip → casefold → fold every run of
+    whitespace / ``/`` / ``_`` and every run of characters outside ``[\\w.-]``
+    to a single ``-`` → collapse ``..`` and ``--`` runs → strip leading/trailing
+    ``.``/``-``. Underscore is folded (not preserved) so ``proj a``, ``proj/a``
+    and ``proj_a`` share one key.
+
+    Two properties are guaranteed (and pinned by tests):
+
+    * **idempotent** — ``canonical_project_key(k) == k`` when *k* is already a key.
+    * **``sanitize_name`` fixed point** — ``sanitize_name(k) == k``, so filename
+      identity equals semantic identity: a case-insensitive filesystem can
+      neither merge two distinct keys nor split one (the drift/collision class
+      ADR-006 closes).
+
+    Raises:
+        ProjectKeyError: *label* has no usable characters.
+    """
+    s = unicodedata.normalize("NFC", label).strip().casefold()
+    s = _SEP_RUN.sub("-", s)
+    s = _NON_KEY_RUN.sub("-", s)
+    s = _DOT_RUN.sub(".", s)
+    s = _DASH_RUN.sub("-", s)
+    s = s.strip(".-")
+    if not s:
+        raise ProjectKeyError(f"project label {label!r} has no usable characters for a canonical key")
+    return s
+
+
+# ── Registry models ───────────────────────────────────────────────────────
+
+
+class ProjectConfig(BaseModel):
+    """Per-project privacy posture — a RESTRICT-ONLY ratchet (ADR-006 §6).
+
+    A registry entry may *tighten* a global setting (force a client project
+    local-only) but can never loosen a global restriction; the ratchet itself
+    is applied by the learn extension in S4, this is only the carrier.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    local_only: bool = False
+    llm_enabled: bool | None = None
+    embedding_backend_max: Literal["local", "any"] = "any"
+
+
+class ProjectEntry(BaseModel):
+    """One canonical project: its key, human label, and every historical alias."""
+
+    model_config = ConfigDict(extra="allow")
+
+    key: str
+    display_label: str
+    aliases: list[str] = Field(default_factory=list)
+    status: Literal["active", "retired", "quarantined", "merged"] = "active"
+    merged_into: str | None = None
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    enrolled_by: str = ""
+    config: ProjectConfig = Field(default_factory=ProjectConfig)
+    notes: str = ""
+
+
+class RegistryChange(BaseModel):
+    """An append-only audit entry for every registry mutation."""
+
+    model_config = ConfigDict(extra="allow")
+
+    ts: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    actor: str = ""
+    action: str = ""
+    details: dict[str, Any] = Field(default_factory=dict)
+
+
+class ProjectRegistry(BaseModel):
+    """The alias registry: canonical keys → entries, plus an append-only history.
+
+    ``version`` is the registry format line, versioned independently of the
+    session ``SCHEMA_VERSION`` (it evolves on a different cadence); a major
+    mismatch fails closed on load. ``extra='allow'`` round-trips unknown fields
+    from a newer writer.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    version: str = "1"
+    strict: bool = False
+    projects: dict[str, ProjectEntry] = Field(default_factory=dict)
+    history: list[RegistryChange] = Field(default_factory=list)
+
+    def resolve(self, label: str) -> str | None:
+        """Return the canonical key *label* belongs to, or None if unknown.
+
+        Match order: verbatim key → verbatim alias → canonical-key equality →
+        canonicalized-alias equality. Tolerant of a *label* that cannot form a
+        key (treated as no match).
+        """
+        if label in self.projects:
+            return label
+        for key, entry in self.projects.items():
+            if label in entry.aliases:
+                return key
+        try:
+            canon = canonical_project_key(label)
+        except ProjectKeyError:
+            return None
+        if canon in self.projects:
+            return canon
+        for key, entry in self.projects.items():
+            if canon == key:
+                return key
+            for alias in entry.aliases:
+                try:
+                    if canonical_project_key(alias) == canon:
+                        return key
+                except ProjectKeyError:
+                    continue
+        return None
+
+    def assert_unique_aliases(self) -> None:
+        """Raise if any identifier (key or alias, verbatim or canonical) maps to two entries.
+
+        Enforced before every persist so the registry cannot drift into an
+        ambiguous state where one label resolves to two projects.
+        """
+        seen: dict[str, str] = {}
+        for key, entry in self.projects.items():
+            idents: set[str] = {key}
+            for raw in (key, *entry.aliases):
+                idents.add(raw)
+                try:
+                    idents.add(canonical_project_key(raw))
+                except ProjectKeyError:
+                    continue
+            for ident in idents:
+                owner = seen.get(ident)
+                if owner is not None and owner != key:
+                    raise ValueError(
+                        f"registry inconsistency: identifier {ident!r} resolves to both "
+                        f"'{owner}' and '{key}'"
+                    )
+                seen[ident] = key
+
+
+# ── Registry persistence (fail-closed) ────────────────────────────────────
+
+_DEFAULT_REGISTRY = os.path.expanduser("~/.trace/projects.json")
+_REGISTRY_MAJOR = "1"
+_registry_cache: tuple[str, float, ProjectRegistry | None] | None = None
+
+
+def registry_path() -> Path:
+    """Path to the project registry (``TRACE_REGISTRY_PATH`` or ``~/.trace/projects.json``)."""
+    return Path(os.environ.get("TRACE_REGISTRY_PATH", _DEFAULT_REGISTRY))
+
+
+@contextlib.contextmanager
+def exclusive_file_lock(
+    lock_path: str | Path,
+    *,
+    timeout: float = 10.0,
+    steal_after: float = 60.0,
+    poll: float = 0.02,
+) -> Iterator[None]:
+    """Sync fail-closed advisory lock — the ``JsonFileStorage.lock`` pattern.
+
+    Exclusive lock file (``O_CREAT | O_EXCL``), no fcntl/filelock dependency. A
+    held lock is stolen only if its holder process is provably dead (single-host
+    PID liveness via ``_holder_status``) or — for an unparseable/legacy token —
+    if it is older than *steal_after*; a live holder is never stolen. A byte +
+    mtime re-verify guards the steal against a TOCTOU where a fresh lock replaces
+    the stale one mid-check. **Fail closed:** raises ``TimeoutError`` rather than
+    proceeding unlocked (S4/registry writes must be visible, not silently raced).
+
+    Reused by the knowledge-store lock in S4 (keyed by canonical key there).
+
+    Raises:
+        TimeoutError: the lock could not be acquired within *timeout*.
+    """
+    lock_path = Path(lock_path)
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    token = f"{os.getpid()}:{time.time_ns()}".encode()
+    acquired = False
+    waited = 0.0
+    while True:
+        try:
+            fd = os.open(str(lock_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+            try:
+                os.write(fd, token)
+            finally:
+                os.close(fd)
+            acquired = True
+            break
+        except FileExistsError:
+            pass  # held — decide below whether to steal
+
+        stole = False
+        try:
+            token_seen = lock_path.read_bytes()
+            before = os.stat(lock_path)
+            holder = _holder_status(token_seen)
+            stale_by_time = (time.time() - before.st_mtime) > steal_after
+            if holder == "dead" or (holder == "unknown" and stale_by_time):
+                after = os.stat(lock_path)
+                if after.st_mtime_ns == before.st_mtime_ns and lock_path.read_bytes() == token_seen:
+                    os.unlink(lock_path)
+                    stole = True
+        except OSError:
+            pass  # lock vanished mid-check — retry (counts against the budget)
+        if stole:
+            continue
+        if waited >= timeout:
+            raise TimeoutError(
+                f"Could not acquire lock {lock_path} within {timeout}s; another writer holds it. "
+                "Refusing to write unlocked (fail-closed)."
+            )
+        time.sleep(poll)
+        waited += poll
+    try:
+        yield
+    finally:
+        if acquired:
+            try:
+                os.unlink(lock_path)
+            except OSError:
+                pass
+
+
+def load_registry(*, required: bool) -> ProjectRegistry | None:
+    """Load the registry from disk. Fail closed on corruption; never rewrite.
+
+    Returns the parsed ``ProjectRegistry``; ``None`` when the file is absent and
+    *required* is False (the normal pre-migration state).
+
+    Raises:
+        RegistryUnavailableError: file absent and *required* is True, or the file
+            is unreadable, not a JSON object, an unknown major version, or fails
+            schema validation. The on-disk file is never modified on this path.
+    """
+    path = registry_path()
+    if not path.exists():
+        if required:
+            raise RegistryUnavailableError(f"project registry not found at {path}")
+        return None
+    try:
+        raw = json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError) as exc:
+        raise RegistryUnavailableError(f"project registry at {path} is unreadable/corrupt: {exc}") from exc
+    if not isinstance(raw, dict):
+        raise RegistryUnavailableError(f"project registry at {path} is not a JSON object")
+    version = str(raw.get("version", "1"))
+    if version.split(".", 1)[0] != _REGISTRY_MAJOR:
+        raise RegistryUnavailableError(
+            f"project registry at {path} has unknown major version {version!r} "
+            f"(this build understands major {_REGISTRY_MAJOR}); refusing to read or rewrite it."
+        )
+    try:
+        return ProjectRegistry.model_validate(raw)
+    except ValidationError as exc:
+        raise RegistryUnavailableError(f"project registry at {path} failed validation: {exc}") from exc
+
+
+def get_registry_cached() -> ProjectRegistry | None:
+    """Return the registry, cached by (path, mtime). ``None`` if absent.
+
+    Cheap enough to call per-operation; the cache is keyed on the path so a
+    test's ``TRACE_REGISTRY_PATH`` override cannot see another test's registry.
+    A corrupt/unknown-major file raises ``RegistryUnavailableError`` (never
+    cached as "absent").
+    """
+    global _registry_cache
+    path = registry_path()
+    try:
+        mtime = path.stat().st_mtime
+    except FileNotFoundError:
+        return None
+    key = str(path)
+    if _registry_cache is not None and _registry_cache[0] == key and _registry_cache[1] == mtime:
+        return _registry_cache[2]
+    reg = load_registry(required=False)
+    _registry_cache = (key, mtime, reg)
+    return reg
+
+
+def _reset_registry_cache() -> None:
+    """Clear the mtime cache. For tests that write a registry then read it back."""
+    global _registry_cache
+    _registry_cache = None
+
+
+def _atomic_write_registry(path: Path, registry: ProjectRegistry) -> None:
+    """Serialize *registry* to *path* atomically (temp + ``os.replace``).
+
+    The SOLE registry write path — every mutation routes through
+    ``locked_registry`` which calls this under the lock (INV-7).
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data = json.dumps(registry.model_dump(mode="json"), indent=2) + "\n"
+    fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=".projects-", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as handle:
+            handle.write(data)
+        os.replace(tmp, path)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp)
+        raise
+
+
+@contextlib.contextmanager
+def locked_registry() -> Iterator[ProjectRegistry]:
+    """Fail-closed read-modify-write of the registry (INV-7).
+
+    Acquires the registry lock, yields the freshest on-disk ``ProjectRegistry``
+    (an empty default if none exists), and on CLEAN exit validates alias
+    uniqueness and persists it atomically. If the caller raises, nothing is
+    written. If the on-disk registry is corrupt, ``load_registry`` raises
+    ``RegistryUnavailableError`` and the file is left untouched.
+
+    Raises:
+        TimeoutError: the registry lock could not be acquired (fail-closed).
+        RegistryUnavailableError: the on-disk registry is corrupt/unknown-major.
+    """
+    path = registry_path()
+    lock_path = path.with_name(path.name + ".lock")
+    with exclusive_file_lock(lock_path):
+        registry = load_registry(required=False) or ProjectRegistry()
+        yield registry
+        registry.assert_unique_aliases()
+        _atomic_write_registry(path, registry)
+        _reset_registry_cache()
+
+
+# ── Resolution, binding, coherence ────────────────────────────────────────
+
+
+def resolve_project_key(label: str, *, allow_enroll: bool, actor: str) -> str:
+    """Resolve *label* to a canonical project key via the registry.
+
+    - A registry hit (key/alias/canonical) returns that key.
+    - No registry yet → the canonical key (degraded; the caller should warn).
+    - Registry present but *label* unknown:
+        * strict mode or ``allow_enroll=False`` → ``ProjectKeyError`` with guidance.
+        * otherwise enroll a **new** entry (never an alias of an existing key —
+          a typo must not be fused into another project) and return its key.
+
+    A label whose canonical form is reserved (``auto``/``shared``) is rejected
+    unless it already exists as a registry entry.
+
+    Raises:
+        ProjectKeyError: label unusable, reserved, or unknown while enrollment
+            is disallowed / strict.
+    """
+    canon = canonical_project_key(label)
+    registry = get_registry_cached()
+    if registry is None:
+        if canon in RESERVED_KEYS:
+            raise ProjectKeyError(f"'{canon}' is a reserved project key and cannot be used as a label")
+        return canon  # degraded: no registry yet
+    hit = registry.resolve(label)
+    if hit is not None:
+        return hit
+    if canon in RESERVED_KEYS:
+        raise ProjectKeyError(f"'{canon}' is a reserved project key and cannot be used as a label")
+    if registry.strict or not allow_enroll:
+        raise ProjectKeyError(
+            f"project {label!r} (key '{canon}') is not enrolled in the registry at {registry_path()}. "
+            "Run `trace-mcp init --project <name>` to enroll it, or omit the project argument to use the pin."
+        )
+    with locked_registry() as live:
+        hit2 = live.resolve(label)  # re-check under the lock (another process may have enrolled)
+        if hit2 is not None:
+            return hit2
+        live.projects[canon] = ProjectEntry(key=canon, display_label=label, enrolled_by=actor)
+        live.history.append(RegistryChange(actor=actor, action="enroll", details={"key": canon, "label": label}))
+        return canon
+
+
+def _meta_get(meta: Any, name: str) -> Any:
+    """Read *name* from a session's metadata, whether a model or a raw dict.
+
+    Handles the two shapes the codebase carries: a ``SessionMetadata`` model
+    (with ``extra='allow'`` extras in ``model_extra``) and a parsed JSON dict
+    (what ``json_file`` filtering operates on).
+    """
+    if isinstance(meta, Mapping):
+        return meta.get(name)
+    value = getattr(meta, name, None)
+    if value is None:
+        extra = getattr(meta, "model_extra", None)
+        if isinstance(extra, Mapping):
+            return extra.get(name)
+    return value
+
+
+def session_project_key(meta: Any) -> str:
+    """The canonical key a session record belongs to.
+
+    Uses ``project_key`` when present (authoritative), else resolves the
+    display ``project`` label through the registry, else canonicalizes it.
+    Returns ``""`` for a degenerate/empty label (which then matches no real key).
+    """
+    project_key = _meta_get(meta, "project_key")
+    if isinstance(project_key, str) and project_key:
+        return project_key
+    label = _meta_get(meta, "project")
+    if not isinstance(label, str) or not label.strip():
+        return ""
+    registry = get_registry_cached()
+    if registry is not None:
+        hit = registry.resolve(label)
+        if hit is not None:
+            return hit
+    try:
+        return canonical_project_key(label)
+    except ProjectKeyError:
+        return ""
+
+
+def session_matches_project(meta: Any, key: str) -> bool:
+    """True when a session record (model or dict) belongs to canonical *key*."""
+    return bool(key) and session_project_key(meta) == key
+
+
+async def validate_project_session(storage: TraceStorage, project: str, session_id: str) -> str:
+    """Fail-closed (project, session) coherence check (INV-6).
+
+    Resolves *project* to a canonical key, loads *session_id*, and raises
+    ``ProjectMismatchError`` unless the session belongs to the same key. Returns
+    the resolved key so callers can key their store off the validated identity.
+    Call this BEFORE any store is touched.
+
+    Raises:
+        ProjectMismatchError: the session belongs to a different project.
+        ProjectKeyError: *project* is unusable/unenrolled.
+        FileNotFoundError: no such session.
+    """
+    project_key = resolve_project_key(project, allow_enroll=False, actor="validate")
+    session = await storage.get_session(session_id)
+    session_key = session_project_key(session.metadata)
+    if session_key != project_key:
+        raise ProjectMismatchError(
+            f"session {session_id!r} belongs to project '{session_key or '<unknown>'}' but the call "
+            f"named '{project_key}'. Refusing to cross project boundaries (INV-6)."
+        )
+    return project_key
+
+
+class BoundProject(BaseModel):
+    """The process's pinned project (from ``TRACE_PROJECT``)."""
+
+    key: str
+    display_label: str
+    degraded: bool = False
+    """True when the pin is set but the registry is unavailable or the key is
+    unenrolled: session capture may proceed on the canonical key, but knowledge
+    and egress paths must fail closed (ADR-006 §6 / D4)."""
+
+
+def get_bound_project() -> BoundProject | None:
+    """Return the process's ``TRACE_PROJECT`` pin, or ``None`` if unpinned.
+
+    Recomputed from the environment on each call (the pin is stable per process,
+    the registry is mtime-cached); if the pin is set but the registry is absent,
+    corrupt, or the key is unenrolled, returns ``degraded=True``.
+    """
+    raw = os.environ.get("TRACE_PROJECT")
+    if not raw or not raw.strip():
+        return None
+    try:
+        canon = canonical_project_key(raw)
+    except ProjectKeyError:
+        return None
+    try:
+        registry = get_registry_cached()
+    except RegistryUnavailableError:
+        return BoundProject(key=canon, display_label=raw, degraded=True)
+    if registry is None:
+        return BoundProject(key=canon, display_label=raw, degraded=True)
+    hit = registry.resolve(raw)
+    if hit is None:
+        return BoundProject(key=canon, display_label=raw, degraded=True)
+    entry = registry.projects.get(hit)
+    return BoundProject(key=hit, display_label=entry.display_label if entry else raw)

--- a/src/trace_mcp/server.py
+++ b/src/trace_mcp/server.py
@@ -17,6 +17,7 @@ from mcp.server.fastmcp import FastMCP
 
 from trace_mcp import __version__
 from trace_mcp import extension_hooks as hooks
+from trace_mcp import project_identity as pident
 from trace_mcp.schema import (
     ActorType,
     AnnotationCategory,
@@ -48,6 +49,7 @@ mcp = FastMCP("trace")
 storage = JsonFileStorage()
 active_sessions: dict[str, Session] = {}
 _current_session_id: str | None = None
+_unpinned_warned = False
 
 
 def _compact(obj: Any) -> str:
@@ -59,6 +61,91 @@ def _compact(obj: Any) -> str:
     (``trace_export``) uses pretty JSON instead.
     """
     return json.dumps(obj, separators=(",", ":"), default=str)
+
+
+# ── Project-Pin Enforcement (ADR-006) ──────────────────────────────────────
+
+
+def _bound_project() -> pident.BoundProject | None:
+    """The process's ``TRACE_PROJECT`` pin (None if unpinned).
+
+    Warns once per process when unpinned so an operator running without
+    isolation sees it, without spamming every call.
+    """
+    global _unpinned_warned
+    bound = pident.get_bound_project()
+    if bound is None and not _unpinned_warned:
+        _unpinned_warned = True
+        logger.warning(
+            "TRACE_PROJECT is not set — this server is UNPINNED and cross-project isolation is "
+            "NOT enforced. Set TRACE_PROJECT in the server's .mcp.json env to enforce it."
+        )
+    return bound
+
+
+def _require_pin_error() -> str | None:
+    """Return an error string when ``TRACE_REQUIRE_PIN=1`` but the process is unpinned, else None.
+
+    Default off; flipped on fleet-wide only after the migration sweep (ADR-006 S9).
+    """
+    if os.environ.get("TRACE_REQUIRE_PIN") == "1" and pident.get_bound_project() is None:
+        return (
+            "Error: TRACE_REQUIRE_PIN=1 but this server is not pinned (TRACE_PROJECT unset). "
+            "Set TRACE_PROJECT in the server's .mcp.json env, or unset TRACE_REQUIRE_PIN."
+        )
+    return None
+
+
+def _resolve_start_project(project: str | None, bound: pident.BoundProject | None) -> str:
+    """Return the display label to record as ``metadata.project`` for a new session.
+
+    Pinned: ``None`` resolves to the pin's display label; a supplied label MUST
+    resolve to the pinned key. Unpinned: a non-empty label is required. A label
+    resolving to a reserved key (``auto``/``shared``) is rejected.
+
+    Raises ``ProjectKeyError`` on any violation (the caller surfaces it).
+    """
+    if bound is not None:
+        if bound.key in pident.RESERVED_KEYS:
+            raise pident.ProjectKeyError(f"server is pinned to reserved key '{bound.key}' — fix TRACE_PROJECT.")
+        if project is None:
+            return bound.display_label
+        supplied = pident.key_for_label(project)
+        if supplied != bound.key:
+            raise pident.ProjectKeyError(
+                f"this server is pinned to project '{bound.key}', but trace_start_session named "
+                f"{project!r} (key '{supplied or '<invalid>'}'). Omit the project argument to use the pin."
+            )
+        return project
+    if not project or not project.strip():
+        raise pident.ProjectKeyError(
+            "no project given and this server is not pinned (TRACE_PROJECT unset). "
+            'Pass project="<name>", or set TRACE_PROJECT in the server\'s .mcp.json env.'
+        )
+    if pident.canonical_project_key(project) in pident.RESERVED_KEYS:
+        raise pident.ProjectKeyError(f"{project!r} resolves to a reserved project key and cannot be used.")
+    return project
+
+
+def check_read_scope(session: Session) -> None:
+    """Fail-closed cross-project read guard for the id-only read/export tools.
+
+    When the process is pinned and *session* belongs to a different project,
+    raise ``ProjectMismatchError`` — unless ``TRACE_ALLOW_CROSS_PROJECT_READS=1``
+    (operator escape hatch). Cross-project WRITES are blocked separately (pointer
+    promotion + learn coherence), so a permitted read cannot be re-persisted into
+    the pinned store.
+    """
+    bound = pident.get_bound_project()
+    if bound is None or pident.session_matches_project(session.metadata, bound.key):
+        return
+    if os.environ.get("TRACE_ALLOW_CROSS_PROJECT_READS") == "1":
+        return
+    other = pident.session_project_key(session.metadata) or "<unknown>"
+    raise pident.ProjectMismatchError(
+        f"session belongs to project '{other}' but this server is pinned to '{bound.key}'. "
+        "Cross-project reads are denied; set TRACE_ALLOW_CROSS_PROJECT_READS=1 to override."
+    )
 
 
 # ── Auto-Session Infrastructure ────────────────────────────────────────────
@@ -74,7 +161,14 @@ async def _infer_project() -> str:
     the auto-created session (and any learnings later extracted from it) into
     that unrelated project's knowledge store. A stable sentinel keeps
     unattributed sessions out of a real project's provenance.
+
+    Precedence (ADR-006): the ``TRACE_PROJECT`` pin (its display label) >
+    ``TRACE_DEFAULT_PROJECT`` > the stable ``"auto"`` sentinel. A pinned process
+    therefore never falls into the ``"auto"`` pool.
     """
+    bound = pident.get_bound_project()
+    if bound is not None and bound.key not in pident.RESERVED_KEYS:
+        return bound.display_label
     return os.environ.get("TRACE_DEFAULT_PROJECT") or "auto"
 
 
@@ -93,6 +187,16 @@ async def _ensure_session(session_id: str | None) -> tuple[Session, str]:
     # 1. Explicit session_id provided — look it up (may raise)
     if session_id:
         session = await session_tools.get_or_load_session(storage, active_sessions, session_id)
+        # Pointer-capture guard (ADR-006 bleed path 1): a pinned process must
+        # never use another project's session — otherwise pointer-less events
+        # would append into it. Denied regardless of status (fail closed).
+        bound = _bound_project()
+        if bound is not None and not pident.session_matches_project(session.metadata, bound.key):
+            other = pident.session_project_key(session.metadata) or "<unknown>"
+            raise pident.ProjectMismatchError(
+                f"session '{session_id}' belongs to project '{other}' but this server is pinned to "
+                f"'{bound.key}'. Refusing to use another project's session."
+            )
         # Only an ACTIVE session may become the new current session. An
         # explicit session_id targeting a completed session (e.g. resolving
         # a decision proposed in a prior, now-closed session) must not move
@@ -140,10 +244,12 @@ async def _ensure_session(session_id: str | None) -> tuple[Session, str]:
         f"Call trace_start_session with a proper description for better provenance."
     )
 
-    # Try to recall learnings for the auto-session
-    recalled = await hooks.recall_if_available(project, "", None, 3)
-    if recalled:
-        auto_msg += hooks.format_recalled_learnings(recalled)
+    # Recall learnings for the auto-session — but NOT for the reserved 'auto'
+    # quarantine pool, whose store commingles projects (ADR-006 D14).
+    if pident.key_for_label(project) not in pident.RESERVED_KEYS:
+        recalled = await hooks.recall_if_available(project, "", None, 3)
+        if recalled:
+            auto_msg += hooks.format_recalled_learnings(recalled)
 
     return session, auto_msg
 
@@ -153,7 +259,7 @@ async def _ensure_session(session_id: str | None) -> tuple[Session, str]:
 
 @mcp.tool()
 async def trace_start_session(
-    project: str,
+    project: str | None = None,
     experiment_id: str | None = None,
     description: str | None = None,
     participants: list[dict[str, Any]] | None = None,
@@ -173,19 +279,30 @@ async def trace_start_session(
     recall_learnings defaults to False to keep session start cheap and quiet.
     Set recall_learnings=True only when past learnings are likely relevant; it
     surfaces up to recall_limit (default 5) learnings based on description/tags.
+
+    project is OPTIONAL when the server is pinned (TRACE_PROJECT set): omit it to
+    use the pin. When unpinned, project is required. A supplied label must
+    resolve to the pinned project, and reserved keys (auto/shared) are rejected.
     """
     global _current_session_id
+    pin_error = _require_pin_error()
+    if pin_error:
+        return pin_error
+    try:
+        resolved = _resolve_start_project(project, _bound_project())
+    except pident.ProjectKeyError as e:
+        return f"Error: {e}"
     try:
         # Bounded orientation (reads <=25 files) on PRIOR state, computed before
         # creating the new session so it never counts the session being started.
         # This gives the model its bearings so it need not fan out to the query
         # tools in the opening interleaved-thinking turn.
-        brief = await storage.session_brief(project)
+        brief = await storage.session_brief(resolved)
 
         session = await session_tools.create_session(
             storage,
             active_sessions,
-            project=project,
+            project=resolved,
             experiment_id=experiment_id,
             description=description,
             participants=participants,
@@ -198,13 +315,13 @@ async def trace_start_session(
         # Recall is OFF by default (v0.4.2): opt-in only, rendered once.
         recalled_block = ""
         if recall_learnings and description:
-            recalled = await hooks.recall_if_available(project, description, tags, recall_limit)
+            recalled = await hooks.recall_if_available(resolved, description, tags, recall_limit)
             if recalled:
                 recalled_block = hooks.format_recalled_learnings(recalled)
 
         return session_tools.format_bootstrap_message(
             session_id=session.id,
-            project=project,
+            project=resolved,
             path=str(path),
             brief=brief,
             recalled_block=recalled_block,
@@ -241,7 +358,11 @@ async def trace_end_session(
         if extract_learnings:
             try:
                 session = await session_tools.get_or_load_session(storage, active_sessions, session_id)
-                project = session.metadata.project
+                # Do NOT extract from the reserved 'auto' quarantine pool — its
+                # store commingles projects (ADR-006 D14). Leaving project None
+                # skips extraction below.
+                if pident.session_project_key(session.metadata) not in pident.RESERVED_KEYS:
+                    project = session.metadata.project
             except FileNotFoundError:
                 pass
 
@@ -326,6 +447,8 @@ async def trace_log_tool_call(
         session, auto_msg = await _ensure_session(session_id)
     except FileNotFoundError:
         return f"Error: Session '{session_id}' not found."
+    except pident.ProjectMismatchError as e:
+        return f"Error: {e}"
 
     prefix = f"{auto_msg}\n" if auto_msg else ""
     try:
@@ -379,6 +502,8 @@ async def trace_log_annotation(
         session, auto_msg = await _ensure_session(session_id)
     except FileNotFoundError:
         return f"Error: Session '{session_id}' not found."
+    except pident.ProjectMismatchError as e:
+        return f"Error: {e}"
 
     prefix = f"{auto_msg}\n" if auto_msg else ""
     try:
@@ -426,6 +551,8 @@ async def trace_log_contribution(
         session, auto_msg = await _ensure_session(session_id)
     except FileNotFoundError:
         return f"Error: Session '{session_id}' not found."
+    except pident.ProjectMismatchError as e:
+        return f"Error: {e}"
 
     prefix = f"{auto_msg}\n" if auto_msg else ""
     try:
@@ -471,6 +598,8 @@ async def trace_log_state_change(
         session, auto_msg = await _ensure_session(session_id)
     except FileNotFoundError:
         return f"Error: Session '{session_id}' not found."
+    except pident.ProjectMismatchError as e:
+        return f"Error: {e}"
 
     prefix = f"{auto_msg}\n" if auto_msg else ""
     try:
@@ -523,6 +652,8 @@ async def trace_propose_decision(
         session, auto_msg = await _ensure_session(session_id)
     except FileNotFoundError:
         return f"Error: Session '{session_id}' not found."
+    except pident.ProjectMismatchError as e:
+        return f"Error: {e}"
 
     prefix = f"{auto_msg}\n" if auto_msg else ""
     try:
@@ -573,6 +704,8 @@ async def trace_resolve_decision(
         session, auto_msg = await _ensure_session(session_id)
     except FileNotFoundError:
         return f"Error: Session '{session_id}' not found."
+    except pident.ProjectMismatchError as e:
+        return f"Error: {e}"
 
     prefix = f"{auto_msg}\n" if auto_msg else ""
     try:
@@ -599,8 +732,11 @@ async def trace_get_session(session_id: str) -> str:
     """Get the full data for a TRACE session (excluding event details)."""
     try:
         session = await session_tools.get_or_load_session(storage, active_sessions, session_id)
+        check_read_scope(session)
     except FileNotFoundError:
         return f"Error: Session '{session_id}' not found."
+    except pident.ProjectMismatchError as e:
+        return f"Error: {e}"
 
     summary = query_tools.get_session_summary(session)
     return _compact(summary)
@@ -615,8 +751,11 @@ async def trace_get_events(
     """List events in a session, optionally filtered by type."""
     try:
         session = await session_tools.get_or_load_session(storage, active_sessions, session_id)
+        check_read_scope(session)
     except FileNotFoundError:
         return f"Error: Session '{session_id}' not found."
+    except pident.ProjectMismatchError as e:
+        return f"Error: {e}"
 
     events = query_tools.get_events(session, type_filter=type, limit=limit)
     return _compact(events)
@@ -631,8 +770,11 @@ async def trace_get_decisions(
     """List all decisions in a session, optionally filtered by disposition status and/or proposer type."""
     try:
         session = await session_tools.get_or_load_session(storage, active_sessions, session_id)
+        check_read_scope(session)
     except FileNotFoundError:
         return f"Error: Session '{session_id}' not found."
+    except pident.ProjectMismatchError as e:
+        return f"Error: {e}"
 
     decisions = query_tools.get_decisions(session, disposition=disposition, proposed_by_type=proposed_by_type)
     return _compact(decisions)
@@ -649,8 +791,11 @@ async def trace_get_decision_chain(
     """
     try:
         session = await session_tools.get_or_load_session(storage, active_sessions, session_id)
+        check_read_scope(session)
     except FileNotFoundError:
         return f"Error: Session '{session_id}' not found."
+    except pident.ProjectMismatchError as e:
+        return f"Error: {e}"
 
     chain = query_tools.get_decision_chain(session, event_id=event_id)
     if not chain:
@@ -672,8 +817,11 @@ async def trace_search(
     """
     try:
         session = await session_tools.get_or_load_session(storage, active_sessions, session_id)
+        check_read_scope(session)
     except FileNotFoundError:
         return f"Error: Session '{session_id}' not found."
+    except pident.ProjectMismatchError as e:
+        return f"Error: {e}"
 
     all_results = query_tools.search_events(session, query=query)
     cap = max(1, min(limit, query_tools.MAX_SEARCH_LIMIT))
@@ -744,8 +892,11 @@ async def trace_export(
     """
     try:
         session = await session_tools.get_or_load_session(storage, active_sessions, session_id)
+        check_read_scope(session)
     except FileNotFoundError:
         return f"Error: Session '{session_id}' not found."
+    except pident.ProjectMismatchError as e:
+        return f"Error: {e}"
 
     try:
         return export_tools.export_session(session, format=format, pretty=pretty)

--- a/src/trace_mcp/storage/json_file.py
+++ b/src/trace_mcp/storage/json_file.py
@@ -253,7 +253,14 @@ class JsonFileStorage(TraceStorage):
         return Session.model_validate(raw)
 
     async def list_sessions(self, project: str | None = None, limit: int = 50) -> list[dict[str, Any]]:
+        # INV-4: filter by CANONICAL project key (not raw case-sensitive label),
+        # so display-label drift (TRACE vs trace-mcp, coeqwal vs COEQWAL) resolves
+        # to ONE project and cannot split one project or merge two. Lazy import
+        # avoids a json_file <-> project_identity module cycle.
+        from trace_mcp.project_identity import key_for_label, session_project_key
+
         self._ensure_dir()
+        query_key = key_for_label(project) if project else None
         summaries: list[dict[str, Any]] = []
         files = sorted(self._dir.glob("trace_*.json"), reverse=True)
         for path in files:
@@ -262,13 +269,10 @@ class JsonFileStorage(TraceStorage):
             try:
                 with open(path) as f:
                     raw = json.load(f)
-                proj = raw.get("metadata", {}).get("project", "")
-                # INV-4: EXACT (case-sensitive) project match — the same predicate
-                # the adapter hooks use (metadata.project == project). A substring
-                # match here silently merged distinct projects (e.g. "trace" pulling
-                # in "trace-mcp" and "TRACE-research").
-                if project and proj != project:
+                meta = raw.get("metadata", {})
+                if query_key is not None and session_project_key(meta) != query_key:
                     continue
+                proj = meta.get("project", "")
                 summaries.append(
                     {
                         "id": raw.get("id", path.stem),
@@ -297,7 +301,12 @@ class JsonFileStorage(TraceStorage):
 
         Side effects: reads up to ``scan_cap`` files from the sessions directory.
         """
+        # INV-4: canonical-key match, same as list_sessions (lazy import breaks
+        # the json_file <-> project_identity cycle).
+        from trace_mcp.project_identity import key_for_label, session_project_key
+
         self._ensure_dir()
+        query_key = key_for_label(project) if project else None
         files = sorted(self._dir.glob("trace_*.json"), reverse=True)
         total = len(files)
         scanned = 0
@@ -310,11 +319,10 @@ class JsonFileStorage(TraceStorage):
                     raw = json.load(f)
             except (json.JSONDecodeError, OSError):
                 continue
-            proj = raw.get("metadata", {}).get("project", "")
-            # INV-4: EXACT (case-sensitive) project match — same predicate as the
-            # adapter hooks and list_sessions above (no substring merging).
-            if project and proj != project:
+            meta = raw.get("metadata", {})
+            if query_key is not None and session_project_key(meta) != query_key:
                 continue
+            proj = meta.get("project", "")
             matched += 1
             if most_recent is None:
                 most_recent = {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,7 +37,13 @@ from pathlib import Path
 
 import pytest
 
-_ISOLATED_VARS = ("TRACE_KNOWLEDGE_DIR", "TRACE_SESSIONS_DIR", "TRACE_SCRATCHPAD_DIR", "TRACE_EGRESS_LOG")
+_ISOLATED_VARS = (
+    "TRACE_KNOWLEDGE_DIR",
+    "TRACE_SESSIONS_DIR",
+    "TRACE_SCRATCHPAD_DIR",
+    "TRACE_EGRESS_LOG",
+    "TRACE_REGISTRY_PATH",
+)
 _REAL_DATA_ENV = "TRACE_REAL_DATA_TESTS"
 _previous_env: dict[str, str | None] = {}
 
@@ -53,10 +59,12 @@ def pytest_configure(config: pytest.Config) -> None:
     Side effect: mutates os.environ (restored in pytest_unconfigure).
     """
     base = Path(tempfile.mkdtemp(prefix="trace-isolated-"))
-    # The first three are directories; TRACE_EGRESS_LOG is a file path (the
-    # egress ledger). Same isolation contract either way: a test that forgets
-    # an explicit path must not be able to touch the developer's real ~/.trace.
-    for name, sub in zip(_ISOLATED_VARS, ("knowledge", "sessions", "scratchpads", "egress.jsonl"), strict=True):
+    # The first three are directories; TRACE_EGRESS_LOG and TRACE_REGISTRY_PATH
+    # are file paths (the egress ledger and the project registry). Same
+    # isolation contract either way: a test that forgets an explicit path must
+    # not be able to touch the developer's real ~/.trace.
+    subs = ("knowledge", "sessions", "scratchpads", "egress.jsonl", "projects.json")
+    for name, sub in zip(_ISOLATED_VARS, subs, strict=True):
         _previous_env[name] = os.environ.get(name)
         os.environ[name] = str(base / sub)
 

--- a/tests/test_init_project.py
+++ b/tests/test_init_project.py
@@ -60,11 +60,16 @@ def test_reinit_preserves_with_extras(tmp_path: Path) -> None:
             "trace": {
                 "command": "uvx",
                 "args": [
-                    "--from", "/old/TRACE",
-                    "--with", "openai",
-                    "--with", "numpy",
-                    "--with", "model2vec",
-                    "--refresh", "trace-mcp",
+                    "--from",
+                    "/old/TRACE",
+                    "--with",
+                    "openai",
+                    "--with",
+                    "numpy",
+                    "--with",
+                    "model2vec",
+                    "--refresh",
+                    "trace-mcp",
                 ],
             }
         }

--- a/tests/test_init_project.py
+++ b/tests/test_init_project.py
@@ -1,0 +1,211 @@
+"""Tests for ``trace-mcp init`` .mcp.json merge behavior (ADR-006 step S1).
+
+Re-running ``init`` must be non-destructive: an existing ``trace`` server
+entry's hand-added ``--with`` extras, ``env`` block, and unknown keys are
+preserved, and sibling MCP servers are left untouched. A pre-existing
+``.mcp.json`` that cannot be parsed is left on disk and surfaces as a
+``TraceInitError`` (fail closed) instead of being silently discarded and
+replaced — the previous behavior would have destroyed every other server entry.
+
+The fleet migration (ADR-006 S8) re-runs ``init`` across ~18 deployed configs
+that all carry hand-added ``--with openai/numpy/model2vec`` extras (and, for at
+least one, a ``TRACE_DEFAULT_PROJECT`` env pin); this behavior is the
+prerequisite that keeps that sweep from breaking them.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from trace_mcp.init_project import (
+    TraceInitError,
+    _extract_with_packages,
+    _mcp_server_config,
+    _merge_trace_entry,
+    _write_mcp_json,
+)
+
+_SOURCE = "/abs/path/to/TRACE"
+
+
+@pytest.fixture(autouse=True)
+def _fixed_source(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pin the resolved ``--from`` source so args assertions are deterministic.
+
+    conftest isolates the four TRACE data-dir vars but not TRACE_SOURCE_PATH,
+    so this per-test override is safe and does not fight the root conftest.
+    """
+    monkeypatch.setenv("TRACE_SOURCE_PATH", _SOURCE)
+
+
+def _read(project_dir: Path) -> dict:
+    return json.loads((project_dir / ".mcp.json").read_text())
+
+
+def test_fresh_init_shape(tmp_path: Path) -> None:
+    status = _write_mcp_json(tmp_path)
+    assert "wrote" in status
+    entry = _read(tmp_path)["mcpServers"]["trace"]
+    assert entry["command"] == "uvx"
+    assert entry["args"] == ["--from", _SOURCE, "--refresh-package", "trace-mcp", "trace-mcp"]
+    assert "env" not in entry  # no empty env block on a fresh install
+
+
+def test_reinit_preserves_with_extras(tmp_path: Path) -> None:
+    existing = {
+        "mcpServers": {
+            "trace": {
+                "command": "uvx",
+                "args": [
+                    "--from", "/old/TRACE",
+                    "--with", "openai",
+                    "--with", "numpy",
+                    "--with", "model2vec",
+                    "--refresh", "trace-mcp",
+                ],
+            }
+        }
+    }
+    (tmp_path / ".mcp.json").write_text(json.dumps(existing))
+
+    status = _write_mcp_json(tmp_path)
+    assert "updated" in status
+
+    args = _read(tmp_path)["mcpServers"]["trace"]["args"]
+    # Canonical source is rebuilt (old /old/TRACE gone), the command stays last,
+    # and the hand-added extras are preserved in order.
+    assert args[:4] == ["--from", _SOURCE, "--refresh-package", "trace-mcp"]
+    assert args[-1] == "trace-mcp"
+    with_pkgs = [args[i + 1] for i, a in enumerate(args) if a == "--with"]
+    assert with_pkgs == ["openai", "numpy", "model2vec"]
+
+
+def test_reinit_preserves_env_block(tmp_path: Path) -> None:
+    existing = {
+        "mcpServers": {
+            "trace": {
+                "command": "uvx",
+                "args": ["--from", "/old/TRACE", "--refresh-package", "trace-mcp", "trace-mcp"],
+                "env": {"TRACE_DEFAULT_PROJECT": "coeqwal"},
+            }
+        }
+    }
+    (tmp_path / ".mcp.json").write_text(json.dumps(existing))
+
+    _write_mcp_json(tmp_path)
+
+    assert _read(tmp_path)["mcpServers"]["trace"]["env"] == {"TRACE_DEFAULT_PROJECT": "coeqwal"}
+
+
+def test_reinit_preserves_unknown_keys(tmp_path: Path) -> None:
+    existing = {
+        "mcpServers": {
+            "trace": {
+                "command": "uvx",
+                "args": ["--from", "/old/TRACE", "--refresh-package", "trace-mcp", "trace-mcp"],
+                "customField": {"keep": True},
+            }
+        }
+    }
+    (tmp_path / ".mcp.json").write_text(json.dumps(existing))
+
+    _write_mcp_json(tmp_path)
+
+    assert _read(tmp_path)["mcpServers"]["trace"]["customField"] == {"keep": True}
+
+
+def test_reinit_is_idempotent(tmp_path: Path) -> None:
+    """Re-running init on an already-merged config must be stable (S8 re-inits configs)."""
+    existing = {
+        "mcpServers": {
+            "trace": {
+                "command": "uvx",
+                "args": ["--from", "/old/TRACE", "--with", "openai", "--refresh", "trace-mcp"],
+                "env": {"TRACE_DEFAULT_PROJECT": "coeqwal"},
+            }
+        }
+    }
+    (tmp_path / ".mcp.json").write_text(json.dumps(existing))
+
+    _write_mcp_json(tmp_path)
+    once = (tmp_path / ".mcp.json").read_text()
+    _write_mcp_json(tmp_path)
+    twice = (tmp_path / ".mcp.json").read_text()
+
+    assert once == twice
+
+
+def test_other_servers_preserved(tmp_path: Path) -> None:
+    existing = {
+        "mcpServers": {
+            "playwright": {"command": "npx", "args": ["@playwright/mcp@latest"]},
+        }
+    }
+    (tmp_path / ".mcp.json").write_text(json.dumps(existing))
+
+    _write_mcp_json(tmp_path)
+
+    cfg = _read(tmp_path)
+    assert cfg["mcpServers"]["playwright"] == {"command": "npx", "args": ["@playwright/mcp@latest"]}
+    assert "trace" in cfg["mcpServers"]
+
+
+def test_unparseable_mcp_json_fails_closed(tmp_path: Path) -> None:
+    mcp = tmp_path / ".mcp.json"
+    mcp.write_text("this is not json {")
+    original = mcp.read_bytes()
+
+    with pytest.raises(TraceInitError):
+        _write_mcp_json(tmp_path)
+
+    assert mcp.read_bytes() == original  # file left untouched
+
+
+def test_non_object_json_fails_closed(tmp_path: Path) -> None:
+    mcp = tmp_path / ".mcp.json"
+    mcp.write_text("[1, 2, 3]")
+    original = mcp.read_bytes()
+
+    with pytest.raises(TraceInitError):
+        _write_mcp_json(tmp_path)
+
+    assert mcp.read_bytes() == original
+
+
+def test_non_object_mcpservers_fails_closed(tmp_path: Path) -> None:
+    mcp = tmp_path / ".mcp.json"
+    mcp.write_text(json.dumps({"mcpServers": ["not", "a", "dict"]}))
+    original = mcp.read_bytes()
+
+    with pytest.raises(TraceInitError):
+        _write_mcp_json(tmp_path)
+
+    assert mcp.read_bytes() == original
+
+
+def test_missing_mcpservers_key_is_created(tmp_path: Path) -> None:
+    # A valid JSON object without an mcpServers key is a normal (empty) config.
+    (tmp_path / ".mcp.json").write_text(json.dumps({"other": 1}))
+
+    _write_mcp_json(tmp_path)
+
+    cfg = _read(tmp_path)
+    assert cfg["other"] == 1
+    assert cfg["mcpServers"]["trace"]["command"] == "uvx"
+
+
+def test_extract_with_packages_dedup_and_tolerant() -> None:
+    assert _extract_with_packages(["--with", "a", "--with", "b", "--with", "a"]) == ["a", "b"]
+    assert _extract_with_packages("not a list") == []
+    assert _extract_with_packages(["--with"]) == []  # trailing --with, no value
+    assert _extract_with_packages(["--with", 123]) == []  # non-string value skipped
+    assert _extract_with_packages(["--from", "x", "trace-mcp"]) == []
+
+
+def test_merge_non_dict_existing_returns_fresh() -> None:
+    fresh = _mcp_server_config()["trace"]
+    assert _merge_trace_entry("garbage", fresh) == fresh
+    assert _merge_trace_entry(None, fresh) == fresh

--- a/tests/test_invariants.py
+++ b/tests/test_invariants.py
@@ -102,23 +102,29 @@ def test_inv3_resolve_decision_validates_before_write() -> None:
     )
 
 
-# ── INV-4: project scoping uses ONE (exact) predicate across core + hooks ──
-# The core query filters (list_sessions, session_brief) must match projects
-# EXACTLY (metadata.project == project) — the same predicate the adapter hooks
-# use — never a case-insensitive SUBSTRING match, which silently merged distinct
-# projects (e.g. "trace" pulling in "trace-mcp" and "TRACE-research"). See INV-4.
+# ── INV-4: project scoping matches by CANONICAL KEY across core query filters ──
+# The core query filters (list_sessions, session_brief) must match projects by
+# canonical key (project_identity.session_project_key), never a case-insensitive
+# SUBSTRING match (which merged distinct projects) and never raw case-sensitive
+# label equality (which SPLITS one project across drifted labels — TRACE vs
+# trace-mcp, coeqwal vs COEQWAL). See INV-4 and ADR-006.
 
 
-def test_inv4_project_filter_is_exact_not_substring() -> None:
+def test_inv4_project_filter_uses_canonical_key() -> None:
     source = (SRC / "storage" / "json_file.py").read_text(encoding="utf-8")
     assert "not in proj.lower()" not in source, (
         "INV-4 regression: json_file.py filters projects by case-insensitive "
-        "SUBSTRING again — core must match projects EXACTLY (proj != project), "
-        "the same predicate the adapter hooks use, or distinct projects merge."
+        "SUBSTRING again — match by canonical key, or distinct projects merge."
     )
-    assert source.count("proj != project") >= 2, (
-        "INV-4: both list_sessions and session_brief must filter by exact project "
-        "match (proj != project) so core and hooks resolve one session set."
+    assert "proj != project" not in source, (
+        "INV-4 regression: json_file.py compares RAW project labels again — a "
+        "display-label variant would split one project. Match by canonical key "
+        "(session_project_key(meta) != query_key)."
+    )
+    assert source.count("session_project_key(meta) != query_key") >= 2, (
+        "INV-4: both list_sessions and session_brief must filter by canonical "
+        "project key (session_project_key(meta) != query_key) so drifted labels "
+        "resolve to one project."
     )
 
 

--- a/tests/test_invariants.py
+++ b/tests/test_invariants.py
@@ -274,3 +274,34 @@ def test_inv8_knowledge_lock_is_fail_closed_and_dependency_free() -> None:
         "INV-8: project_lock must acquire project_identity.exclusive_file_lock (fail-closed, "
         "raises TimeoutError rather than proceeding unlocked)."
     )
+
+
+# ── INV-9: every learn tool guards its free-form project label ────────────
+# Each @mcp.tool in extensions/learn taking a `project` param MUST call
+# _reserved_project_error at entry, so a reserved-key (auto/shared) or degenerate
+# label cannot reach a knowledge store through a tool.
+def _learn_tool_functions_with_project() -> set[tuple[str, str]]:
+    found: set[tuple[str, str]] = set()
+    path = SRC / "extensions" / "learn" / "__init__.py"
+    tree = ast.parse(path.read_text(), filename=str(path))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            is_tool = any(
+                isinstance(d, ast.Call) and isinstance(d.func, ast.Attribute) and d.func.attr == "tool"
+                for d in node.decorator_list
+            )
+            params = {a.arg for a in node.args.args}
+            if is_tool and "project" in params:
+                found.add((_rel(path), node.name))
+    return found
+
+
+def test_inv9_learn_tools_guard_reserved_projects() -> None:
+    tools = _learn_tool_functions_with_project()
+    assert tools, "INV-9 positive control: no @mcp.tool with a project param found — pattern rot."
+    guards = _functions_calling("_reserved_project_error")
+    missing = tools - guards
+    assert not missing, (
+        "INV-9 violation (docs/INVARIANTS.md): these learn tools take a free-form project but do not "
+        f"call _reserved_project_error at entry: {sorted(missing)}. A reserved-key label could reach a store."
+    )

--- a/tests/test_invariants.py
+++ b/tests/test_invariants.py
@@ -225,3 +225,52 @@ def test_inv7_registry_write_only_via_locked_registry() -> None:
     )
     stale = INV7_REGISTRY_WRITE_SITES - callers
     assert not stale, f"INV-7 registry is stale — registered writers with no call anymore: {sorted(stale)}."
+
+
+# ── INV-6: (project, session) coherence for learn extraction ──────────────
+# Every function in extensions/learn whose signature carries BOTH `project` and
+# `session_id` (i.e. it extracts a session into a project's store) MUST call
+# project_identity.validate_project_session first — else project B's store is
+# written from project A's session and shipped to the cloud as dedup context.
+def _project_session_functions() -> set[tuple[str, str]]:
+    found: set[tuple[str, str]] = set()
+    learn = SRC / "extensions" / "learn"
+    for path in sorted(learn.rglob("*.py")):
+        tree = ast.parse(path.read_text(), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+                params = {a.arg for a in node.args.args}
+                if "project" in params and "session_id" in params:
+                    found.add((_rel(path), node.name))
+    return found
+
+
+def test_inv6_project_session_sites_validate_coherence() -> None:
+    sites = _project_session_functions()
+    assert sites, (
+        "INV-6 positive control failed: no (project, session_id) functions found in "
+        "extensions/learn — the AST pattern no longer matches; the guard is blind."
+    )
+    validators = _functions_calling("validate_project_session")
+    missing = sites - validators
+    assert not missing, (
+        "INV-6 violation (docs/INVARIANTS.md): these learn functions take both a project "
+        f"and a session_id but never call validate_project_session: {sorted(missing)}. "
+        "A session could be extracted into another project's store."
+    )
+
+
+# ── INV-8: the knowledge-store lock is fail-closed and dependency-free ────
+# project_lock must use the O_EXCL + PID-liveness lock (raises on timeout, no
+# optional filelock dependency, no warn-and-proceed) — the same fail-closed
+# standard as the session lock (INV-1).
+def test_inv8_knowledge_lock_is_fail_closed_and_dependency_free() -> None:
+    source = (SRC / "extensions" / "learn" / "store.py").read_text(encoding="utf-8")
+    assert "import filelock" not in source and "from filelock" not in source, (
+        "INV-8 regression: store.py imports the optional 'filelock' package again — the "
+        "knowledge-store lock must be the dependency-free fail-closed exclusive_file_lock."
+    )
+    assert "exclusive_file_lock" in source, (
+        "INV-8: project_lock must acquire project_identity.exclusive_file_lock (fail-closed, "
+        "raises TimeoutError rather than proceeding unlocked)."
+    )

--- a/tests/test_invariants.py
+++ b/tests/test_invariants.py
@@ -192,3 +192,30 @@ def test_inv5_every_egress_site_attests_first() -> None:
         f"INV-5 violation: egress call sites that never call attest_egress(): {sorted(missing)} — "
         "cloud content would leave the machine with no ledger record."
     )
+
+
+# ── INV-7: every project-registry WRITE routes through locked_registry ────
+# The registry's sole serializer is project_identity._atomic_write_registry; it
+# must be called ONLY from locked_registry, which holds the fail-closed lock and
+# writes atomically (temp + os.replace). A new caller elsewhere is an
+# unlocked/non-atomic registry write — the lost-update/drift failure the lock
+# exists to prevent.
+INV7_REGISTRY_WRITE_SITES = {
+    ("project_identity.py", "locked_registry"),
+}
+
+
+def test_inv7_registry_write_only_via_locked_registry() -> None:
+    callers = _functions_calling("_atomic_write_registry")
+    assert callers, (
+        "INV-7 positive control failed: no caller of _atomic_write_registry found — "
+        "the guard is blind (was it renamed?)."
+    )
+    unregistered = callers - INV7_REGISTRY_WRITE_SITES
+    assert not unregistered, (
+        "INV-7 violation (docs/INVARIANTS.md): these functions write the project registry "
+        f"outside locked_registry: {sorted(unregistered)}. Route the write through "
+        "project_identity.locked_registry (fail-closed lock + atomic write)."
+    )
+    stale = INV7_REGISTRY_WRITE_SITES - callers
+    assert not stale, f"INV-7 registry is stale — registered writers with no call anymore: {sorted(stale)}."

--- a/tests/test_learn_containment.py
+++ b/tests/test_learn_containment.py
@@ -1,0 +1,64 @@
+"""Knowledge-store containment tests (ADR-006 step S4).
+
+Verifies that the knowledge store is keyed by canonical project key (so a
+case-insensitive filesystem cannot merge two projects nor split one) and that
+its lock is fail-closed (INV-8). The (project, session) extract-coherence check
+(INV-6) is enforced structurally by
+``tests/test_invariants.py :: test_inv6_project_session_sites_validate_coherence``
+and behaviorally by ``validate_project_session`` in
+``tests/test_project_identity.py``.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from trace_mcp.extensions.learn import store
+from trace_mcp.extensions.learn.models import KnowledgeStore
+from trace_mcp.extensions.learn.store import add_learning, load_store, save_store
+
+
+def test_store_path_is_canonical(tmp_path: Path) -> None:
+    assert store._store_path("TRACE", str(tmp_path)).name == "trace.json"
+    assert store._store_path("proj_a", str(tmp_path)).name == "proj-a.json"
+    assert store._store_path("My Project", str(tmp_path)).name == "my-project.json"
+
+
+def test_case_and_separator_variants_share_one_file(tmp_path: Path) -> None:
+    variants = ("COEQWAL", "coeqwal", "Coeqwal")
+    paths = {store._store_path(v, str(tmp_path)) for v in variants}
+    assert len(paths) == 1
+    sep = {store._store_path(v, str(tmp_path)) for v in ("proj a", "proj/a", "proj_a")}
+    assert len(sep) == 1
+
+
+def test_save_load_case_variant_roundtrip(tmp_path: Path) -> None:
+    ks = KnowledgeStore(project="COEQWAL")
+    add_learning(ks, content="a shared learning")
+    save_store(ks, directory=str(tmp_path))
+    # A case-variant label resolves to the same store (canonical merge).
+    loaded = load_store("coeqwal", directory=str(tmp_path))
+    assert len(loaded.learnings) == 1
+    # Exactly one physical file exists for the project.
+    assert sorted(p.name for p in tmp_path.glob("*.json")) == ["coeqwal.json"]
+
+
+def test_project_lock_fails_closed_on_live_holder(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TRACE_LOCK_TIMEOUT", "0.2")
+    lock_path = Path(str(store._store_path("waggle", str(tmp_path))) + ".lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path.write_bytes(f"{os.getpid()}:{time.time_ns()}".encode())  # this (alive) process holds it
+
+    with pytest.raises(TimeoutError):
+        with store.project_lock("waggle", directory=str(tmp_path)):
+            pass
+
+
+def test_project_lock_no_filelock_dependency() -> None:
+    # INV-8: the store must not import the optional filelock package anywhere.
+    source = Path(store.__file__).read_text(encoding="utf-8")
+    assert "import filelock" not in source and "from filelock" not in source

--- a/tests/test_learn_store.py
+++ b/tests/test_learn_store.py
@@ -60,16 +60,18 @@ class TestLoadStore:
 
     def test_invalid_schema_returns_empty(self, tmp_path):
         """Valid JSON but wrong schema → fresh store."""
-        path = tmp_path / "bad_schema.json"
+        # File name must be the canonical store path (ADR-006: stores are
+        # keyed by canonical project key; 'bad-schema' is already canonical).
+        path = tmp_path / "bad-schema.json"
         path.write_text('{"not_a_valid_field": 42}', encoding="utf-8")
-        ks = load_store("bad_schema", directory=str(tmp_path))
+        ks = load_store("bad-schema", directory=str(tmp_path))
         assert ks.learnings == []
 
     def test_invalid_schema_strict_raises(self, tmp_path):
-        path = tmp_path / "bad_schema.json"
+        path = tmp_path / "bad-schema.json"
         path.write_text('{"not_a_valid_field": 42}', encoding="utf-8")
         with pytest.raises(StoreLoadError, match="Failed to validate"):
-            load_store("bad_schema", directory=str(tmp_path), strict=True)
+            load_store("bad-schema", directory=str(tmp_path), strict=True)
 
 
 class TestSaveStore:
@@ -269,7 +271,9 @@ class TestEnvironmentVariable:
         add_learning(ks, content="env override")
         # Pass directory=None so it reads from env var
         save_store(ks, directory=None)
-        assert (custom_dir / "env_test.json").exists()
+        # 'env_test' canonicalizes to 'env-test' (underscore folds), so the
+        # store file is env-test.json (ADR-006 canonical keying).
+        assert (custom_dir / "env-test.json").exists()
         loaded = load_store("env_test", directory=None)
         assert len(loaded.learnings) == 1
 

--- a/tests/test_project_identity.py
+++ b/tests/test_project_identity.py
@@ -1,0 +1,313 @@
+"""Tests for the core project-identity module (ADR-006 step S2).
+
+Covers the two guaranteed canonical-key properties (idempotence and the
+``sanitize_name`` fixed point), the fail-closed alias registry (locking,
+atomic writes, corrupt/unknown-major refusal), enrollment semantics
+(never merge a near-miss into an existing project), (project, session)
+coherence (INV-6), and the ``TRACE_PROJECT`` binding.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+import trace_mcp.project_identity as pi
+from trace_mcp.storage.base import TraceStorage
+from trace_mcp.storage.json_file import sanitize_name
+
+# Labels that must all reduce cleanly; used for the property checks.
+_CANONICALIZABLE = [
+    "TRACE",
+    "trace-mcp",
+    "coeqwal",
+    "COEQWAL",
+    "proj a",
+    "proj/a",
+    "proj_a",
+    "My Project!",
+    "  spaced  ",
+    "a..b",
+    "dots...",
+    "Café Ω",
+    "green-narrative",
+    "when-algorithms-meet-artists",
+    "REAP",
+    "my.financial.advisor",
+    "a/b/c",
+]
+
+
+@pytest.fixture(autouse=True)
+def _isolate_registry(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Point every test at a fresh registry file and a clean cache."""
+    monkeypatch.setenv("TRACE_REGISTRY_PATH", str(tmp_path / "projects.json"))
+    monkeypatch.delenv("TRACE_PROJECT", raising=False)
+    pi._reset_registry_cache()
+
+
+# ── canonical_project_key ─────────────────────────────────────────────────
+
+
+def test_canonical_key_idempotent() -> None:
+    for label in _CANONICALIZABLE:
+        key = pi.canonical_project_key(label)
+        assert pi.canonical_project_key(key) == key, label
+
+
+def test_canonical_key_is_sanitize_name_fixed_point() -> None:
+    for label in _CANONICALIZABLE:
+        key = pi.canonical_project_key(label)
+        assert sanitize_name(key) == key, label
+
+
+def test_casefold_pairs_merge() -> None:
+    assert pi.canonical_project_key("TRACE") == pi.canonical_project_key("trace") == "trace"
+    assert pi.canonical_project_key("COEQWAL") == pi.canonical_project_key("coeqwal") == "coeqwal"
+
+
+def test_separator_and_underscore_fold() -> None:
+    keys = {pi.canonical_project_key(x) for x in ("proj a", "proj/a", "proj_a", "proj  a")}
+    assert keys == {"proj-a"}
+
+
+def test_degenerate_labels_raise() -> None:
+    for bad in ("", "   ", "///", "...", "__", "-.-"):
+        with pytest.raises(pi.ProjectKeyError):
+            pi.canonical_project_key(bad)
+
+
+# ── registry model ────────────────────────────────────────────────────────
+
+
+def test_resolve_matches_key_alias_and_canonical() -> None:
+    reg = pi.ProjectRegistry(
+        projects={"waggle": pi.ProjectEntry(key="waggle", display_label="Waggle", aliases=["waggle-crm"])}
+    )
+    assert reg.resolve("waggle") == "waggle"  # verbatim key
+    assert reg.resolve("waggle-crm") == "waggle"  # verbatim alias
+    assert reg.resolve("Waggle") == "waggle"  # canonical of the display label
+    assert reg.resolve("nope") is None
+
+
+def test_assert_unique_aliases_raises_on_conflict() -> None:
+    reg = pi.ProjectRegistry(
+        projects={
+            "a": pi.ProjectEntry(key="a", display_label="A", aliases=["shared-alias"]),
+            "b": pi.ProjectEntry(key="b", display_label="B", aliases=["shared-alias"]),
+        }
+    )
+    with pytest.raises(ValueError, match="resolves to both"):
+        reg.assert_unique_aliases()
+
+
+# ── registry persistence (fail closed) ────────────────────────────────────
+
+
+def test_load_registry_absent() -> None:
+    assert pi.load_registry(required=False) is None
+    with pytest.raises(pi.RegistryUnavailableError):
+        pi.load_registry(required=True)
+
+
+def test_load_registry_unknown_major_fails_closed_untouched() -> None:
+    path = pi.registry_path()
+    payload = json.dumps({"version": "99", "projects": {}})
+    path.write_text(payload)
+    with pytest.raises(pi.RegistryUnavailableError, match="unknown major version"):
+        pi.load_registry(required=False)
+    assert path.read_text() == payload  # never rewritten
+
+
+def test_load_registry_corrupt_fails_closed_untouched() -> None:
+    path = pi.registry_path()
+    path.write_text("{not json")
+    with pytest.raises(pi.RegistryUnavailableError):
+        pi.load_registry(required=False)
+    assert path.read_text() == "{not json"
+
+
+def test_locked_registry_enroll_persists_with_history() -> None:
+    with pi.locked_registry() as reg:
+        reg.projects["waggle"] = pi.ProjectEntry(key="waggle", display_label="Waggle", enrolled_by="test")
+        reg.history.append(pi.RegistryChange(actor="test", action="enroll", details={"key": "waggle"}))
+
+    pi._reset_registry_cache()
+    reloaded = pi.load_registry(required=True)
+    assert reloaded is not None
+    assert "waggle" in reloaded.projects
+    assert reloaded.history[-1].action == "enroll"
+
+
+def test_locked_registry_caller_exception_does_not_write() -> None:
+    with pytest.raises(RuntimeError):
+        with pi.locked_registry() as reg:
+            reg.projects["ghost"] = pi.ProjectEntry(key="ghost", display_label="ghost")
+            raise RuntimeError("boom")
+    assert not pi.registry_path().exists()  # nothing persisted
+
+
+def test_atomic_write_leaves_no_tmp_files() -> None:
+    with pi.locked_registry() as reg:
+        reg.projects["a"] = pi.ProjectEntry(key="a", display_label="A")
+    leftovers = list(pi.registry_path().parent.glob(".projects-*.tmp"))
+    assert leftovers == []
+
+
+# ── exclusive_file_lock ────────────────────────────────────────────────────
+
+
+def test_exclusive_lock_timeout_raises_on_live_holder(tmp_path: Path) -> None:
+    lock = tmp_path / "x.lock"
+    lock.write_bytes(f"{__import__('os').getpid()}:{time.time_ns()}".encode())  # this (alive) process
+    with pytest.raises(TimeoutError):
+        with pi.exclusive_file_lock(lock, timeout=0.2, steal_after=10_000):
+            pass
+
+
+def test_exclusive_lock_steals_dead_holder(tmp_path: Path) -> None:
+    proc = subprocess.Popen([sys.executable, "-c", ""])
+    proc.wait()  # now dead and reaped — its pid is provably gone
+    lock = tmp_path / "x.lock"
+    lock.write_bytes(f"{proc.pid}:{time.time_ns()}".encode())
+    with pi.exclusive_file_lock(lock, timeout=0.5):
+        pass  # acquired by stealing the dead holder's lock — no TimeoutError
+
+
+# ── resolve_project_key ────────────────────────────────────────────────────
+
+
+def test_resolve_no_registry_returns_canonical() -> None:
+    assert pi.resolve_project_key("My Project", allow_enroll=False, actor="t") == "my-project"
+
+
+def test_resolve_enrolls_new_key_never_merges_near_miss() -> None:
+    with pi.locked_registry() as reg:
+        reg.projects["waggle"] = pi.ProjectEntry(key="waggle", display_label="waggle")
+    pi._reset_registry_cache()
+
+    # "wagle" is a typo, a DIFFERENT canonical key — it must get its own entry,
+    # never be fused into "waggle".
+    key = pi.resolve_project_key("wagle", allow_enroll=True, actor="t")
+    assert key == "wagle"
+    reg = pi.load_registry(required=True)
+    assert reg is not None
+    assert set(reg.projects) == {"waggle", "wagle"}
+
+
+def test_resolve_strict_mode_refuses_unknown() -> None:
+    with pi.locked_registry() as reg:
+        reg.strict = True
+    pi._reset_registry_cache()
+    with pytest.raises(pi.ProjectKeyError, match="not enrolled"):
+        pi.resolve_project_key("brand-new", allow_enroll=True, actor="t")
+
+
+def test_resolve_disallow_enroll_refuses_unknown() -> None:
+    with pi.locked_registry() as reg:
+        reg.projects["known"] = pi.ProjectEntry(key="known", display_label="known")
+    pi._reset_registry_cache()
+    with pytest.raises(pi.ProjectKeyError):
+        pi.resolve_project_key("unknown", allow_enroll=False, actor="t")
+
+
+def test_resolve_reserved_key_rejected() -> None:
+    with pytest.raises(pi.ProjectKeyError, match="reserved"):
+        pi.resolve_project_key("auto", allow_enroll=True, actor="t")
+
+
+# ── coherence + binding ────────────────────────────────────────────────────
+
+
+class _Meta:
+    def __init__(self, project: str, project_key: str | None = None) -> None:
+        self.project = project
+        if project_key is not None:
+            self.project_key = project_key
+
+
+class _Sess:
+    def __init__(self, metadata: _Meta) -> None:
+        self.metadata = metadata
+
+
+class _Storage:
+    def __init__(self, sessions: dict[str, _Sess]) -> None:
+        self._sessions = sessions
+
+    async def get_session(self, session_id: str) -> _Sess:
+        try:
+            return self._sessions[session_id]
+        except KeyError as exc:
+            raise FileNotFoundError(session_id) from exc
+
+
+def _enroll(*keys: str) -> None:
+    with pi.locked_registry() as reg:
+        for key in keys:
+            reg.projects[key] = pi.ProjectEntry(key=key, display_label=key)
+    pi._reset_registry_cache()
+
+
+async def test_validate_project_session_match_returns_key() -> None:
+    _enroll("waggle")
+    storage = cast(TraceStorage, _Storage({"s1": _Sess(_Meta("Waggle"))}))
+    assert await pi.validate_project_session(storage, "waggle", "s1") == "waggle"
+
+
+async def test_validate_project_session_mismatch_names_both() -> None:
+    _enroll("waggle", "chemmasters")
+    storage = cast(TraceStorage, _Storage({"s1": _Sess(_Meta("Waggle"))}))
+    with pytest.raises(pi.ProjectMismatchError) as exc:
+        await pi.validate_project_session(storage, "chemmasters", "s1")
+    message = str(exc.value)
+    assert "waggle" in message and "chemmasters" in message
+
+
+def test_session_project_key_prefers_project_key() -> None:
+    assert pi.session_project_key(_Meta("Display Label", project_key="the-key")) == "the-key"
+
+
+def test_session_project_key_from_dict_meta() -> None:
+    assert pi.session_project_key({"project": "COEQWAL"}) == "coeqwal"
+    assert pi.session_project_key({"project": "x", "project_key": "y"}) == "y"
+
+
+def test_session_matches_project_label_fallback() -> None:
+    assert pi.session_matches_project(_Meta("TRACE"), "trace") is True
+    assert pi.session_matches_project(_Meta("TRACE"), "coeqwal") is False
+    assert pi.session_matches_project(_Meta(""), "trace") is False
+
+
+def test_get_bound_project_unpinned_is_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("TRACE_PROJECT", raising=False)
+    assert pi.get_bound_project() is None
+
+
+def test_get_bound_project_enrolled_is_bound(monkeypatch: pytest.MonkeyPatch) -> None:
+    _enroll("waggle")
+    monkeypatch.setenv("TRACE_PROJECT", "Waggle")
+    bound = pi.get_bound_project()
+    assert bound is not None
+    assert bound.key == "waggle" and bound.degraded is False
+
+
+def test_get_bound_project_unenrolled_is_degraded(monkeypatch: pytest.MonkeyPatch) -> None:
+    _enroll("waggle")
+    monkeypatch.setenv("TRACE_PROJECT", "some-other-project")
+    bound = pi.get_bound_project()
+    assert bound is not None
+    assert bound.key == "some-other-project" and bound.degraded is True
+
+
+def test_get_bound_project_no_registry_is_degraded(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TRACE_PROJECT", "anything")
+    bound = pi.get_bound_project()
+    assert bound is not None
+    assert bound.degraded is True

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -227,3 +227,41 @@ class TestCorruptSessionJson:
         path.write_text('{"id": "trace_20260205_abc', encoding="utf-8")
         with pytest.raises(json.JSONDecodeError):
             await storage.get_session("trace_20260205_abc123")
+
+
+class TestCanonicalProjectMatching:
+    """INV-4: query filters resolve drifted display labels to one canonical project."""
+
+    async def test_case_variant_labels_merge(self, storage: JsonFileStorage) -> None:
+        await storage.create_session(Session(id="trace_20260720_c1", metadata=SessionMetadata(project="COEQWAL")))
+        await storage.create_session(Session(id="trace_20260720_c2", metadata=SessionMetadata(project="coeqwal")))
+        # Both case variants resolve to the one key "coeqwal" (canonical merge).
+        assert len(await storage.list_sessions(project="coeqwal")) == 2
+        assert len(await storage.list_sessions(project="COEQWAL")) == 2
+        brief = await storage.session_brief(project="Coeqwal")
+        assert brief["matched"] == 2
+
+    async def test_distinct_canonical_keys_do_not_merge(self, storage: JsonFileStorage) -> None:
+        await storage.create_session(Session(id="trace_20260720_d1", metadata=SessionMetadata(project="climate-analysis")))
+        await storage.create_session(Session(id="trace_20260720_d2", metadata=SessionMetadata(project="materials-science")))
+        assert len(await storage.list_sessions(project="climate-analysis")) == 1
+        assert await storage.list_sessions(project="climate") == []  # not a substring match
+
+    async def test_registry_alias_merges_rename_drift(
+        self, storage: JsonFileStorage, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import trace_mcp.project_identity as pi
+
+        monkeypatch.setenv("TRACE_REGISTRY_PATH", str(tmp_path / "reg.json"))
+        pi._reset_registry_cache()
+        with pi.locked_registry() as reg:
+            reg.projects["trace-mcp"] = pi.ProjectEntry(
+                key="trace-mcp", display_label="trace-mcp", aliases=["TRACE"]
+            )
+        pi._reset_registry_cache()
+
+        await storage.create_session(Session(id="trace_20260720_t1", metadata=SessionMetadata(project="TRACE")))
+        await storage.create_session(Session(id="trace_20260720_t2", metadata=SessionMetadata(project="trace-mcp")))
+        # The alias table merges the rename pair (TRACE -> trace-mcp) into one project.
+        assert len(await storage.list_sessions(project="trace-mcp")) == 2
+        pi._reset_registry_cache()

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -242,8 +242,12 @@ class TestCanonicalProjectMatching:
         assert brief["matched"] == 2
 
     async def test_distinct_canonical_keys_do_not_merge(self, storage: JsonFileStorage) -> None:
-        await storage.create_session(Session(id="trace_20260720_d1", metadata=SessionMetadata(project="climate-analysis")))
-        await storage.create_session(Session(id="trace_20260720_d2", metadata=SessionMetadata(project="materials-science")))
+        await storage.create_session(
+            Session(id="trace_20260720_d1", metadata=SessionMetadata(project="climate-analysis"))
+        )
+        await storage.create_session(
+            Session(id="trace_20260720_d2", metadata=SessionMetadata(project="materials-science"))
+        )
         assert len(await storage.list_sessions(project="climate-analysis")) == 1
         assert await storage.list_sessions(project="climate") == []  # not a substring match
 
@@ -255,9 +259,7 @@ class TestCanonicalProjectMatching:
         monkeypatch.setenv("TRACE_REGISTRY_PATH", str(tmp_path / "reg.json"))
         pi._reset_registry_cache()
         with pi.locked_registry() as reg:
-            reg.projects["trace-mcp"] = pi.ProjectEntry(
-                key="trace-mcp", display_label="trace-mcp", aliases=["TRACE"]
-            )
+            reg.projects["trace-mcp"] = pi.ProjectEntry(key="trace-mcp", display_label="trace-mcp", aliases=["TRACE"])
         pi._reset_registry_cache()
 
         await storage.create_session(Session(id="trace_20260720_t1", metadata=SessionMetadata(project="TRACE")))

--- a/tests/test_v05_pinning.py
+++ b/tests/test_v05_pinning.py
@@ -1,0 +1,168 @@
+"""Tests for the TRACE_PROJECT process pin and its fail-closed boundaries (ADR-006 S3).
+
+Exercises the pin-guarded enforcement in ``server.py`` — none of which the
+pre-existing suite covers, because no other test sets ``TRACE_PROJECT``:
+pin-aware ``trace_start_session``, cross-project read hard-deny (+ escape hatch),
+pointer-capture denial in the logging path, the reserved-key usage ban, the
+auto-quarantine extraction gate, and ``TRACE_REQUIRE_PIN``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import trace_mcp.project_identity as pident
+from trace_mcp import server
+from trace_mcp.schema import Session, SessionMetadata
+from trace_mcp.storage.json_file import JsonFileStorage
+
+
+@pytest.fixture(autouse=True)
+def _isolated_server(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Fresh per-test storage + registry, clean pin env, reset server globals."""
+    monkeypatch.setattr(server, "storage", JsonFileStorage(directory=str(tmp_path / "sessions")))
+    monkeypatch.setenv("TRACE_REGISTRY_PATH", str(tmp_path / "projects.json"))
+    for var in ("TRACE_PROJECT", "TRACE_DEFAULT_PROJECT", "TRACE_REQUIRE_PIN", "TRACE_ALLOW_CROSS_PROJECT_READS"):
+        monkeypatch.delenv(var, raising=False)
+    server._current_session_id = None
+    server.active_sessions.clear()
+    server._unpinned_warned = False
+    pident._reset_registry_cache()
+
+
+def _enroll(*keys: str) -> None:
+    with pident.locked_registry() as reg:
+        for key in keys:
+            reg.projects[key] = pident.ProjectEntry(key=key, display_label=key)
+    pident._reset_registry_cache()
+
+
+async def _make_foreign_session(sid: str, project: str) -> None:
+    await server.storage.create_session(Session(id=sid, metadata=SessionMetadata(project=project)))
+
+
+# ── pin-aware start ────────────────────────────────────────────────────────
+
+
+async def test_pinned_start_defaults_to_pin(monkeypatch: pytest.MonkeyPatch) -> None:
+    _enroll("waggle")
+    monkeypatch.setenv("TRACE_PROJECT", "waggle")
+    result = await server.trace_start_session()
+    assert "Error" not in result
+    assert server._current_session_id is not None
+    session = await server.storage.get_session(server._current_session_id)
+    assert session.metadata.project == "waggle"
+
+
+async def test_pinned_start_foreign_label_errors_naming_both(monkeypatch: pytest.MonkeyPatch) -> None:
+    _enroll("waggle")
+    monkeypatch.setenv("TRACE_PROJECT", "waggle")
+    result = await server.trace_start_session(project="chemmasters")
+    assert "Error" in result and "waggle" in result and "chemmasters" in result
+
+
+async def test_unpinned_start_requires_project() -> None:
+    result = await server.trace_start_session()
+    assert "Error" in result and "not pinned" in result
+
+
+async def test_unpinned_start_rejects_reserved_key() -> None:
+    result = await server.trace_start_session(project="auto")
+    assert "Error" in result and "reserved" in result
+
+
+async def test_require_pin_fails_closed_when_unpinned(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TRACE_REQUIRE_PIN", "1")
+    result = await server.trace_start_session(project="anything")
+    assert "Error" in result and "TRACE_REQUIRE_PIN" in result
+
+
+# ── cross-project read scope ───────────────────────────────────────────────
+
+
+async def test_cross_project_read_denied(monkeypatch: pytest.MonkeyPatch) -> None:
+    _enroll("waggle", "chemmasters")
+    await _make_foreign_session("trace_20260720_r1", "chemmasters")
+    monkeypatch.setenv("TRACE_PROJECT", "waggle")
+    result = await server.trace_get_session("trace_20260720_r1")
+    assert "Error" in result and "denied" in result and "waggle" in result
+
+
+async def test_cross_project_read_escape_hatch_allows(monkeypatch: pytest.MonkeyPatch) -> None:
+    _enroll("waggle", "chemmasters")
+    await _make_foreign_session("trace_20260720_r2", "chemmasters")
+    monkeypatch.setenv("TRACE_PROJECT", "waggle")
+    monkeypatch.setenv("TRACE_ALLOW_CROSS_PROJECT_READS", "1")
+    result = await server.trace_get_session("trace_20260720_r2")
+    assert "Error" not in result
+
+
+async def test_same_project_read_allowed(monkeypatch: pytest.MonkeyPatch) -> None:
+    _enroll("waggle")
+    await _make_foreign_session("trace_20260720_r3", "Waggle")  # case variant of the pin
+    monkeypatch.setenv("TRACE_PROJECT", "waggle")
+    result = await server.trace_get_session("trace_20260720_r3")
+    assert "Error" not in result
+
+
+# ── pointer capture (logging path) ─────────────────────────────────────────
+
+
+async def test_pointer_capture_denied_in_logging(monkeypatch: pytest.MonkeyPatch) -> None:
+    _enroll("waggle", "chemmasters")
+    await _make_foreign_session("trace_20260720_p1", "chemmasters")
+    monkeypatch.setenv("TRACE_PROJECT", "waggle")
+    result = await server.trace_log_annotation(
+        category="observation", content="x", session_id="trace_20260720_p1"
+    )
+    assert "Error" in result and "another project" in result
+    # The foreign session must NOT have become the current pointer.
+    assert server._current_session_id is None
+
+
+# ── auto-quarantine extraction gate ────────────────────────────────────────
+
+
+async def test_end_auto_session_skips_extraction(monkeypatch: pytest.MonkeyPatch) -> None:
+    called: list[tuple[str, str]] = []
+
+    async def _spy_extract(project: str, session_id: str):  # noqa: ANN202 - test stub
+        called.append((project, session_id))
+
+        class _R:
+            error = None
+            new_ids: list[str] = []
+
+        return _R()
+
+    monkeypatch.setattr(server.hooks, "extract_if_available", _spy_extract)
+    # An unpinned auto session (project == "auto").
+    await server.storage.create_session(
+        Session(id="trace_20260720_a1", metadata=SessionMetadata(project="auto"))
+    )
+    result = await server.trace_end_session("trace_20260720_a1", summary="done", write_scratchpad=False)
+    assert "Error" not in result
+    assert called == []  # extraction gated off for the reserved quarantine pool
+
+
+async def test_end_real_session_still_extracts(monkeypatch: pytest.MonkeyPatch) -> None:
+    called: list[tuple[str, str]] = []
+
+    async def _spy_extract(project: str, session_id: str):  # noqa: ANN202 - test stub
+        called.append((project, session_id))
+
+        class _R:
+            error = None
+            new_ids: list[str] = []
+
+        return _R()
+
+    monkeypatch.setattr(server.hooks, "extract_if_available", _spy_extract)
+    await server.storage.create_session(
+        Session(id="trace_20260720_a2", metadata=SessionMetadata(project="waggle"))
+    )
+    result = await server.trace_end_session("trace_20260720_a2", summary="done", write_scratchpad=False)
+    assert "Error" not in result
+    assert called == [("waggle", "trace_20260720_a2")]

--- a/tests/test_v05_pinning.py
+++ b/tests/test_v05_pinning.py
@@ -114,9 +114,7 @@ async def test_pointer_capture_denied_in_logging(monkeypatch: pytest.MonkeyPatch
     _enroll("waggle", "chemmasters")
     await _make_foreign_session("trace_20260720_p1", "chemmasters")
     monkeypatch.setenv("TRACE_PROJECT", "waggle")
-    result = await server.trace_log_annotation(
-        category="observation", content="x", session_id="trace_20260720_p1"
-    )
+    result = await server.trace_log_annotation(category="observation", content="x", session_id="trace_20260720_p1")
     assert "Error" in result and "another project" in result
     # The foreign session must NOT have become the current pointer.
     assert server._current_session_id is None
@@ -139,9 +137,7 @@ async def test_end_auto_session_skips_extraction(monkeypatch: pytest.MonkeyPatch
 
     monkeypatch.setattr(server.hooks, "extract_if_available", _spy_extract)
     # An unpinned auto session (project == "auto").
-    await server.storage.create_session(
-        Session(id="trace_20260720_a1", metadata=SessionMetadata(project="auto"))
-    )
+    await server.storage.create_session(Session(id="trace_20260720_a1", metadata=SessionMetadata(project="auto")))
     result = await server.trace_end_session("trace_20260720_a1", summary="done", write_scratchpad=False)
     assert "Error" not in result
     assert called == []  # extraction gated off for the reserved quarantine pool
@@ -160,9 +156,7 @@ async def test_end_real_session_still_extracts(monkeypatch: pytest.MonkeyPatch) 
         return _R()
 
     monkeypatch.setattr(server.hooks, "extract_if_available", _spy_extract)
-    await server.storage.create_session(
-        Session(id="trace_20260720_a2", metadata=SessionMetadata(project="waggle"))
-    )
+    await server.storage.create_session(Session(id="trace_20260720_a2", metadata=SessionMetadata(project="waggle")))
     result = await server.trace_end_session("trace_20260720_a2", summary="done", write_scratchpad=False)
     assert "Error" not in result
     assert called == [("waggle", "trace_20260720_a2")]


### PR DESCRIPTION
## Summary

Replaces TRACE's cooperative project labeling with enforced canonical identity,
closing every known cross-project bleed path. This is the foundation and
enforcement stage of [ADR-006](docs/adr/006-project-identity-and-isolation.md).

- **Canonical project identity** (`src/trace_mcp/project_identity.py`): a
  `canonical_project_key` with two guaranteed, test-pinned properties —
  idempotence and a `sanitize_name` fixed point — so filename identity equals
  semantic identity and a case-insensitive filesystem can neither merge two
  distinct projects nor split one.
- **Fail-closed alias registry** (`~/.trace/projects.json`, override
  `TRACE_REGISTRY_PATH`): versioned, `O_EXCL` + PID-liveness locked, atomic
  writes, unknown-major refusal that never rewrites a corrupt file (INV-7).
- **Process pin** (`TRACE_PROJECT`): a pinned server cannot cross project
  boundaries — pointer capture, cross-project id-only reads (with a
  `TRACE_ALLOW_CROSS_PROJECT_READS` operator escape), and the `auto` quarantine
  pool are all fail-closed; `_infer_project` routes a pinned auto-session to the
  pin. `project` on `trace_start_session` becomes optional (defaults to the pin).
- **Canonical query filters**: `list_sessions` / `session_brief` match by
  canonical key, so drifted display labels resolve to one project — case
  variants via canonicalization, rename aliases via the registry (INV-4).
- **Knowledge-store containment**: stores key on the canonical key; the store
  lock is now fail-closed and dependency-free (`O_EXCL` + PID-liveness, no
  optional `filelock`, INV-8); `trace_learn_extract` and its hook validate
  `(project, session)` coherence before touching a store (INV-6), closing the
  cross-wired-extract path that shipped one project's whole store to the cloud
  as de-duplication context alongside another project's events; every learn tool
  rejects a reserved-key (`auto`/`shared`) or degenerate label (INV-9).

All enforcement is pin-guarded, so an unpinned server keeps its existing
behavior.

## Why

The knowledge/session store commingled projects with drifted labels (case
variants, pre/post-rename names) and no enforcement: cross-project pointer
capture, cross-wired extraction, case-insensitive store merges, and label-blind
reads. This is sequenced before the capture-time-integrity work (ADR-005), whose
genesis records bind the project label into hashed content — so identity must
be made canonical first, or the drift is cryptographically frozen and later
repair becomes indistinguishable from tampering.

## Verification

- Full suite: **1077 passed, 11 skipped**. `ruff` and `pyright` clean.
- Five invariants (INV-4/6/7/8/9) each gain a mechanical AST/source guard in
  `tests/test_invariants.py` (a future change that reopens a bleed fails CI),
  plus behavioral coverage in `tests/test_project_identity.py`,
  `tests/test_v05_pinning.py`, `tests/test_learn_containment.py`, and new
  canonical-matching cases in `tests/test_storage.py`.

## Migration note (read before deploying)

Canonical store keying means a knowledge-store file whose name contains an
underscore or space is read at its canonical path (e.g. `foo_bar.json` →
`foo-bar.json`); the migration tooling (a following stage) consolidates such
files. Case/APFS variants resolve unchanged. A deploy of this change must be
paired with that migration.

## Scope / follow-ups

Additive enhancements intentionally left for a following stage (none are
cross-project bleed closures — those are all closed here): egress `project_key`
attribution at the matching/embeddings ledger sites, the per-project config
ratchet (force a project local-only), `load_store` fail-closed on corrupt JSON,
the adapter-hook alignment to canonical matching, and the v0.5 spec/schema
additions. `TRACE_REQUIRE_PIN` currently gates session start but not auto-create.

## References

- ADR: `docs/adr/006-project-identity-and-isolation.md`
- Invariants: `docs/INVARIANTS.md` (INV-4, INV-6, INV-7, INV-8, INV-9)
