### PR TITLE
feat(adapter): canonical project identity in hooks and an init-minted pin

### DIFF
--- a/src/trace_mcp/adapters/claude_code/assets/hooks/decision-audit.sh
+++ b/src/trace_mcp/adapters/claude_code/assets/hooks/decision-audit.sh
@@ -1,37 +1,173 @@
 #!/bin/bash
 # trace-mcp:claude-code — PostToolUse hook for trace_end_session.
-# v0.4.1: extended to surface the new audit metrics from the server-side
-# AttributionAudit extension. Reads the most recently ended session JSON
-# and surfaces guard-rail warnings.
+# Reads the most recently ended session JSON FOR THIS PROJECT and surfaces
+# guard-rail warnings from the server-side AttributionAudit extension.
+#
+# Project scoping: the session is selected through the shared
+# canonical-identity block below. Selecting the globally newest session
+# regardless of project — as this hook once did — reports another project's
+# audit findings whenever two servers run side by side.
 #
 # Detection logic generalized per spec §3.6 Proposer Identity Rule —
-# self-resolution check now fires on ANY same-instance pair (type AND
-# id match), not just ai→ai. This catches same-instance self-resolution
-# between non-ai actors (e.g. human→human in a multi-actor session), not
-# only the ai→ai case.
+# self-resolution check fires on ANY same-instance pair (type AND id match),
+# not just ai→ai. This catches same-instance self-resolution between non-ai
+# actors (e.g. human→human in a multi-actor session), not only the ai→ai case.
 
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$PWD}"
 SESSIONS_DIR="${TRACE_SESSIONS_DIR:-$HOME/.trace/sessions}"
 
-LATEST=$(ls -t "$SESSIONS_DIR"/trace_*.json 2>/dev/null | head -1)
-
-if [ -z "$LATEST" ]; then
-    exit 0
-fi
-
 # Compute all v0.4.1 audit metrics in one Python invocation for efficiency.
-# v0.4.1 amendment: this script must run on macOS bash 3.2 (the default
-# /bin/bash on macOS; Apple has not shipped a newer bash since the GPLv3
-# transition). bash 3.2 does NOT have `mapfile`, so we emit a single
-# space-separated line from Python and parse it with `read`, which is
-# POSIX-portable.
-METRICS_RAW=$(python3 - "$LATEST" 2>/dev/null << 'PYEOF'
+# This script must run on macOS bash 3.2 (the default /bin/bash on macOS; Apple
+# has not shipped a newer bash since the GPLv3 transition). bash 3.2 does NOT
+# have `mapfile`, so we emit a single space-separated line from Python and parse
+# it with `read`, which is POSIX-portable.
+METRICS_RAW=$(python3 - "$PROJECT_DIR" "$SESSIONS_DIR" 2>/dev/null << 'PYEOF'
+# --- trace-project-detect v0.5 begin ---
+# SHARED BLOCK — byte-identical in all four trace-mcp hook scripts, guarded by
+# tests/test_hook_assets_consistency.py. Edit every copy together or the hooks
+# drift apart: one such drift (a pin regex that did not tolerate markdown bold)
+# made one hook read the CLAUDE.md project name while another fell through to
+# the git basename, minting two labels for a single repository.
+#
+# Pure stdlib, and deliberately no registry read: a hook canonicalizes a label,
+# it never resolves aliases. Alias resolution belongs to the server and the
+# identity CLI, which can fail closed on a damaged registry; a hook must not.
+import re
+import subprocess
+import unicodedata
+from pathlib import Path
+
+_SEP_RUN = re.compile(r"[\s/_]+")
+_NON_KEY_RUN = re.compile(r"[^\w.-]+")
+_DOT_RUN = re.compile(r"\.{2,}")
+_DASH_RUN = re.compile(r"-{2,}")
+# Bold-tolerant: matches both `TRACE project name: "x"` and the bolded
+# `**TRACE project name**: "x"` form that renders as a definition line.
+_PIN_LINE = re.compile(r'TRACE project name\**\s*:\s*"([^"]+)"')
+
+
+def canonical_key(label: str) -> str:
+    """Return the canonical project key for *label*, or "" if it yields none.
+
+    Mirrors trace_mcp.project_identity.canonical_project_key exactly, except
+    that a degenerate label yields "" instead of raising: a hook advises, and
+    must never fail the tool call it runs alongside.
+    """
+    s = unicodedata.normalize("NFC", label).strip().casefold()
+    s = _SEP_RUN.sub("-", s)
+    s = _NON_KEY_RUN.sub("-", s)
+    s = _DOT_RUN.sub(".", s)
+    s = _DASH_RUN.sub("-", s)
+    return s.strip(".-")
+
+
+def detect_project(project_dir: Path) -> str:
+    """Return the canonical project key for *project_dir*, or "" if undetectable.
+
+    Order: the `.claude/trace.project` pin file written by `trace-mcp init`,
+    then a CLAUDE.md pin line, then the git toplevel basename, then the
+    directory name. Every candidate is canonicalized, so the four sources agree
+    on one identity instead of minting variants of it.
+    """
+    pin = project_dir / ".claude" / "trace.project"
+    if pin.is_file():
+        key = canonical_key(pin.read_text(errors="replace").strip())
+        if key:
+            return key
+    md = project_dir / "CLAUDE.md"
+    if md.is_file():
+        match = _PIN_LINE.search(md.read_text(errors="replace"))
+        if match:
+            key = canonical_key(match.group(1))
+            if key:
+                return key
+    try:
+        top = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            cwd=project_dir,
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=2,
+        ).stdout.strip()
+        if top:
+            key = canonical_key(Path(top).name)
+            if key:
+                return key
+    except Exception:
+        pass
+    return canonical_key(project_dir.name)
+
+
+def session_key(data: dict) -> str:
+    """Return the canonical key a session record belongs to.
+
+    `metadata.project_key` is authoritative when present (sessions written by a
+    pinned server carry it); otherwise the display label is canonicalized, which
+    is what keeps legacy sessions matchable.
+    """
+    meta = data.get("metadata") or {}
+    key = meta.get("project_key")
+    if isinstance(key, str) and key:
+        return key
+    label = meta.get("project")
+    return canonical_key(label) if isinstance(label, str) else ""
+# --- trace-project-detect v0.5 end ---
+
 import json
 import sys
-try:
-    data = json.load(open(sys.argv[1]))
-except Exception:
-    # Fail-open: emit zeros if we can't parse
-    print("0 0 0 0 0 0")
+
+project_dir = Path(sys.argv[1])
+sessions_dir = Path(sys.argv[2])
+
+ZEROS = "0 0 0 0 0 0"
+_DATED_NAME = re.compile(r"trace_(\d{8})_")
+
+
+def name_date(path):
+    """The filename's YYYYMMDD stamp, or "" when it has none (sorts oldest)."""
+    match = _DATED_NAME.match(path.name)
+    return match.group(1) if match else ""
+
+
+def newest_for_project(key):
+    """Return the parsed newest session belonging to *key*, or None.
+
+    Ordered by the filename's YYYYMMDD stamp — the same "newest" notion the
+    other three hooks use — with mtime breaking ties inside a day, which is
+    what actually identifies the session that just ended.
+
+    Walks newest-date-first and stops once the date changes after a match, so a
+    store holding hundreds of sessions costs a handful of reads rather than a
+    full parse of every file on every session end.
+    """
+    best = None
+    best_mtime = 0.0
+    best_date = None
+    for path in sorted(sessions_dir.glob("trace_*.json"), key=lambda p: (name_date(p), p.name), reverse=True):
+        date = name_date(path)
+        if best_date is not None and date != best_date:
+            break  # dates descend: nothing further can be newer than the match
+        try:
+            data = json.loads(path.read_text())
+        except Exception:
+            continue
+        if session_key(data) != key:
+            continue
+        try:
+            mtime = path.stat().st_mtime
+        except OSError:
+            continue
+        if best is None or mtime > best_mtime:
+            best, best_mtime, best_date = data, mtime, date
+    return best
+
+
+key = detect_project(project_dir)
+data = newest_for_project(key) if key and sessions_dir.is_dir() else None
+if data is None:
+    # Fail-open: no session for this project (or none parseable) → emit zeros.
+    print(ZEROS)
     raise SystemExit
 
 events = data.get("events", [])
@@ -139,5 +275,5 @@ if [ "$MISSING_CORR" -gt 0 ]; then
 fi
 
 if [ -n "$WARNINGS" ]; then
-    echo "TRACE Decision Audit: ${WARNINGS}Review the Attribution Audit above and fix any misattributions before closing."
+    echo "TRACE Decision Audit: ${WARNINGS}Review the Attribution Audit above and fix any misattributions before closing. [trace-hooks v0.5]"
 fi

--- a/src/trace_mcp/adapters/claude_code/assets/hooks/pretool-guard.sh
+++ b/src/trace_mcp/adapters/claude_code/assets/hooks/pretool-guard.sh
@@ -3,6 +3,8 @@
 #
 # Runs before Edit/Write tool calls. If no active TRACE session exists for
 # this project today, emits a warning reminding the model to start one.
+# Project detection and session matching go through the shared
+# canonical-identity block below.
 #
 # Modes (set via TRACE_GUARD env var):
 #   soft    — print a warning, allow the tool call to proceed (default)
@@ -25,23 +27,65 @@ PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$PWD}"
 SESSIONS_DIR="${TRACE_SESSIONS_DIR:-$HOME/.trace/sessions}"
 
 REPORT=$(python3 - "$PROJECT_DIR" "$SESSIONS_DIR" <<'PYEOF' 2>/dev/null
-import json
+# --- trace-project-detect v0.5 begin ---
+# SHARED BLOCK — byte-identical in all four trace-mcp hook scripts, guarded by
+# tests/test_hook_assets_consistency.py. Edit every copy together or the hooks
+# drift apart: one such drift (a pin regex that did not tolerate markdown bold)
+# made one hook read the CLAUDE.md project name while another fell through to
+# the git basename, minting two labels for a single repository.
+#
+# Pure stdlib, and deliberately no registry read: a hook canonicalizes a label,
+# it never resolves aliases. Alias resolution belongs to the server and the
+# identity CLI, which can fail closed on a damaged registry; a hook must not.
 import re
 import subprocess
-import sys
-from datetime import datetime, timezone
+import unicodedata
 from pathlib import Path
 
-project_dir = Path(sys.argv[1])
-sessions_dir = Path(sys.argv[2])
+_SEP_RUN = re.compile(r"[\s/_]+")
+_NON_KEY_RUN = re.compile(r"[^\w.-]+")
+_DOT_RUN = re.compile(r"\.{2,}")
+_DASH_RUN = re.compile(r"-{2,}")
+# Bold-tolerant: matches both `TRACE project name: "x"` and the bolded
+# `**TRACE project name**: "x"` form that renders as a definition line.
+_PIN_LINE = re.compile(r'TRACE project name\**\s*:\s*"([^"]+)"')
 
 
-def detect_project() -> str:
+def canonical_key(label: str) -> str:
+    """Return the canonical project key for *label*, or "" if it yields none.
+
+    Mirrors trace_mcp.project_identity.canonical_project_key exactly, except
+    that a degenerate label yields "" instead of raising: a hook advises, and
+    must never fail the tool call it runs alongside.
+    """
+    s = unicodedata.normalize("NFC", label).strip().casefold()
+    s = _SEP_RUN.sub("-", s)
+    s = _NON_KEY_RUN.sub("-", s)
+    s = _DOT_RUN.sub(".", s)
+    s = _DASH_RUN.sub("-", s)
+    return s.strip(".-")
+
+
+def detect_project(project_dir: Path) -> str:
+    """Return the canonical project key for *project_dir*, or "" if undetectable.
+
+    Order: the `.claude/trace.project` pin file written by `trace-mcp init`,
+    then a CLAUDE.md pin line, then the git toplevel basename, then the
+    directory name. Every candidate is canonicalized, so the four sources agree
+    on one identity instead of minting variants of it.
+    """
+    pin = project_dir / ".claude" / "trace.project"
+    if pin.is_file():
+        key = canonical_key(pin.read_text(errors="replace").strip())
+        if key:
+            return key
     md = project_dir / "CLAUDE.md"
     if md.is_file():
-        match = re.search(r'TRACE project name:\s*"([^"]+)"', md.read_text(errors="replace"))
+        match = _PIN_LINE.search(md.read_text(errors="replace"))
         if match:
-            return match.group(1)
+            key = canonical_key(match.group(1))
+            if key:
+                return key
     try:
         top = subprocess.run(
             ["git", "rev-parse", "--show-toplevel"],
@@ -52,13 +96,38 @@ def detect_project() -> str:
             timeout=2,
         ).stdout.strip()
         if top:
-            return Path(top).name
+            key = canonical_key(Path(top).name)
+            if key:
+                return key
     except Exception:
         pass
-    return project_dir.name
+    return canonical_key(project_dir.name)
 
 
-def has_active(project: str) -> bool:
+def session_key(data: dict) -> str:
+    """Return the canonical key a session record belongs to.
+
+    `metadata.project_key` is authoritative when present (sessions written by a
+    pinned server carry it); otherwise the display label is canonicalized, which
+    is what keeps legacy sessions matchable.
+    """
+    meta = data.get("metadata") or {}
+    key = meta.get("project_key")
+    if isinstance(key, str) and key:
+        return key
+    label = meta.get("project")
+    return canonical_key(label) if isinstance(label, str) else ""
+# --- trace-project-detect v0.5 end ---
+
+import json
+import sys
+from datetime import datetime, timezone
+
+project_dir = Path(sys.argv[1])
+sessions_dir = Path(sys.argv[2])
+
+
+def has_active(key: str) -> bool:
     if not sessions_dir.is_dir():
         return False
     today = datetime.now(timezone.utc).strftime("%Y%m%d")
@@ -69,14 +138,14 @@ def has_active(project: str) -> bool:
             continue
         if data.get("status") != "active":
             continue
-        if data.get("metadata", {}).get("project") == project:
+        if session_key(data) == key:
             return True
     return False
 
 
-project = detect_project()
-state = "active" if has_active(project) else "none"
-print(f"{project}|{state}")
+key = detect_project(project_dir)
+state = "active" if key and has_active(key) else "none"
+print(f"{key}|{state}")
 PYEOF
 )
 
