### PR TITLE
test(e2e): budget server cold-start separately and report server stderr

### DIFF
--- a/tests/test_e2e_server.py
+++ b/tests/test_e2e_server.py
@@ -29,8 +29,38 @@ import trace_mcp
 
 TRACE_ROOT = Path(__file__).parent.parent
 
+# Cold-starting the server subprocess (interpreter boot, importing trace_mcp and
+# its mcp/pydantic dependency tree, extension discovery) costs far more than any
+# request made once it is warm. Budgeting both from one 15s allowance made the
+# handshake the first thing to break whenever the machine was loaded — a busy CI
+# runner or a concurrent build — surfacing as an unattributable TimeoutError in
+# whichever e2e test happened to run first. The two budgets are therefore
+# separate, and the startup one is overridable for pathologically slow hosts.
+_REQUEST_TIMEOUT = 15.0
+_HANDSHAKE_TIMEOUT = float(os.environ.get("TRACE_E2E_HANDSHAKE_TIMEOUT", "90"))
+
 
 # ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+async def _drain_server_stderr(proc: asyncio.subprocess.Process, limit: int = 4000) -> str:
+    """Return the tail of *proc*'s stderr, killing it first so the read can end.
+
+    Side effects: kills the subprocess if still running, and consumes its stderr
+    pipe. Only call this on a failure path — a live server never closes stderr,
+    so the read would otherwise block forever.
+
+    Returns the last *limit* characters, or "" if nothing could be recovered.
+    """
+    if proc.stderr is None:
+        return ""
+    if proc.returncode is None:
+        proc.kill()  # force EOF; draining a live process's stderr would hang
+    try:
+        data = await asyncio.wait_for(proc.stderr.read(), timeout=5.0)
+    except (TimeoutError, ProcessLookupError):
+        return ""
+    return data.decode("utf-8", errors="replace").strip()[-limit:]
 
 
 def _make_jsonrpc_request(method: str, params: dict[str, Any] | None = None, id: int = 1) -> str:
@@ -59,7 +89,7 @@ def _make_jsonrpc_notification(method: str, params: dict[str, Any] | None = None
 async def _send_and_receive(
     proc: asyncio.subprocess.Process,
     message: str,
-    timeout: float = 15.0,
+    timeout: float = _REQUEST_TIMEOUT,
 ) -> dict[str, Any]:
     """Send a JSON-RPC message and read the response.
 
@@ -81,9 +111,26 @@ async def _send_and_receive(
 
     # Read lines until we get a response (skip notifications)
     while True:
-        line = await asyncio.wait_for(proc.stdout.readline(), timeout=timeout)
+        try:
+            line = await asyncio.wait_for(proc.stdout.readline(), timeout=timeout)
+        except TimeoutError as exc:
+            # A bare TimeoutError reports only that no line arrived. The server's
+            # own stderr — an import error, a failed extension registration, a
+            # traceback — is what distinguishes "crashed" from "still too slow",
+            # and it is otherwise discarded when the pipe is garbage-collected.
+            stderr_tail = await _drain_server_stderr(proc)
+            raise TimeoutError(
+                f"No JSON-RPC response for request id {expected_id} within {timeout}s. "
+                + (f"Server stderr:\n{stderr_tail}" if stderr_tail else "Server wrote nothing to stderr.")
+            ) from exc
         if not line:
-            raise ConnectionError("Server closed stdout")
+            # EOF: the server exited. Its stderr carries the reason.
+            stderr_tail = await _drain_server_stderr(proc)
+            raise ConnectionError(
+                "Server closed stdout before answering request "
+                f"id {expected_id}. "
+                + (f"Server stderr:\n{stderr_tail}" if stderr_tail else "Server wrote nothing to stderr.")
+            )
         line_str = line.decode("utf-8").strip()
         if not line_str:
             continue
@@ -148,7 +195,7 @@ async def _initialize_server(proc: asyncio.subprocess.Process) -> dict[str, Any]
             "clientInfo": {"name": "trace-test", "version": "1.0.0"},
         },
     )
-    response = await _send_and_receive(proc, init_request)
+    response = await _send_and_receive(proc, init_request, timeout=_HANDSHAKE_TIMEOUT)
 
     # Send initialized notification
     notif = _make_jsonrpc_notification("notifications/initialized")


### PR DESCRIPTION
## Summary

Splits the end-to-end MCP harness's single 15s timeout into two budgets, and makes both failure paths report the server subprocess's stderr.

- Warm request/response keeps 15s (`_REQUEST_TIMEOUT`).
- The `initialize` handshake gets 90s (`_HANDSHAKE_TIMEOUT`), overridable via `TRACE_E2E_HANDSHAKE_TIMEOUT` for slower hosts.
- On timeout, and on the server exiting early, the raised error now carries the subprocess's stderr tail.

## Why

Cold start and warm requests are not comparable costs. Starting the server subprocess means interpreter boot, importing `trace_mcp` with its `mcp`/`pydantic` dependency tree, and extension discovery; a warm tool call is a single round trip. Funding both from one 15s allowance made the handshake the first thing to break whenever the machine was loaded, failing whichever e2e test happened to run first — an intermittent failure unrelated to the code under test.

The diagnostics were the worse half of the problem. A stalled server raised a bare `TimeoutError` and an exited one a bare `ConnectionError`, neither of which distinguishes "crashed on import" from "still too slow". The subprocess traceback that answers this was written to stderr and then discarded unread when the pipe was garbage-collected. Draining it requires killing the process first, since a live server never closes stderr and an unguarded read would hang rather than report.

`_send_and_receive` / `_initialize_server` are shared helpers, so this covers roughly 25 call sites across `test_e2e_server.py`, `test_decision_guards_e2e.py`, and `test_failure_modes_e2e.py`.

## Verification

- Full suite: 1077 passed, 11 skipped.
- E2E suites specifically: 66 passed.
- `ruff check`, `ruff format --check`, `pyright` clean.
- Fault injection against stand-in servers confirms the behavior rather than assuming it: a server that writes to stderr and exits produces a `ConnectionError` carrying that stderr; a server that writes to stderr and then hangs produces a `TimeoutError` carrying it, raised at the timeout instead of hanging.

## Risks / rollback

Test-only change; no `src/` files touched. A genuinely hung server now takes up to 90s to fail instead of 15s, which is the intended trade for not failing healthy runs. Revert the commit to restore the previous behavior.