@@ -91,7 +160,7 @@ if [ "$STATE" = "active" ]; then
     exit 0
 fi
 
-MESSAGE="⚠️ TRACE: editing files in '$NAME' but no active session exists. Call trace_start_session so this edit is recorded in the audit trail."
+MESSAGE="⚠️ TRACE: editing files in '$NAME' but no active session exists. Call trace_start_session so this edit is recorded in the audit trail. [trace-hooks v0.5]"
 
 if [ "$MODE" = "strict" ]; then
     echo "$MESSAGE" >&2

--- a/src/trace_mcp/adapters/claude_code/assets/hooks/prompt-reminder.sh
+++ b/src/trace_mcp/adapters/claude_code/assets/hooks/prompt-reminder.sh
@@ -1,15 +1,18 @@
 #!/bin/bash
 # trace-mcp:claude-code — UserPromptSubmit hook.
 # Periodically nudges when the user is working in a project with no active
-# TRACE session. Catches the 2026-04-13 "started acting before session
-# existed" failure mode where SessionStart fired once and was ignored.
+# TRACE session. Catches the "started acting before a session existed" failure
+# mode where SessionStart fires once and is ignored.
 #
 # Behavior:
 #   - If an active session exists for this project today → no output.
 #   - Else: track turns and nudge only after N turns (default 3) and at
 #     most once every COOLDOWN_SEC (default 300s) to avoid spam.
 #
-# State file: ~/.trace/runtime/<project>.state.json
+# State file: ~/.trace/runtime/<canonical-project-key>.state.json — the key is
+# filesystem-safe by construction, so no separate sanitizer is needed (one used
+# to live here and folded characters differently from the canonical key, which
+# is exactly the kind of divergence the shared block below exists to prevent).
 
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$PWD}"
 SESSIONS_DIR="${TRACE_SESSIONS_DIR:-$HOME/.trace/sessions}"
@@ -18,26 +21,65 @@ MIN_TURNS="${TRACE_PROMPT_MIN_TURNS:-3}"
 COOLDOWN_SEC="${TRACE_PROMPT_COOLDOWN_SEC:-300}"
 
 OUTPUT=$(python3 - "$PROJECT_DIR" "$SESSIONS_DIR" "$RUNTIME_DIR" "$MIN_TURNS" "$COOLDOWN_SEC" <<'PYEOF' 2>/dev/null
-import json
+# --- trace-project-detect v0.5 begin ---
+# SHARED BLOCK — byte-identical in all four trace-mcp hook scripts, guarded by
+# tests/test_hook_assets_consistency.py. Edit every copy together or the hooks
+# drift apart: one such drift (a pin regex that did not tolerate markdown bold)
+# made one hook read the CLAUDE.md project name while another fell through to
+# the git basename, minting two labels for a single repository.
+#
+# Pure stdlib, and deliberately no registry read: a hook canonicalizes a label,
+# it never resolves aliases. Alias resolution belongs to the server and the
+# identity CLI, which can fail closed on a damaged registry; a hook must not.
 import re
 import subprocess
-import sys
-from datetime import datetime, timezone
+import unicodedata
 from pathlib import Path
 
-project_dir = Path(sys.argv[1])
-sessions_dir = Path(sys.argv[2])
-runtime_dir = Path(sys.argv[3])
-min_turns = int(sys.argv[4])
-cooldown_sec = int(sys.argv[5])
+_SEP_RUN = re.compile(r"[\s/_]+")
+_NON_KEY_RUN = re.compile(r"[^\w.-]+")
+_DOT_RUN = re.compile(r"\.{2,}")
+_DASH_RUN = re.compile(r"-{2,}")
+# Bold-tolerant: matches both `TRACE project name: "x"` and the bolded
+# `**TRACE project name**: "x"` form that renders as a definition line.
+_PIN_LINE = re.compile(r'TRACE project name\**\s*:\s*"([^"]+)"')
 
 
-def detect_project() -> str:
+def canonical_key(label: str) -> str:
+    """Return the canonical project key for *label*, or "" if it yields none.
+
+    Mirrors trace_mcp.project_identity.canonical_project_key exactly, except
+    that a degenerate label yields "" instead of raising: a hook advises, and
+    must never fail the tool call it runs alongside.
+    """
+    s = unicodedata.normalize("NFC", label).strip().casefold()
+    s = _SEP_RUN.sub("-", s)
+    s = _NON_KEY_RUN.sub("-", s)
+    s = _DOT_RUN.sub(".", s)
+    s = _DASH_RUN.sub("-", s)
+    return s.strip(".-")
+
+
+def detect_project(project_dir: Path) -> str:
+    """Return the canonical project key for *project_dir*, or "" if undetectable.
+
+    Order: the `.claude/trace.project` pin file written by `trace-mcp init`,
+    then a CLAUDE.md pin line, then the git toplevel basename, then the
+    directory name. Every candidate is canonicalized, so the four sources agree
+    on one identity instead of minting variants of it.
+    """
+    pin = project_dir / ".claude" / "trace.project"
+    if pin.is_file():
+        key = canonical_key(pin.read_text(errors="replace").strip())
+        if key:
+            return key
     md = project_dir / "CLAUDE.md"
     if md.is_file():
-        match = re.search(r'TRACE project name:\s*"([^"]+)"', md.read_text(errors="replace"))
+        match = _PIN_LINE.search(md.read_text(errors="replace"))
         if match:
-            return match.group(1)
+            key = canonical_key(match.group(1))
+            if key:
+                return key
     try:
         top = subprocess.run(
             ["git", "rev-parse", "--show-toplevel"],
@@ -48,13 +90,41 @@ def detect_project() -> str:
             timeout=2,
         ).stdout.strip()
         if top:
-            return Path(top).name
+            key = canonical_key(Path(top).name)
+            if key:
+                return key
     except Exception:
         pass
-    return project_dir.name
+    return canonical_key(project_dir.name)
 
 
-def has_active(project: str) -> bool:
+def session_key(data: dict) -> str:
+    """Return the canonical key a session record belongs to.
+
+    `metadata.project_key` is authoritative when present (sessions written by a
+    pinned server carry it); otherwise the display label is canonicalized, which
+    is what keeps legacy sessions matchable.
+    """
+    meta = data.get("metadata") or {}
+    key = meta.get("project_key")
+    if isinstance(key, str) and key:
+        return key
+    label = meta.get("project")
+    return canonical_key(label) if isinstance(label, str) else ""
+# --- trace-project-detect v0.5 end ---
+
+import json
+import sys
+from datetime import datetime, timezone
+
+project_dir = Path(sys.argv[1])
+sessions_dir = Path(sys.argv[2])
+runtime_dir = Path(sys.argv[3])
+min_turns = int(sys.argv[4])
+cooldown_sec = int(sys.argv[5])
+
+
+def has_active(key: str) -> bool:
     if not sessions_dir.is_dir():
         return False
     today = datetime.now(timezone.utc).strftime("%Y%m%d")
@@ -65,18 +135,17 @@ def has_active(project: str) -> bool:
             continue
         if data.get("status") != "active":
             continue
-        if data.get("metadata", {}).get("project") == project:
+        if session_key(data) == key:
             return True
     return False
 
 
-def _sanitize(name: str) -> str:
-    # Keep it filesystem-friendly without importing trace_mcp
-    return re.sub(r"[^A-Za-z0-9._-]", "_", name) or "unknown"
+def state_path(key: str) -> Path:
+    return runtime_dir / f"{key or 'unknown'}.state.json"
 
 
-def load_state(project: str) -> dict:
-    path = runtime_dir / f"{_sanitize(project)}.state.json"
+def load_state(key: str) -> dict:
+    path = state_path(key)
     if path.is_file():
         try:
             return json.loads(path.read_text())
@@ -85,20 +154,19 @@ def load_state(project: str) -> dict:
     return {}
 
 
-def save_state(project: str, state: dict) -> None:
+def save_state(key: str, state: dict) -> None:
     runtime_dir.mkdir(parents=True, exist_ok=True)
-    path = runtime_dir / f"{_sanitize(project)}.state.json"
-    path.write_text(json.dumps(state, indent=2))
+    state_path(key).write_text(json.dumps(state, indent=2))
 
 
-project = detect_project()
+key = detect_project(project_dir)
 
-if has_active(project):
-    save_state(project, {"turn_count": 0, "last_nudged": None})
+if key and has_active(key):
+    save_state(key, {"turn_count": 0, "last_nudged": None})
     sys.exit(0)
 
 now = datetime.now(timezone.utc)
-state = load_state(project)
+state = load_state(key)
 turn_count = int(state.get("turn_count", 0)) + 1
 
 last_nudged_str = state.get("last_nudged")
@@ -114,15 +182,18 @@ should_nudge = turn_count >= min_turns and cooldown_expired
 
 if should_nudge:
     state = {"turn_count": turn_count, "last_nudged": now.isoformat()}
-    save_state(project, state)
-    print(f"NUDGE|{project}")
+    save_state(key, state)
+    print(f"NUDGE|{key}")
 else:
     state["turn_count"] = turn_count
-    save_state(project, state)
+    save_state(key, state)
 PYEOF
 )
 
 if [[ "$OUTPUT" == NUDGE\|* ]]; then
     NAME="${OUTPUT#NUDGE|}"
-    echo "⚠️ TRACE: you've been working in '$NAME' for several turns without an active session. Call trace_start_session now so this work is part of the audit record."
+    if [ -z "$NAME" ]; then
+        NAME="this project"
+    fi
+    echo "⚠️ TRACE: you've been working in '$NAME' for several turns without an active session. Call trace_start_session now so this work is part of the audit record. [trace-hooks v0.5]"
 fi

--- a/src/trace_mcp/adapters/claude_code/assets/hooks/session-reminder.sh
+++ b/src/trace_mcp/adapters/claude_code/assets/hooks/session-reminder.sh
@@ -2,13 +2,10 @@
 # trace-mcp:claude-code — SessionStart hook.
 # Emits a reminder when no active TRACE session exists for THIS project today.
 #
-# Project detection (same order as /trace-session skill):
-#   1. CLAUDE.md line matching `TRACE project name: "..."` → that value
-#   2. basename of the git repo toplevel
-#   3. basename of the project directory
-#
-# Session match: metadata.project == detected project AND status == "active"
-# AND filename matches today's YYYYMMDD prefix.
+# Project detection and session matching both go through the shared
+# canonical-identity block below: a session matches when its canonical project
+# key equals this directory's, so a display-label variant can neither split one
+# project in two nor merge two into one.
 
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$PWD}"
 SESSIONS_DIR="${TRACE_SESSIONS_DIR:-$HOME/.trace/sessions}"
@@ -18,23 +15,65 @@ if [ ! -d "$SESSIONS_DIR" ]; then
 fi
 
 REPORT=$(python3 - "$PROJECT_DIR" "$SESSIONS_DIR" <<'PYEOF' 2>/dev/null
-import json
+# --- trace-project-detect v0.5 begin ---
+# SHARED BLOCK — byte-identical in all four trace-mcp hook scripts, guarded by
+# tests/test_hook_assets_consistency.py. Edit every copy together or the hooks
+# drift apart: one such drift (a pin regex that did not tolerate markdown bold)
+# made one hook read the CLAUDE.md project name while another fell through to
+# the git basename, minting two labels for a single repository.
+#
+# Pure stdlib, and deliberately no registry read: a hook canonicalizes a label,
+# it never resolves aliases. Alias resolution belongs to the server and the
+# identity CLI, which can fail closed on a damaged registry; a hook must not.
 import re
 import subprocess
-import sys
-from datetime import datetime, timezone
+import unicodedata
 from pathlib import Path
 
-project_dir = Path(sys.argv[1])
-sessions_dir = Path(sys.argv[2])
+_SEP_RUN = re.compile(r"[\s/_]+")
+_NON_KEY_RUN = re.compile(r"[^\w.-]+")
+_DOT_RUN = re.compile(r"\.{2,}")
+_DASH_RUN = re.compile(r"-{2,}")
+# Bold-tolerant: matches both `TRACE project name: "x"` and the bolded
+# `**TRACE project name**: "x"` form that renders as a definition line.
+_PIN_LINE = re.compile(r'TRACE project name\**\s*:\s*"([^"]+)"')
 
 
-def detect_project() -> str:
+def canonical_key(label: str) -> str:
+    """Return the canonical project key for *label*, or "" if it yields none.
+
+    Mirrors trace_mcp.project_identity.canonical_project_key exactly, except
+    that a degenerate label yields "" instead of raising: a hook advises, and
+    must never fail the tool call it runs alongside.
+    """
+    s = unicodedata.normalize("NFC", label).strip().casefold()
+    s = _SEP_RUN.sub("-", s)
+    s = _NON_KEY_RUN.sub("-", s)
+    s = _DOT_RUN.sub(".", s)
+    s = _DASH_RUN.sub("-", s)
+    return s.strip(".-")
+
+
+def detect_project(project_dir: Path) -> str:
+    """Return the canonical project key for *project_dir*, or "" if undetectable.
+
+    Order: the `.claude/trace.project` pin file written by `trace-mcp init`,
+    then a CLAUDE.md pin line, then the git toplevel basename, then the
+    directory name. Every candidate is canonicalized, so the four sources agree
+    on one identity instead of minting variants of it.
+    """
+    pin = project_dir / ".claude" / "trace.project"
+    if pin.is_file():
+        key = canonical_key(pin.read_text(errors="replace").strip())
+        if key:
+            return key
     md = project_dir / "CLAUDE.md"
     if md.is_file():
-        match = re.search(r'TRACE project name:\s*"([^"]+)"', md.read_text(errors="replace"))
+        match = _PIN_LINE.search(md.read_text(errors="replace"))
         if match:
-            return match.group(1)
+            key = canonical_key(match.group(1))
+            if key:
+                return key
     try:
         top = subprocess.run(
             ["git", "rev-parse", "--show-toplevel"],
@@ -45,13 +84,38 @@ def detect_project() -> str:
             timeout=2,
         ).stdout.strip()
         if top:
-            return Path(top).name
+            key = canonical_key(Path(top).name)
+            if key:
+                return key
     except Exception:
         pass
-    return project_dir.name
+    return canonical_key(project_dir.name)
 
 
-def has_active(project: str) -> bool:
+def session_key(data: dict) -> str:
+    """Return the canonical key a session record belongs to.
+
+    `metadata.project_key` is authoritative when present (sessions written by a
+    pinned server carry it); otherwise the display label is canonicalized, which
+    is what keeps legacy sessions matchable.
+    """
+    meta = data.get("metadata") or {}
+    key = meta.get("project_key")
+    if isinstance(key, str) and key:
+        return key
+    label = meta.get("project")
+    return canonical_key(label) if isinstance(label, str) else ""
+# --- trace-project-detect v0.5 end ---
+
+import json
+import sys
+from datetime import datetime, timezone
+
+project_dir = Path(sys.argv[1])
+sessions_dir = Path(sys.argv[2])
+
+
+def has_active(key: str) -> bool:
     today = datetime.now(timezone.utc).strftime("%Y%m%d")
     for path in sessions_dir.glob(f"trace_{today}_*.json"):
         try:
@@ -60,14 +124,14 @@ def has_active(project: str) -> bool:
             continue
         if data.get("status") != "active":
             continue
-        if data.get("metadata", {}).get("project") == project:
+        if session_key(data) == key:
             return True
     return False
 
 
-project = detect_project()
-state = "active" if has_active(project) else "none"
-print(f"{project}|{state}")
+key = detect_project(project_dir)
+state = "active" if key and has_active(key) else "none"
+print(f"{key}|{state}")
 PYEOF
 )
 
@@ -78,5 +142,5 @@ if [ -z "$REPORT" ] || [ "$STATE" = "none" ]; then
     if [ -z "$NAME" ]; then
         NAME="this project"
     fi
-    echo "⚠️ TRACE MCP is available but no active session exists for project '$NAME'. Start one with trace_start_session before logging events. If you forget, events will auto-create a session, but explicit sessions have better descriptions and tags."
+    echo "⚠️ TRACE MCP is available but no active session exists for project '$NAME'. Start one with trace_start_session before logging events. If you forget, events will auto-create a session, but explicit sessions have better descriptions and tags. [trace-hooks v0.5]"
 fi

--- a/src/trace_mcp/init_project.py
+++ b/src/trace_mcp/init_project.py
@@ -4,6 +4,14 @@ Writes ``.mcp.json`` and dispatches to a host adapter (Claude Code, Codex, ...)
 to install hook scripts, merge settings, and append the minimal CLAUDE.md
 block. Adapters live in ``trace_mcp.adapters`` and contain no runtime code
 imported by the MCP server.
+
+Init is also the sanctioned place where a project's canonical identity is
+minted: it enrolls the project in the alias registry and writes the three
+artifacts that make every consumer agree on that identity — the
+``TRACE_PROJECT`` env pin in ``.mcp.json`` (the server), a
+``.claude/trace.project`` pin file (the hooks), and a machine-parseable
+CLAUDE.md pin line (a model reading the repository). A running server never
+mints identity; only this command does.
 """
 
 from __future__ import annotations
@@ -11,11 +19,22 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import sys
 from pathlib import Path
 
+from trace_mcp import project_identity as pident
 from trace_mcp.adapters import detect_adapter, get_adapter, list_adapters
 from trace_mcp.adapters.base import Adapter
+
+# Bold-tolerant, and byte-identical in intent to the hooks' shared block: the
+# absence check MUST accept the bolded form, or init appends a second pin line
+# to a file that already has one.
+_PIN_LINE_RE = re.compile(r'TRACE project name\**\s*:\s*"([^"]+)"')
+
+_PIN_FILE = Path(".claude") / "trace.project"
+
+_INIT_ACTOR = "trace-mcp init"
 
 
 class TraceSourceUnresolvedError(RuntimeError):
@@ -63,21 +82,173 @@ def _resolve_trace_source() -> str:
     )
 
 
-def _mcp_server_config() -> dict:
+def _mcp_server_config(project_key: str | None = None) -> dict:
     """Build the `.mcp.json` ``mcpServers`` entry for TRACE.
 
     Resolves the ``--from`` source lazily, at write time — not at import
     time — so importing this module (tests, ``--help``) never raises;
     only actually writing `.mcp.json` can surface
     ``TraceSourceUnresolvedError``.
+
+    When *project_key* is given the entry carries ``env.TRACE_PROJECT``, which
+    pins the server process to one project: with a pin, cross-project reads and
+    writes are refused rather than silently accepted.
     """
     source = _resolve_trace_source()
-    return {
-        "trace": {
-            "command": "uvx",
-            "args": ["--from", source, "--refresh-package", "trace-mcp", "trace-mcp"],
-        }
+    entry: dict = {
+        "command": "uvx",
+        "args": ["--from", source, "--refresh-package", "trace-mcp", "trace-mcp"],
     }
+    if project_key:
+        entry["env"] = {"TRACE_PROJECT": project_key}
+    return {"trace": entry}
+
+
+# ── Project identity ──────────────────────────────────────────────────────
+
+
+def _read_pin_line(claude_md: Path) -> str | None:
+    """Return the project name declared in *claude_md*, or None."""
+    if not claude_md.is_file():
+        return None
+    match = _PIN_LINE_RE.search(claude_md.read_text(errors="replace"))
+    return match.group(1) if match else None
+
+
+def get_project_label(project_dir: Path) -> str:
+    """Return the best-effort display label for *project_dir*.
+
+    Order — the same precedence the hooks use, so init and the hooks cannot
+    disagree about which project a directory is: the ``.claude/trace.project``
+    pin file (which makes re-running init idempotent), then a CLAUDE.md pin
+    line, then the git toplevel basename, then the directory name.
+
+    Side effects: reads files under *project_dir* and may run ``git``.
+    """
+    pin_file = project_dir / _PIN_FILE
+    if pin_file.is_file():
+        pinned = pin_file.read_text(errors="replace").strip()
+        if pinned:
+            return pinned
+    declared = _read_pin_line(project_dir / "CLAUDE.md")
+    if declared:
+        return declared
+    try:
+        import subprocess
+
+        top = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            cwd=project_dir,
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=5,
+        ).stdout.strip()
+        if top:
+            return Path(top).name
+    except Exception:
+        pass
+    return project_dir.name
+
+
+def get_project_key(project_dir: Path, explicit: str | None = None) -> str:
+    """Resolve *project_dir* (or *explicit*) to a canonical project key.
+
+    Pure: consults the registry for an existing alias/key match but never
+    enrolls and never writes. Raises ``TraceInitError`` when the label cannot
+    form a usable key or names a reserved one.
+    """
+    label = explicit or get_project_label(project_dir)
+    try:
+        key = pident.canonical_project_key(label)
+    except pident.ProjectKeyError as exc:
+        raise TraceInitError(f"cannot derive a project key: {exc}") from exc
+    if key in pident.RESERVED_KEYS:
+        raise TraceInitError(
+            f"'{label}' resolves to the reserved key '{key}', which is not a project. "
+            "Pass --project <name> with a real project name."
+        )
+    try:
+        registry = pident.get_registry_cached()
+    except pident.RegistryUnavailableError as exc:
+        raise TraceInitError(
+            f"the project registry at {pident.registry_path()} is unreadable ({exc}); "
+            "refusing to guess this project's identity. Repair or move the file and re-run."
+        ) from exc
+    if registry is not None:
+        hit = registry.resolve(label)
+        if hit is not None:
+            return hit
+    return key
+
+
+def _enroll_project(key: str, label: str) -> str:
+    """Enroll *key* in the alias registry if absent. Returns a one-line status.
+
+    Side effects: writes ``~/.trace/projects.json`` under the fail-closed
+    registry lock. Enrolling here — rather than in a running server — is what
+    keeps identity minting a deliberate, human-initiated act.
+    """
+    try:
+        with pident.locked_registry() as registry:
+            hit = registry.resolve(label) or registry.resolve(key)
+            if hit is not None:
+                return f"  registry: '{hit}' already enrolled"
+            registry.projects[key] = pident.ProjectEntry(
+                key=key,
+                display_label=label,
+                enrolled_by=_INIT_ACTOR,
+            )
+            registry.history.append(
+                pident.RegistryChange(
+                    actor=_INIT_ACTOR,
+                    action="enroll",
+                    details={"key": key, "label": label},
+                )
+            )
+            return f"  registry: enrolled '{key}'"
+    except pident.RegistryUnavailableError as exc:
+        raise TraceInitError(
+            f"the project registry at {pident.registry_path()} is unreadable ({exc}); "
+            "refusing to overwrite it. Repair or move the file and re-run."
+        ) from exc
+    except TimeoutError as exc:
+        raise TraceInitError(
+            f"could not acquire the project registry lock ({exc}). Another process is "
+            "writing it; retry once that finishes."
+        ) from exc
+
+
+def _write_pin_file(project_dir: Path, key: str) -> str:
+    """Write ``.claude/trace.project`` — the hooks' highest-precedence source."""
+    path = project_dir / _PIN_FILE
+    existing = path.read_text(errors="replace").strip() if path.is_file() else None
+    if existing == key:
+        return f"  skipped: {path}"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f"{key}\n")
+    return f"  {'updated' if existing is not None else 'wrote'}: {path}"
+
+
+def _write_claude_pin_line(project_dir: Path, key: str) -> str:
+    """Add the machine-parseable pin line to CLAUDE.md when none is present.
+
+    An existing line is left exactly as written — including a bolded one, which
+    the absence check accepts. Rewriting someone's declared project name is how
+    identity drifts; declaring it once when it is missing is the whole job.
+    """
+    path = project_dir / "CLAUDE.md"
+    declared = _read_pin_line(path)
+    if declared is not None:
+        return f"  skipped: {path} (already declares '{declared}')"
+    line = f'TRACE project name: "{key}"\n'
+    if path.is_file():
+        existing = path.read_text()
+        sep = "\n" if existing.endswith("\n") else "\n\n"
+        path.write_text(existing + sep + line)
+        return f"  updated: {path}"
+    path.write_text(f"# Project Instructions\n\n{line}")
+    return f"  wrote: {path}"
 
 
 def _extract_with_packages(args: object) -> list[str]:
@@ -137,14 +308,17 @@ def _merge_trace_entry(existing: object, fresh: dict) -> dict:
     return merged
 
 
-def _write_mcp_json(project_dir: Path) -> str:
+def _write_mcp_json(project_dir: Path, project_key: str | None = None) -> str:
     """Write or merge the TRACE entry into ``.mcp.json``. Returns a one-line status.
 
     Re-running is non-destructive: an existing ``trace`` entry's ``--with``
     extras, ``env`` block, and unknown keys are preserved, and sibling servers
-    are left untouched. A pre-existing ``.mcp.json`` that is not valid JSON (or
-    not a JSON object) is left on disk and raises ``TraceInitError`` (fail
-    closed) rather than being silently discarded and replaced.
+    are left untouched. When *project_key* is given, ``env.TRACE_PROJECT`` is
+    set to it — the fresh value wins over a stale one, since init is the
+    authority on a project's identity. A pre-existing ``.mcp.json`` that is not
+    valid JSON (or not a JSON object) is left on disk and raises
+    ``TraceInitError`` (fail closed) rather than being silently discarded and
+    replaced.
     """
     mcp_path = project_dir / ".mcp.json"
     if mcp_path.exists():
@@ -173,7 +347,7 @@ def _write_mcp_json(project_dir: Path) -> str:
         servers = config["mcpServers"]
 
     was_present = "trace" in servers
-    fresh_entry = _mcp_server_config()["trace"]
+    fresh_entry = _mcp_server_config(project_key)["trace"]
     servers["trace"] = _merge_trace_entry(servers.get("trace"), fresh_entry) if was_present else fresh_entry
 
     mcp_path.write_text(json.dumps(config, indent=2) + "\n")
@@ -203,8 +377,15 @@ def init_project(
     *,
     client: str | None = None,
     dry_run: bool = False,
+    project: str | None = None,
 ) -> None:
-    """Initialize TRACE in a project directory."""
+    """Initialize TRACE in a project directory.
+
+    *project* overrides the derived display label. Whatever the source, the
+    label is reduced to a canonical key, enrolled in the alias registry, and
+    written to all three pin locations so the server, the hooks, and a model
+    reading the repository resolve one identity.
+    """
     project_dir = Path(directory) if directory else Path.cwd()
 
     if not project_dir.is_dir():
@@ -213,19 +394,51 @@ def init_project(
 
     print(f"Initializing TRACE in {project_dir}")
 
-    # 1. .mcp.json (host-independent). A dry run resolves the source too, so
+    # Preflight the `.mcp.json` source before ANY write. It is the one step
+    # that can fail for reasons outside this directory, and discovering that
+    # after enrolling the project and writing pin files would leave it half
+    # initialized.
+    try:
+        _resolve_trace_source()
+    except TraceSourceUnresolvedError as exc:
+        print(f"Error: {exc}")
+        sys.exit(1)
+
+    # 1. Project identity, before anything that embeds it. Resolution is
+    # read-only, so an unusable name fails before a single file is touched.
+    try:
+        label = project or get_project_label(project_dir)
+        project_key = get_project_key(project_dir, project)
+    except TraceInitError as exc:
+        print(f"Error: {exc}")
+        sys.exit(1)
+    print(f"  project: '{project_key}'" + (f" (from label '{label}')" if label != project_key else ""))
+
+    try:
+        if not dry_run:
+            print(_enroll_project(project_key, label))
+            print(_write_pin_file(project_dir, project_key))
+            print(_write_claude_pin_line(project_dir, project_key))
+        else:
+            print(f"  [dry-run] would enroll '{project_key}' in {pident.registry_path()}")
+            print(f"  [dry-run] would write: {project_dir / _PIN_FILE}")
+    except TraceInitError as exc:
+        print(f"Error: {exc}")
+        sys.exit(1)
+
+    # 2. .mcp.json (host-independent). A dry run resolves the source too, so
     # an unresolvable source is discovered before a real run, not during it.
     try:
         if not dry_run:
-            print(_write_mcp_json(project_dir))
+            print(_write_mcp_json(project_dir, project_key))
         else:
-            entry = _mcp_server_config()["trace"]
+            entry = _mcp_server_config(project_key)["trace"]
             print(f"  [dry-run] would write: {project_dir / '.mcp.json'} (uvx --from {entry['args'][1]})")
     except (TraceSourceUnresolvedError, TraceInitError) as exc:
         print(f"Error: {exc}")
         sys.exit(1)
 
-    # 2. Host adapter
+    # 3. Host adapter
     adapter = _pick_adapter(project_dir, client)
     if adapter is None:
         print("Skipping host adapter installation.")
@@ -255,6 +468,24 @@ def init_project(
     print("TRACE tools will be available automatically.")
 
 
+def print_project_key(directory: str | None = None) -> int:
+    """Print the canonical project key for *directory*. Returns a process exit code.
+
+    The one command that answers "which project does this directory belong to?"
+    the same way the server and the hooks answer it.
+    """
+    project_dir = Path(directory) if directory else Path.cwd()
+    if not project_dir.is_dir():
+        print(f"Error: {project_dir} is not a directory", file=sys.stderr)
+        return 1
+    try:
+        print(get_project_key(project_dir))
+    except TraceInitError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
 def main() -> None:
     """CLI entry point for trace-mcp init."""
     parser = argparse.ArgumentParser(
@@ -273,6 +504,12 @@ def main() -> None:
         action="store_true",
         help="show what would be written without touching files",
     )
+    parser.add_argument(
+        "--project",
+        default=None,
+        metavar="NAME",
+        help="project name to enrol and pin (default: derived from the pin file, CLAUDE.md, git, or the directory name)",
+    )
     # Allow legacy `trace-mcp init init .` invocation used by bare `trace-mcp-init`.
     args = sys.argv[1:]
     if args and args[0] == "init":
@@ -280,4 +517,4 @@ def main() -> None:
 
     ns = parser.parse_args()
     client = None if ns.client == "auto" else ns.client
-    init_project(ns.directory, client=client, dry_run=ns.dry_run)
+    init_project(ns.directory, client=client, dry_run=ns.dry_run, project=ns.project)

--- a/src/trace_mcp/server.py
+++ b/src/trace_mcp/server.py
@@ -948,11 +948,19 @@ def _load_extensions() -> None:
 def main() -> None:
     """Run the TRACE MCP server (or handle subcommands like 'init' or 'validate')."""
     if len(sys.argv) > 1 and sys.argv[1] == "init":
-        from trace_mcp.init_project import init_project
+        # Delegate to init's own argument parser rather than re-deriving one
+        # here: the previous hand-rolled dispatch read argv[2] as the directory,
+        # so every flag (`--project`, `--dry-run`, `--client`) was silently
+        # swallowed as a path. init's parser already strips the leading "init".
+        from trace_mcp.init_project import main as init_main
 
-        directory = sys.argv[2] if len(sys.argv) > 2 else None
-        init_project(directory)
+        init_main()
         return
+
+    if len(sys.argv) > 1 and sys.argv[1] == "project-key":
+        from trace_mcp.init_project import print_project_key
+
+        raise SystemExit(print_project_key(sys.argv[2] if len(sys.argv) > 2 else None))
 
     if len(sys.argv) > 1 and sys.argv[1] == "validate":
         # In-package validator (schema ships as package data) — the previous

--- a/tests/test_adapter_hooks.py
+++ b/tests/test_adapter_hooks.py
@@ -31,12 +31,16 @@ def _make_session(
     session_id: str,
     project: str,
     status: str = "active",
+    project_key: str | None = None,
 ) -> Path:
+    metadata: dict[str, object] = {"project": project}
+    if project_key is not None:
+        metadata["project_key"] = project_key
     data = {
         "id": session_id,
         "created": f"{datetime.now(UTC).isoformat()}",
         "status": status,
-        "metadata": {"project": project},
+        "metadata": metadata,
         "events": [],
     }
     path = sessions_dir / f"{session_id}.json"
@@ -383,6 +387,153 @@ class TestPreToolGuard:
             stdin=stdin_payload,
         )
         assert result.returncode == 0
+
+
+# ── canonical project identity (shared detection block) ───────────────────
+
+
+class TestCanonicalProjectIdentity:
+    """Identity is a canonical key, so labels that differ only cosmetically match.
+
+    Each test drives a real hook end to end: what is asserted is what the
+    shipped asset does, not a re-implementation of it.
+    """
+
+    def test_bolded_claude_md_pin_line_is_detected(self, tmp_path: Path) -> None:
+        """The verified root cause of a live drift pair.
+
+        A plain-only regex skipped the bolded marker, so the hooks fell through
+        to the git basename while a model reading the same file saw the marker's
+        value — deterministically minting two labels for one repository.
+        """
+        project_dir = tmp_path / "proj"
+        project_dir.mkdir()
+        subprocess.run(["git", "init"], cwd=project_dir, capture_output=True, check=True)
+        (project_dir / "CLAUDE.md").write_text('> **TRACE project name**: "pinned-name"\n')
+        sessions = tmp_path / "sessions"
+        sessions.mkdir()
+        _make_session(sessions, session_id=f"trace_{_today()}_aaaaaa", project="pinned-name")
+
+        result = _run_hook(SESSION_REMINDER, project_dir=project_dir, sessions_dir=sessions)
+        assert result.stdout.strip() == "", (
+            "bolded pin line was not detected; the hook fell through to the git basename"
+        )
+
+    def test_hooks_prefer_pin_file_over_claude_md(self, tmp_path: Path) -> None:
+        project_dir = tmp_path / "proj"
+        (project_dir / ".claude").mkdir(parents=True)
+        (project_dir / "CLAUDE.md").write_text('TRACE project name: "md-name"\n')
+        (project_dir / ".claude" / "trace.project").write_text("pin-name\n")
+        sessions = tmp_path / "sessions"
+        sessions.mkdir()
+        # An active session for the CLAUDE.md name must NOT satisfy the pin.
+        _make_session(sessions, session_id=f"trace_{_today()}_aaaaaa", project="md-name")
+
+        result = _run_hook(SESSION_REMINDER, project_dir=project_dir, sessions_dir=sessions)
+        assert "no active session" in result.stdout
+        assert "pin-name" in result.stdout
+
+        # ...and one for the pin name does.
+        _make_session(sessions, session_id=f"trace_{_today()}_bbbbbb", project="pin-name")
+        result = _run_hook(SESSION_REMINDER, project_dir=project_dir, sessions_dir=sessions)
+        assert result.stdout.strip() == ""
+
+    def test_hooks_match_project_key_sessions(self, tmp_path: Path) -> None:
+        """A stamped project_key is authoritative over the display label."""
+        project_dir = tmp_path / "proj"
+        project_dir.mkdir()
+        (project_dir / "CLAUDE.md").write_text('TRACE project name: "my-proj"\n')
+        sessions = tmp_path / "sessions"
+        sessions.mkdir()
+        _make_session(
+            sessions,
+            session_id=f"trace_{_today()}_aaaaaa",
+            project="Some Legacy Display Label",
+            project_key="my-proj",
+        )
+
+        result = _run_hook(SESSION_REMINDER, project_dir=project_dir, sessions_dir=sessions)
+        assert result.stdout.strip() == "", "session with a matching project_key was not matched"
+
+    def test_hooks_fall_back_to_canonicalized_label_for_legacy_sessions(self, tmp_path: Path) -> None:
+        """Legacy sessions carry no key, so the label is canonicalized to match."""
+        project_dir = tmp_path / "proj"
+        project_dir.mkdir()
+        (project_dir / "CLAUDE.md").write_text('TRACE project name: "my-proj"\n')
+        sessions = tmp_path / "sessions"
+        sessions.mkdir()
+        # Case and separator variants of the same project.
+        _make_session(sessions, session_id=f"trace_{_today()}_aaaaaa", project="My_Proj")
+
+        result = _run_hook(SESSION_REMINDER, project_dir=project_dir, sessions_dir=sessions)
+        assert result.stdout.strip() == "", "a display-label variant split one project in two"
+
+    def test_distinct_projects_still_do_not_match(self, tmp_path: Path) -> None:
+        """Canonicalization must not over-merge: a different project is still different."""
+        project_dir = tmp_path / "proj"
+        project_dir.mkdir()
+        (project_dir / "CLAUDE.md").write_text('TRACE project name: "my-proj"\n')
+        sessions = tmp_path / "sessions"
+        sessions.mkdir()
+        _make_session(sessions, session_id=f"trace_{_today()}_aaaaaa", project="my-proj-two")
+
+        result = _run_hook(SESSION_REMINDER, project_dir=project_dir, sessions_dir=sessions)
+        assert "no active session" in result.stdout
+
+    def test_pretool_guard_strict_mode_still_finds_sessions_post_change(self, tmp_path: Path) -> None:
+        """Regression: strict mode must not hard-block on a session it should match.
+
+        Strict mode exits 2, which blocks the edit outright — a detection change
+        that stopped matching valid sessions would turn this guard into a wall.
+        """
+        project_dir = tmp_path / "proj"
+        project_dir.mkdir()
+        (project_dir / "CLAUDE.md").write_text('> **TRACE project name**: "my-proj"\n')
+        sessions = tmp_path / "sessions"
+        sessions.mkdir()
+        _make_session(sessions, session_id=f"trace_{_today()}_aaaaaa", project="My-Proj")
+
+        result = _run_hook(
+            PRETOOL_GUARD,
+            project_dir=project_dir,
+            sessions_dir=sessions,
+            env_overrides={"TRACE_GUARD": "strict"},
+        )
+        assert result.returncode == 0, f"strict mode blocked despite an active session: {result.stderr!r}"
+        assert result.stdout.strip() == ""
+
+    def test_prompt_reminder_state_file_is_named_by_canonical_key(self, tmp_path: Path) -> None:
+        project_dir = tmp_path / "proj"
+        project_dir.mkdir()
+        (project_dir / "CLAUDE.md").write_text('TRACE project name: "My Weird/Name"\n')
+        sessions = tmp_path / "sessions"
+        sessions.mkdir()
+        runtime = tmp_path / "runtime"
+
+        _run_hook(PROMPT_REMINDER, project_dir=project_dir, sessions_dir=sessions, runtime_dir=runtime)
+
+        assert [p.name for p in runtime.glob("*.state.json")] == ["my-weird-name.state.json"]
+
+    @pytest.mark.parametrize(
+        ("script", "needs_runtime"),
+        [(SESSION_REMINDER, False), (PROMPT_REMINDER, True), (PRETOOL_GUARD, False)],
+    )
+    def test_hooks_emit_version_stamp(self, tmp_path: Path, script: Path, needs_runtime: bool) -> None:
+        """A stale fleet copy self-identifies by the absence of this stamp."""
+        project_dir = tmp_path / "proj"
+        project_dir.mkdir()
+        (project_dir / "CLAUDE.md").write_text('TRACE project name: "my-proj"\n')
+        sessions = tmp_path / "sessions"
+        sessions.mkdir()
+
+        result = _run_hook(
+            script,
+            project_dir=project_dir,
+            sessions_dir=sessions,
+            runtime_dir=tmp_path / "runtime" if needs_runtime else None,
+            env_overrides={"TRACE_PROMPT_MIN_TURNS": "1"} if needs_runtime else None,
+        )
+        assert "[trace-hooks v0.5]" in result.stdout
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_hook_assets_consistency.py
+++ b/tests/test_hook_assets_consistency.py
@@ -1,0 +1,203 @@
+"""Anti-divergence guard for the bundled Claude Code hook scripts.
+
+All four hooks embed one shared canonical-identity block. Divergence between
+copies is not hypothetical: a pin-line regex that did not tolerate markdown
+bold once made one hook read a repository's CLAUDE.md project name while
+another fell through to the git basename, minting two labels — and therefore
+two knowledge stores and two session pools — for a single repository.
+
+These tests read the shipped assets as text and assert structural properties a
+future edit could silently break: the block is byte-identical everywhere, the
+embedded canonicalizer still agrees with the core implementation, every hook
+stamps its version, and the project filter has not regressed to picking the
+globally newest session.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from trace_mcp.project_identity import ProjectKeyError, canonical_project_key
+
+_HOOKS_DIR = Path(__file__).parent.parent / "src" / "trace_mcp" / "adapters" / "claude_code" / "assets" / "hooks"
+
+HOOK_NAMES = [
+    "session-reminder.sh",
+    "prompt-reminder.sh",
+    "pretool-guard.sh",
+    "decision-audit.sh",
+]
+
+BLOCK_BEGIN = "# --- trace-project-detect v0.5 begin ---"
+BLOCK_END = "# --- trace-project-detect v0.5 end ---"
+
+VERSION_STAMP = "[trace-hooks v0.5]"
+
+
+def _hook_text(name: str) -> str:
+    return (_HOOKS_DIR / name).read_text(encoding="utf-8")
+
+
+def _extract_block(text: str, name: str) -> str:
+    """Return the shared detection block, delimiters included."""
+    start = text.find(BLOCK_BEGIN)
+    end = text.find(BLOCK_END)
+    assert start != -1, f"{name} has no shared-block begin delimiter {BLOCK_BEGIN!r}"
+    assert end != -1, f"{name} has no shared-block end delimiter {BLOCK_END!r}"
+    assert start < end, f"{name} has the shared-block delimiters in the wrong order"
+    return text[start : end + len(BLOCK_END)]
+
+
+def test_all_four_hooks_exist() -> None:
+    """Positive control: the guard is blind if the assets move or get renamed."""
+    for name in HOOK_NAMES:
+        assert (_HOOKS_DIR / name).is_file(), f"missing hook asset {name}"
+
+
+def test_detection_block_byte_identical_across_four_hooks() -> None:
+    """The shared block must be one text, not four that merely resemble each other."""
+    blocks = {name: _extract_block(_hook_text(name), name) for name in HOOK_NAMES}
+    reference_name = HOOK_NAMES[0]
+    reference = blocks[reference_name]
+    assert len(reference) > 500, "extracted block is implausibly short — check the delimiters"
+    for name, block in blocks.items():
+        assert block == reference, (
+            f"{name}'s shared detection block differs from {reference_name}'s. "
+            "Edit every copy together — divergence here is what mints two project "
+            "labels for one repository."
+        )
+
+
+def test_all_hooks_emit_version_stamp() -> None:
+    """Every emitted message carries the stamp, so a stale fleet copy self-identifies."""
+    for name in HOOK_NAMES:
+        assert VERSION_STAMP in _hook_text(name), f"{name} emits no {VERSION_STAMP} version stamp"
+
+
+def test_decision_audit_has_project_filter_no_bare_ls_t() -> None:
+    """decision-audit must not go back to selecting the globally newest session."""
+    text = _hook_text("decision-audit.sh")
+    assert "ls -t" not in text, (
+        "decision-audit.sh selects the newest session with `ls -t` again — that "
+        "ignores the project and reports another project's audit findings whenever "
+        "two servers run side by side."
+    )
+    assert "newest_for_project" in text, "decision-audit.sh no longer filters sessions by project key"
+    assert "CLAUDE_PROJECT_DIR" in text, "decision-audit.sh no longer resolves a project directory"
+
+
+def test_no_hook_defines_a_private_sanitizer() -> None:
+    """A second name-folding function is exactly the divergence this PR removed."""
+    for name in HOOK_NAMES:
+        assert "_sanitize" not in _hook_text(name), (
+            f"{name} defines a private sanitizer again — fold names through "
+            "canonical_key in the shared block so filenames and identity agree."
+        )
+
+
+def _run_embedded_canonicalizer(labels: list[str]) -> list[str]:
+    """Execute the shipped block in a fresh interpreter and canonicalize *labels*.
+
+    Runs the real asset text rather than a copy, so the test measures what the
+    hooks actually do.
+    """
+    block = _extract_block(_hook_text(HOOK_NAMES[0]), HOOK_NAMES[0])
+    program = block + "\n\nimport json, sys\nprint(json.dumps([canonical_key(x) for x in json.loads(sys.argv[1])]))\n"
+    import json
+
+    result = subprocess.run(
+        [sys.executable, "-c", program, json.dumps(labels)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=True,
+    )
+    return json.loads(result.stdout)
+
+
+# A corpus spanning the drift classes ADR-006 closes: case variants, separator
+# variants, unicode, punctuation runs, and degenerate input.
+_LABEL_CORPUS = [
+    "trace-mcp",
+    "TRACE",
+    "TRACE-mcp",
+    "trace_mcp",
+    "trace mcp",
+    "trace/mcp",
+    "  Trace   MCP  ",
+    "my/weird name",
+    "COEQWAL",
+    "coeqwal-website",
+    "green-narrative",
+    "hye_in",
+    "When-Algorithms-Meet-Artists",
+    "café-project",
+    "Ünicode_Näme",
+    "proj..name",
+    "proj--name",
+    "---leading-and-trailing---",
+    "...dots...",
+    "a",
+    "PROJECT 2026.07",
+    "emoji-🎯-project",
+]
+
+_DEGENERATE_LABELS = ["", "   ", "---", "...", "///", "___"]
+
+
+def test_embedded_canonicalizer_matches_core() -> None:
+    """The hooks' canonicalizer must agree with canonical_project_key exactly.
+
+    The hooks cannot import trace_mcp (they run as bare python3 with no
+    installed package), so the algorithm is duplicated. This is the guard that
+    keeps the duplicate honest — a divergence here splits one project's
+    sessions between the hooks' view and the server's.
+    """
+    got = _run_embedded_canonicalizer(_LABEL_CORPUS)
+    expected = [canonical_project_key(label) for label in _LABEL_CORPUS]
+    assert got == expected, "embedded canonicalizer diverged from canonical_project_key"
+
+
+def test_embedded_canonicalizer_returns_empty_where_core_raises() -> None:
+    """Degenerate labels yield "" in a hook where the core raises.
+
+    A hook advises; it must never fail the tool call it runs alongside. The
+    empty key then matches no session, which is the safe outcome.
+    """
+    got = _run_embedded_canonicalizer(_DEGENERATE_LABELS)
+    assert got == [""] * len(_DEGENERATE_LABELS)
+    for label in _DEGENERATE_LABELS:
+        with pytest.raises(ProjectKeyError):
+            canonical_project_key(label)
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        'TRACE project name: "trace-mcp"',
+        '**TRACE project name**: "trace-mcp"',
+        '> **TRACE project name**: "trace-mcp"',
+        '- **TRACE project name**: "trace-mcp"',
+        'TRACE project name:  "trace-mcp"',
+        '**TRACE project name** : "trace-mcp"',
+    ],
+)
+def test_regex_matches_plain_and_bolded_pin_lines(line: str) -> None:
+    """The shipped pin regex must accept bolded forms.
+
+    The plain-only regex is the verified mechanical cause of a live drift pair:
+    a model reading the bolded marker saw one name while the hooks fell through
+    to the git basename and saw another.
+    """
+    block = _extract_block(_hook_text(HOOK_NAMES[0]), HOOK_NAMES[0])
+    match = re.search(r"^_PIN_LINE = re\.compile\((r'[^']+')\)$", block, re.MULTILINE)
+    assert match, "could not find _PIN_LINE in the shared block"
+    pattern = re.compile(eval(match.group(1)))  # noqa: S307 - literal from our own asset
+    found = pattern.search(line)
+    assert found, f"pin regex did not match {line!r}"
+    assert found.group(1) == "trace-mcp"

--- a/tests/test_init_project.py
+++ b/tests/test_init_project.py
@@ -20,12 +20,21 @@ from pathlib import Path
 
 import pytest
 
+from trace_mcp import project_identity as pident
 from trace_mcp.init_project import (
     TraceInitError,
+    TraceSourceUnresolvedError,
+    _enroll_project,
     _extract_with_packages,
     _mcp_server_config,
     _merge_trace_entry,
+    _write_claude_pin_line,
     _write_mcp_json,
+    _write_pin_file,
+    get_project_key,
+    get_project_label,
+    init_project,
+    print_project_key,
 )
 
 _SOURCE = "/abs/path/to/TRACE"
@@ -214,3 +223,272 @@ def test_merge_non_dict_existing_returns_fresh() -> None:
     fresh = _mcp_server_config()["trace"]
     assert _merge_trace_entry("garbage", fresh) == fresh
     assert _merge_trace_entry(None, fresh) == fresh
+
+
+# ── project identity: derivation, enrollment, and the three pin locations ──
+
+
+def test_label_prefers_pin_file_then_claude_md(tmp_path: Path) -> None:
+    (tmp_path / "CLAUDE.md").write_text('TRACE project name: "md-name"\n')
+    assert get_project_label(tmp_path) == "md-name"
+
+    (tmp_path / ".claude").mkdir()
+    (tmp_path / ".claude" / "trace.project").write_text("pin-name\n")
+    assert get_project_label(tmp_path) == "pin-name"
+
+
+def test_label_reads_a_bolded_pin_line(tmp_path: Path) -> None:
+    """A bolded marker must be readable; missing it is what minted drift pairs."""
+    (tmp_path / "CLAUDE.md").write_text('> **TRACE project name**: "bolded-name"\n')
+    assert get_project_label(tmp_path) == "bolded-name"
+
+
+def test_label_falls_back_to_directory_name(tmp_path: Path) -> None:
+    project_dir = tmp_path / "some-project"
+    project_dir.mkdir()
+    assert get_project_label(project_dir) == "some-project"
+
+
+def test_key_is_canonical_and_explicit_label_wins(tmp_path: Path) -> None:
+    (tmp_path / "CLAUDE.md").write_text('TRACE project name: "Ignored Name"\n')
+    assert get_project_key(tmp_path, "My Project") == "my-project"
+    assert get_project_key(tmp_path) == "ignored-name"
+
+
+def test_key_rejects_reserved_names(tmp_path: Path) -> None:
+    for reserved in ("auto", "AUTO", "shared"):
+        with pytest.raises(TraceInitError, match="reserved"):
+            get_project_key(tmp_path, reserved)
+
+
+def test_key_rejects_a_degenerate_label(tmp_path: Path) -> None:
+    with pytest.raises(TraceInitError, match="cannot derive"):
+        get_project_key(tmp_path, "---")
+
+
+def test_key_resolves_through_an_existing_alias(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A registered alias wins over bare canonicalization.
+
+    Without this, re-initializing a renamed project would mint a second key
+    for it — precisely the split the registry exists to prevent.
+    """
+    monkeypatch.setenv("TRACE_REGISTRY_PATH", str(tmp_path / "projects.json"))
+    pident._reset_registry_cache()
+    with pident.locked_registry() as registry:
+        registry.projects["trace-mcp"] = pident.ProjectEntry(
+            key="trace-mcp", display_label="trace-mcp", aliases=["TRACE"]
+        )
+    pident._reset_registry_cache()
+
+    assert get_project_key(tmp_path, "TRACE") == "trace-mcp"
+
+
+def test_enroll_is_idempotent_and_records_history(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TRACE_REGISTRY_PATH", str(tmp_path / "projects.json"))
+    pident._reset_registry_cache()
+
+    assert "enrolled" in _enroll_project("my-project", "My Project")
+    pident._reset_registry_cache()
+    assert "already enrolled" in _enroll_project("my-project", "My Project")
+
+    pident._reset_registry_cache()
+    registry = pident.load_registry(required=False)
+    assert registry is not None
+    entry = registry.projects["my-project"]
+    assert entry.display_label == "My Project"
+    assert [h.action for h in registry.history] == ["enroll"]
+
+
+def test_enroll_fails_closed_on_an_unreadable_registry(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A damaged registry must never be silently replaced."""
+    registry_file = tmp_path / "projects.json"
+    registry_file.write_text("{not valid json")
+    monkeypatch.setenv("TRACE_REGISTRY_PATH", str(registry_file))
+    pident._reset_registry_cache()
+
+    with pytest.raises(TraceInitError, match="unreadable"):
+        _enroll_project("my-project", "My Project")
+    assert registry_file.read_text() == "{not valid json", "the damaged registry was overwritten"
+
+
+def test_write_pin_file_creates_and_is_idempotent(tmp_path: Path) -> None:
+    assert "wrote" in _write_pin_file(tmp_path, "my-project")
+    pin = tmp_path / ".claude" / "trace.project"
+    assert pin.read_text() == "my-project\n"
+    assert "skipped" in _write_pin_file(tmp_path, "my-project")
+    assert "updated" in _write_pin_file(tmp_path, "other-project")
+    assert pin.read_text() == "other-project\n"
+
+
+def test_claude_pin_line_written_once(tmp_path: Path) -> None:
+    claude_md = tmp_path / "CLAUDE.md"
+    claude_md.write_text("# Project Instructions\n\nSome guidance.\n")
+
+    assert "updated" in _write_claude_pin_line(tmp_path, "my-project")
+    text = claude_md.read_text()
+    assert 'TRACE project name: "my-project"' in text
+    assert text.startswith("# Project Instructions")
+
+    assert "skipped" in _write_claude_pin_line(tmp_path, "my-project")
+    assert claude_md.read_text() == text, "a second pin line was appended"
+
+
+def test_claude_pin_line_respects_an_existing_bolded_line(tmp_path: Path) -> None:
+    """The absence check is bold-tolerant, so a bolded declaration is not duplicated."""
+    claude_md = tmp_path / "CLAUDE.md"
+    claude_md.write_text('# Project\n\n> **TRACE project name**: "already-named"\n')
+    before = claude_md.read_text()
+
+    status = _write_claude_pin_line(tmp_path, "my-project")
+    assert "skipped" in status
+    assert "already-named" in status
+    assert claude_md.read_text() == before
+
+
+def test_mcp_json_carries_the_env_pin(tmp_path: Path) -> None:
+    _write_mcp_json(tmp_path, "my-project")
+    entry = _read(tmp_path)["mcpServers"]["trace"]
+    assert entry["env"] == {"TRACE_PROJECT": "my-project"}
+
+
+def test_mcp_json_pin_updates_but_preserves_sibling_env(tmp_path: Path) -> None:
+    (tmp_path / ".mcp.json").write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "trace": {
+                        "command": "uvx",
+                        "args": ["--from", "/old", "trace-mcp"],
+                        "env": {"TRACE_PROJECT": "stale-name", "OTHER_VAR": "keep-me"},
+                    }
+                }
+            }
+        )
+    )
+    _write_mcp_json(tmp_path, "fresh-name")
+    env = _read(tmp_path)["mcpServers"]["trace"]["env"]
+    assert env["TRACE_PROJECT"] == "fresh-name", "init must own the pin it wrote"
+    assert env["OTHER_VAR"] == "keep-me", "a hand-added env var was dropped"
+
+
+def test_no_pin_leaves_env_absent(tmp_path: Path) -> None:
+    _write_mcp_json(tmp_path)
+    assert "env" not in _read(tmp_path)["mcpServers"]["trace"]
+
+
+def test_init_writes_pin_file_env_and_claude_line(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """End-to-end: one init makes all three pin locations agree."""
+    monkeypatch.setenv("TRACE_REGISTRY_PATH", str(tmp_path / "projects.json"))
+    pident._reset_registry_cache()
+    project_dir = tmp_path / "My Project"
+    project_dir.mkdir()
+
+    init_project(str(project_dir), client="none")
+
+    assert (project_dir / ".claude" / "trace.project").read_text() == "my-project\n"
+    entry = json.loads((project_dir / ".mcp.json").read_text())["mcpServers"]["trace"]
+    assert entry["env"] == {"TRACE_PROJECT": "my-project"}
+    assert 'TRACE project name: "my-project"' in (project_dir / "CLAUDE.md").read_text()
+
+    pident._reset_registry_cache()
+    registry = pident.load_registry(required=False)
+    assert registry is not None
+    assert "my-project" in registry.projects
+
+
+def test_init_project_flag_overrides_derivation(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TRACE_REGISTRY_PATH", str(tmp_path / "projects.json"))
+    pident._reset_registry_cache()
+    project_dir = tmp_path / "dirname-would-be-this"
+    project_dir.mkdir()
+
+    init_project(str(project_dir), client="none", project="Chosen Name")
+
+    assert (project_dir / ".claude" / "trace.project").read_text() == "chosen-name\n"
+
+
+def test_init_is_idempotent_for_identity(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Re-running init must not mint a second key or a second pin line."""
+    monkeypatch.setenv("TRACE_REGISTRY_PATH", str(tmp_path / "projects.json"))
+    pident._reset_registry_cache()
+    project_dir = tmp_path / "proj"
+    project_dir.mkdir()
+
+    init_project(str(project_dir), client="none")
+    first_md = (project_dir / "CLAUDE.md").read_text()
+    first_mcp = (project_dir / ".mcp.json").read_text()
+
+    pident._reset_registry_cache()
+    init_project(str(project_dir), client="none")
+
+    assert (project_dir / "CLAUDE.md").read_text() == first_md
+    assert (project_dir / ".mcp.json").read_text() == first_mcp
+    pident._reset_registry_cache()
+    registry = pident.load_registry(required=False)
+    assert registry is not None
+    assert list(registry.projects) == ["proj"]
+    assert [h.action for h in registry.history] == ["enroll"]
+
+
+def test_init_dry_run_touches_nothing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    registry_file = tmp_path / "projects.json"
+    monkeypatch.setenv("TRACE_REGISTRY_PATH", str(registry_file))
+    pident._reset_registry_cache()
+    project_dir = tmp_path / "proj"
+    project_dir.mkdir()
+
+    init_project(str(project_dir), client="none", dry_run=True)
+
+    assert not (project_dir / ".claude" / "trace.project").exists()
+    assert not (project_dir / ".mcp.json").exists()
+    assert not registry_file.exists()
+
+
+def test_project_key_cli_prints_key(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    project_dir = tmp_path / "proj"
+    project_dir.mkdir()
+    (project_dir / "CLAUDE.md").write_text('> **TRACE project name**: "My Project"\n')
+
+    assert print_project_key(str(project_dir)) == 0
+    assert capsys.readouterr().out.strip() == "my-project"
+
+
+def test_project_key_cli_reports_a_bad_directory(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    assert print_project_key(str(tmp_path / "nope")) == 1
+    assert "not a directory" in capsys.readouterr().err
+
+
+def test_key_lookup_fails_closed_on_an_unreadable_registry(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Reading identity must fail closed too, not just writing it.
+
+    A corrupt registry cannot be distinguished from "this project has no
+    aliases", so guessing the bare canonical key here would silently split a
+    renamed project off from its own history.
+    """
+    registry_file = tmp_path / "projects.json"
+    registry_file.write_text("{not valid json")
+    monkeypatch.setenv("TRACE_REGISTRY_PATH", str(registry_file))
+    pident._reset_registry_cache()
+
+    with pytest.raises(TraceInitError, match="unreadable"):
+        get_project_key(tmp_path, "My Project")
+
+
+def test_init_preflights_the_source_before_writing_anything(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """An unresolvable `--from` source must not leave a half-initialized project."""
+    monkeypatch.setenv("TRACE_REGISTRY_PATH", str(tmp_path / "projects.json"))
+    monkeypatch.delenv("TRACE_SOURCE_PATH", raising=False)
+    monkeypatch.setattr(
+        "trace_mcp.init_project._resolve_trace_source",
+        lambda: (_ for _ in ()).throw(TraceSourceUnresolvedError("no safe source")),
+    )
+    pident._reset_registry_cache()
+    project_dir = tmp_path / "proj"
+    project_dir.mkdir()
+
+    with pytest.raises(SystemExit):
+        init_project(str(project_dir), client="none")
+
+    assert not (project_dir / ".claude" / "trace.project").exists()
+    assert not (project_dir / "CLAUDE.md").exists()
+    assert not (tmp_path / "projects.json").exists()

--- a/tests/test_v041_decision_audit_hook.py
+++ b/tests/test_v041_decision_audit_hook.py
@@ -35,16 +35,34 @@ def _write_session(dir_path: Path, name: str, session: dict) -> Path:
     return path
 
 
-def _run_hook(sessions_dir: Path, bash_path: str = "/bin/bash") -> subprocess.CompletedProcess:
+def _run_hook(
+    sessions_dir: Path,
+    bash_path: str = "/bin/bash",
+    project: str = "smoke",
+) -> subprocess.CompletedProcess:
     """Invoke the hook against the given sessions dir using a specific bash.
 
     Defaults to /bin/bash, which on macOS is bash 3.2 — the minimum
     bash version we support. If the test passes on /bin/bash, it
     passes on every Linux bash 4+ trivially.
+
+    The hook selects the newest session *for its own project*, so the run needs
+    a project directory whose identity matches the fixture sessions. A
+    `.claude/trace.project` pin file is the highest-precedence source, which
+    keeps these tests independent of the repository's own CLAUDE.md. The env
+    stays otherwise minimal — that minimalism is what exercises the bash 3.2
+    path.
     """
+    project_dir = sessions_dir / "_projectdir"
+    (project_dir / ".claude").mkdir(parents=True, exist_ok=True)
+    (project_dir / ".claude" / "trace.project").write_text(f"{project}\n")
     return subprocess.run(
         [bash_path, str(HOOK_PATH)],
-        env={"TRACE_SESSIONS_DIR": str(sessions_dir), "PATH": "/usr/bin:/bin"},
+        env={
+            "TRACE_SESSIONS_DIR": str(sessions_dir),
+            "CLAUDE_PROJECT_DIR": str(project_dir),
+            "PATH": "/usr/bin:/bin",
+        },
         capture_output=True,
         text=True,
         timeout=15,
@@ -303,7 +321,7 @@ class TestHookExecutesUnderMacOSBash:
         }
         _write_session(tmp_path, "trace_v3", session)
 
-        result = _run_hook(tmp_path)
+        result = _run_hook(tmp_path, project="old")
         assert result.returncode == 0
         # ai→ai self-resolution under both v0.3 (ai-only check) and v0.4.1
         # (same-instance check) — backward-compat message preserves the v0.3 text
@@ -332,7 +350,7 @@ class TestHookExecutesUnderMacOSBash:
         }
         _write_session(tmp_path, "trace_clean", session)
 
-        result = _run_hook(tmp_path)
+        result = _run_hook(tmp_path, project="clean")
         assert result.returncode == 0
         # No TRACE Decision Audit prefix → no warnings to report
         assert "TRACE Decision Audit" not in result.stdout
@@ -352,3 +370,116 @@ class TestHookExecutesUnderMacOSBash:
         assert result.returncode == 0
         # Failed parse → zero metrics → no audit output
         assert "TRACE Decision Audit" not in result.stdout
+
+
+def _decision_session(project: str, *, unresolved: bool) -> dict:
+    """A session for *project* carrying exactly one decision, resolved or not."""
+    decision: dict = {
+        "description": "x",
+        "proposed_by": {"type": "human", "id": "r"},
+        "disposition": "proposed" if unresolved else "accepted",
+    }
+    if not unresolved:
+        decision["resolved_by"] = {"type": "human", "id": "r"}
+    return {
+        "id": f"trace_{project}",
+        "trace_version": "0.4.1",
+        "metadata": {"project": project},
+        "events": [
+            {
+                "id": "evt_001",
+                "type": "decision",
+                "actor": {"type": "human", "id": "r"},
+                "decision": decision,
+            },
+        ],
+    }
+
+
+class TestProjectScoping:
+    """The audit must report THIS project's session, never a neighbour's.
+
+    Before the project filter, the hook read whichever session file was newest
+    across the whole flat store — so two servers running side by side made each
+    one report the other's findings.
+    """
+
+    def test_ignores_a_newer_session_from_another_project(self, tmp_path: Path) -> None:
+        # Ours is clean; the foreign one is dirty and written LAST (so it is
+        # newest by mtime — what the old `ls -t` selection would have picked).
+        _write_session(tmp_path, "trace_20260722_ours00", _decision_session("mine", unresolved=False))
+        _write_session(tmp_path, "trace_20260722_theirs", _decision_session("theirs", unresolved=True))
+
+        result = _run_hook(tmp_path, project="mine")
+        assert result.returncode == 0
+        assert "unresolved decision" not in result.stdout.lower(), (
+            f"reported another project's findings: {result.stdout!r}"
+        )
+
+    def test_reports_our_session_when_a_foreign_one_is_newer(self, tmp_path: Path) -> None:
+        # Mirror image: ours is the dirty one, and it must still be found.
+        _write_session(tmp_path, "trace_20260722_ours00", _decision_session("mine", unresolved=True))
+        _write_session(tmp_path, "trace_20260722_theirs", _decision_session("theirs", unresolved=False))
+
+        result = _run_hook(tmp_path, project="mine")
+        assert result.returncode == 0
+        assert "unresolved decision" in result.stdout.lower()
+
+    def test_silent_when_no_session_belongs_to_this_project(self, tmp_path: Path) -> None:
+        _write_session(tmp_path, "trace_20260722_theirs", _decision_session("theirs", unresolved=True))
+
+        result = _run_hook(tmp_path, project="mine")
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+
+    def test_matches_a_display_label_variant_of_the_same_project(self, tmp_path: Path) -> None:
+        """Case and separator variants are one project, so the audit still fires."""
+        _write_session(tmp_path, "trace_20260722_ours00", _decision_session("My_Project", unresolved=True))
+
+        result = _run_hook(tmp_path, project="my-project")
+        assert result.returncode == 0
+        assert "unresolved decision" in result.stdout.lower()
+
+    def test_prefers_project_key_over_display_label(self, tmp_path: Path) -> None:
+        """A session stamped with project_key is matched on the key, not the label."""
+        session = _decision_session("Some Legacy Display Label", unresolved=True)
+        session["metadata"]["project_key"] = "mine"
+
+        _write_session(tmp_path, "trace_20260722_ours00", session)
+
+        result = _run_hook(tmp_path, project="mine")
+        assert result.returncode == 0
+        assert "unresolved decision" in result.stdout.lower()
+
+    def test_newest_dated_session_wins_within_a_project(self, tmp_path: Path) -> None:
+        """Selection is by filename date first; an older dated file must not win."""
+        _write_session(tmp_path, "trace_20260722_newer0", _decision_session("mine", unresolved=False))
+        # Written last (newest mtime) but an older filename date — must lose.
+        _write_session(tmp_path, "trace_20200101_older0", _decision_session("mine", unresolved=True))
+
+        result = _run_hook(tmp_path, project="mine")
+        assert result.returncode == 0
+        assert "unresolved decision" not in result.stdout.lower(), (
+            f"an older dated session won the selection: {result.stdout!r}"
+        )
+
+    def test_a_dated_session_beats_an_undated_one(self, tmp_path: Path) -> None:
+        """Undated filenames sort oldest, whichever way the names compare.
+
+        Lexically `trace_smoke` sorts ABOVE `trace_20260722_...`, so ordering on
+        the raw filename would let an undated file win and mask the real
+        session's findings.
+        """
+        _write_session(tmp_path, "trace_smoke", _decision_session("mine", unresolved=False))
+        _write_session(tmp_path, "trace_20260722_real00", _decision_session("mine", unresolved=True))
+
+        result = _run_hook(tmp_path, project="mine")
+        assert result.returncode == 0
+        assert "unresolved decision" in result.stdout.lower()
+
+    def test_emits_version_stamp_with_findings(self, tmp_path: Path) -> None:
+        """A stale fleet copy self-identifies by the absence of this stamp."""
+        _write_session(tmp_path, "trace_20260722_ours00", _decision_session("mine", unresolved=True))
+
+        result = _run_hook(tmp_path, project="mine")
+        assert "[trace-hooks v0.5]" in result.stdout


### PR DESCRIPTION
Implements ADR-006 step S5 — the producer side of canonical project identity. Follows PR #32 (identity core and server enforcement) and completes the path from "a project label is whatever each component guessed" to "one declared, canonical key".

## Summary

- One shared, delimited, byte-identical project-detection block replaces four drifted copies across the Claude Code hooks, guarded by a new `tests/test_hook_assets_consistency.py`.
- The pin-line regex is bold-tolerant; detection prefers a `.claude/trace.project` pin file; every candidate label is canonicalized.
- Hooks match sessions by canonical key, preferring a stamped `metadata.project_key` and falling back to canonicalizing the display label.
- `decision-audit.sh` gains a project filter and a bounded newest-first scan.
- `trace-mcp init` enrols the project in the alias registry and writes all three pins; new `trace-mcp project-key` prints the resolved key.
- Every emitted message carries a `[trace-hooks v0.5]` version stamp.

## Why

**The hooks disagreed with each other, and with the repository.** Each hook carried its own copy of project detection. The pin-line regex accepted `TRACE project name: "x"` but not the bolded `**TRACE project name**: "x"`, so on a repository that declares its name in a bolded line the hooks skipped the declaration and fell through to the git basename — while a model reading the same file used the declared name. That is one repository resolving to two labels, deterministically, and it is the mechanical cause of a live drift pair. A single shared block makes the divergence impossible to reintroduce silently; a second copy of the same idea (prompt-reminder's private `_sanitize`, which folded names differently from the canonical key) is removed for the same reason.

**The audit hook reported the wrong project's findings.** `decision-audit.sh` selected the newest session across the whole flat store with no project filter, so with two servers running side by side each reported the other's audit results. It now filters by canonical key and selects by filename date with mtime breaking ties inside a day — which is what actually identifies the session that just ended. The scan walks newest-date-first and stops once the date changes after a match, so a store holding hundreds of sessions costs a handful of reads rather than a full parse on every session end.

**Nothing wrote a project's identity down.** Identity was re-derived by heuristic in every component, which is why it drifted. `init` is now the single place it is minted: it enrols the canonical key through the fail-closed registry lock and writes the `TRACE_PROJECT` env pin, the `.claude/trace.project` pin file, and a machine-parseable CLAUDE.md line when none is declared. An existing declaration — including a bolded one — is respected, never rewritten and never duplicated.

**Failing closed on the registry.** A registry that is present but unreadable now fails closed on both the read and the write path. A corrupt registry cannot be distinguished from "this project has no aliases", so guessing the bare canonical key would silently split a renamed project off from its own history. The `.mcp.json` source is resolved before any write, so an unresolvable source cannot leave a project half initialized.

Hooks read no registry by design: alias resolution belongs to the server and the identity CLI, which may fail closed on damage. A hook advises the tool call it runs alongside and must never fail it — hence the embedded canonicalizer returns `""` where the core implementation raises.

## Incidental fix

The `trace-mcp init` dispatch read `argv[2]` as the project directory, so every flag was swallowed as a path — `trace-mcp init --dry-run` reported "--dry-run is not a directory". Only the separate `trace-mcp-init` console script honoured flags. Both entry points now share init's parser.

## Verification

- Full suite: **1131 passed, 11 skipped** (up from 1077; 54 new tests).
- `ruff check`, `ruff format --check`, `pyright` (0 errors), invariant registry guard, and `uv build` + packaging artifacts all pass.
- **All four hooks executed against real bash 3.2.57**, the minimum supported version — the shell that a previous `mapfile` regression silently broke.
- The embedded canonicalizer is executed *from the shipped asset* and compared against `canonical_project_key` across a unicode label corpus (case, separator, punctuation-run, accented, and emoji labels), plus degenerate labels where core raises and the hook must return `""`. The duplication is deliberate — hooks run as bare `python3` with no installed package — and this is what keeps it honest.
- The project-filter tests are written in mirror-image pairs (ours-clean/theirs-dirty and ours-dirty/theirs-clean) so a filter that matched nothing could not pass them.

## Risks / rollback

Behavioural changes a consumer will notice: hook messages now name the canonical key rather than the raw label (that is what matching uses, so naming the label would misreport why a session did not match), and `decision-audit.sh` is silent when no session belongs to the current project rather than reporting a neighbour's. Existing deployed hook copies are unaffected until re-installed; the version stamp is what makes a stale copy identifiable. Revert the commit to restore prior behaviour — no data is migrated or rewritten.