### PR TITLE
feat(cli): trace-mcp identity — provenance-honest migration tooling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`trace-mcp identity` migration tooling (ADR-006 S6).** Seven subcommands turn
+  the identity enforcement machinery into an operator can run against a store that
+  predates canonical keys, without ever rewriting a capture record:
+  - `snapshot` — back up `~/.trace` (counting by direct glob, so the oldest
+    sessions the 500-cap query would hide are included) and write the marker the
+    destructive phases require.
+  - `scan` — group every drifted label by canonical key into a human-editable
+    plan; writes no registry state.
+  - `apply` — mint the reviewed plan into the registry (idempotent; snapshot-gated).
+  - `check` — report drift (stray knowledge stores, session labels resolving to no
+    registered project, registry health); non-zero exit on findings. Shares one
+    drift-detection function with the health tool, so the two can never disagree.
+  - `merge-stores` — consolidate an alias group's knowledge stores into the
+    canonical-key store: Jaccard-deduped union, sources kept as `*.premerge-<date>`,
+    sidecar regenerated (never migrated), every merge logged to `migrations.jsonl`
+    with content hashes. Idempotent, snapshot-gated, and refuses to run while any
+    writer is active. The `auto` quarantine is never merged.
+  - `adopt` — re-home an `auto`-quarantine session into a real project, append-shaped
+    (records old→new as a `state_change` and stamps `project_key`, never an in-place
+    edit); refuses to relabel a real project's session.
+  - `bundle` — export one project (sessions, knowledge store, matching egress rows,
+    registry entry) as a self-contained tarball, selected by canonical match.
+- **Health check reports project identity.** `trace_health_check` gains a
+  `pinned` / `bound_project_key` / `registry` / `stray_knowledge_stores` block,
+  computed by the same core drift detector as `identity check`.
+
 - **Canonical project identity (spec v0.5.0, schema `trace-v0.5.json`).** A project
   is now identified by a stable canonical key derived from its display label, rather
   than by the label itself. Previously, storage identity and query identity were two

--- a/docs/INVARIANTS.md
+++ b/docs/INVARIANTS.md
@@ -34,6 +34,9 @@ rather than ever proceeding unlocked.
 - `src/trace_mcp/tools/session_tools.py :: append_event`
 - `src/trace_mcp/tools/session_tools.py :: end_session`
 - `src/trace_mcp/tools/decision_tools.py :: resolve_decision`
+- `src/trace_mcp/identity_cli.py :: adopt_session` (ADR-006 S6 — `identity adopt`
+  re-homes an `auto` session into a real project: stamps `metadata.project_key`
+  and appends a `state_change`, append-shaped, under the same locked helper)
 
 **Enforcement.** `JsonFileStorage.lock` writes a `<pid>:<time_ns>` token and
 steals a lock only when the holder PID is provably dead (single-host) or, for an
@@ -49,13 +52,20 @@ liveness), `tests/test_v042_storage_concurrency.py` (cross-process no-lost-updat
 ## INV-2 — Completed sessions are immutable (one documented exception)  · ENFORCED
 
 **Statement.** Once a session is `completed`, no event may be appended and it may
-not be re-ended. The **only** permitted post-completion mutation is resolving a
-still-`proposed` decision (the documented cross-session decision lifecycle),
-which stamps an audit warning. The check is made against **disk truth** inside
-the lock, not the in-memory copy.
+not be re-ended. Two post-completion mutations are permitted, both
+append-shaped and both recorded for audit: (1) resolving a still-`proposed`
+decision (the documented cross-session decision lifecycle), which stamps an
+audit warning; and (2) `identity adopt` re-homing an `auto`-quarantine session
+into a real project (ADR-006 S6), which appends a `state_change` recording
+old→new/actor/reason and stamps `project_key`. Adopt is confined to sessions
+whose key is reserved (`auto`/`shared`) — it can never relabel a real project's
+completed session. The check is made against **disk truth** inside the lock, not
+the in-memory copy.
 
-**Site-set:** the same three INV-1 write paths (each guards `disk.status ==
-"completed"` under the lock).
+**Site-set:** the INV-1 write paths. `append_event`/`end_session`/
+`resolve_decision` each guard `disk.status == "completed"` under the lock;
+`identity_cli.py :: adopt_session` is the second sanctioned post-completion
+appender, gated instead on the session resolving to a reserved key.
 
 **Tests.** `tests/test_decision_integrity.py` (post-completion resolution +
 stale-copy resurrection), `tests/test_integrity_hardening.py`

--- a/src/trace_mcp/identity_cli.py
+++ b/src/trace_mcp/identity_cli.py
@@ -1,0 +1,813 @@
+"""``trace-mcp identity`` — provenance-honest project-identity migration tooling (ADR-006 S6).
+
+Core module (stdlib + core identity types; the learn extension is imported lazily
+inside ``merge-stores`` only, per ADR-003). Seven subcommands turn the enforcement
+machinery of ADR-006 into an operator can actually run against an existing store
+that predates canonical identity:
+
+    snapshot      back up ~/.trace and drop a marker later phases require
+    scan          propose a label→key plan (writes nothing)
+    apply         mint the human-approved plan into the registry
+    check         report drift; non-zero exit on findings
+    merge-stores  consolidate an alias group's knowledge stores (reversible)
+    adopt         re-home an ``auto`` session into a real project (append-shaped)
+    bundle        export one project as a self-contained tarball
+
+Two rules run through all of it, both from ADR-006:
+
+* **Capture records are never rewritten.** ``scan``/``apply`` only build the alias
+  index; ``adopt`` is the one session-touching command and it is append-shaped
+  (it records old→new as a ``state_change`` event, never an in-place edit).
+* **The store is enumerated by direct glob, never ``list_sessions``.** The query
+  layer caps at 500 files and would hide the oldest sessions — exactly the ones
+  most likely to carry drifted labels.
+
+Nothing here runs automatically. Each command is invoked deliberately; the
+destructive ones (``apply``, ``merge-stores``) refuse to run without a snapshot
+marker, and ``merge-stores`` additionally refuses while any writer is active.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import json
+import os
+import sys
+import tarfile
+from collections.abc import Iterable
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from trace_mcp import identity_report
+from trace_mcp import project_identity as pident
+
+# ── Paths ──────────────────────────────────────────────────────────────────
+
+
+def _trace_home() -> Path:
+    """Root of the TRACE data directory (parent of sessions/knowledge/…).
+
+    Derived from ``TRACE_SESSIONS_DIR`` when set (so tests and non-default
+    layouts stay consistent), else ``~/.trace``.
+    """
+    sessions = os.environ.get("TRACE_SESSIONS_DIR")
+    if sessions:
+        return Path(sessions).expanduser().parent
+    return Path("~/.trace").expanduser()
+
+
+def _sessions_dir() -> Path:
+    return Path(os.environ.get("TRACE_SESSIONS_DIR", str(_trace_home() / "sessions"))).expanduser()
+
+
+def _migrations_log() -> Path:
+    """Append-only log of every identity operation (mint / alias / merge / adopt)."""
+    override = os.environ.get("TRACE_MIGRATIONS_LOG")
+    return Path(override).expanduser() if override else _trace_home() / "migrations.jsonl"
+
+
+def _snapshot_marker() -> Path:
+    return _trace_home() / "backups" / ".snapshot-marker.json"
+
+
+# ── Small shared helpers ───────────────────────────────────────────────────
+
+
+def _now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _today() -> str:
+    return datetime.now(UTC).strftime("%Y-%m-%d")
+
+
+def _sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _append_migration(record: dict[str, Any]) -> None:
+    """Append one identity-operation record to the append-only migrations log.
+
+    Side effect: writes ``migrations.jsonl``. Never rewrites existing lines —
+    the log is the audit trail of the repair itself.
+    """
+    log = _migrations_log()
+    log.parent.mkdir(parents=True, exist_ok=True)
+    with log.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps({"ts": _now(), **record}) + "\n")
+
+
+def _iter_session_files() -> Iterable[Path]:
+    """Every session JSON by DIRECT GLOB (not list_sessions — its 500-cap hides the oldest)."""
+    d = _sessions_dir()
+    if not d.is_dir():
+        return []
+    return sorted(d.glob("trace_*.json"))
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def _session_label(data: dict[str, Any]) -> str | None:
+    meta = data.get("metadata") or {}
+    label = meta.get("project")
+    return label if isinstance(label, str) and label.strip() else None
+
+
+def _require_snapshot(out) -> bool:
+    """True if a snapshot marker exists; else print guidance and return False."""
+    if _snapshot_marker().is_file():
+        return True
+    print(
+        "Error: no snapshot marker found. Run `trace-mcp identity snapshot` first — "
+        "the destructive phases refuse to run without a backup.",
+        file=out,
+    )
+    return False
+
+
+# ── snapshot ───────────────────────────────────────────────────────────────
+
+
+def cmd_snapshot(args: argparse.Namespace, out) -> int:
+    """Back up the whole TRACE home to a dated tarball and record a manifest + marker.
+
+    Counts are obtained by direct glob so the manifest reflects the true store
+    size, not the query layer's capped view. The marker gates every later phase.
+    """
+    home = _trace_home()
+    if not home.is_dir():
+        print(f"Error: {home} does not exist; nothing to snapshot.", file=out)
+        return 1
+
+    backups = home / "backups"
+    backups.mkdir(parents=True, exist_ok=True)
+    stamp = _today()
+    archive = backups / f"pre-identity-{stamp}.tar.gz"
+    # Distinct suffix if a snapshot already exists today, so a re-run never
+    # silently overwrites an earlier backup.
+    n = 1
+    while archive.exists():
+        archive = backups / f"pre-identity-{stamp}-{n}.tar.gz"
+        n += 1
+
+    session_files = list(_iter_session_files())
+    knowledge = identity_report.knowledge_dir()
+    knowledge_files = sorted(knowledge.glob("*.json")) if knowledge.is_dir() else []
+
+    with tarfile.open(archive, "w:gz") as tar:
+        # Exclude the backups dir itself so the archive never contains prior archives.
+        tar.add(home, arcname=home.name, filter=lambda ti: None if "/backups/" in ti.name + "/" else ti)
+
+    manifest = {
+        "created": _now(),
+        "archive": str(archive),
+        "archive_sha256": _sha256(archive),
+        "counts": {
+            "sessions": len(session_files),
+            "knowledge_stores": len(knowledge_files),
+        },
+        "trace_home": str(home),
+    }
+    marker = _snapshot_marker()
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker.write_text(json.dumps(manifest, indent=2) + "\n")
+    _append_migration({"op": "snapshot", "archive": str(archive), "counts": manifest["counts"]})
+
+    print(f"Snapshot written: {archive}", file=out)
+    print(
+        f"  {manifest['counts']['sessions']} sessions, {manifest['counts']['knowledge_stores']} knowledge stores",
+        file=out,
+    )
+    print(f"  marker: {marker}", file=out)
+    return 0
+
+
+# ── scan ───────────────────────────────────────────────────────────────────
+
+
+def _collect_label_groups() -> dict[str, dict[str, Any]]:
+    """Group every distinct raw label (sessions + stores) by canonical key.
+
+    Returns ``{key: {"labels": [...], "session_counts": {label: n}, "stores": [...]}}``.
+    Pure read; writes nothing.
+    """
+    groups: dict[str, dict[str, Any]] = {}
+
+    def _group(key: str) -> dict[str, Any]:
+        return groups.setdefault(key, {"labels": [], "session_counts": {}, "stores": []})
+
+    for path in _iter_session_files():
+        data = _read_json(path)
+        if data is None:
+            continue
+        label = _session_label(data)
+        if label is None:
+            continue
+        try:
+            key = pident.canonical_project_key(label)
+        except pident.ProjectKeyError:
+            continue
+        g = _group(key)
+        if label not in g["labels"]:
+            g["labels"].append(label)
+        g["session_counts"][label] = g["session_counts"].get(label, 0) + 1
+
+    knowledge = identity_report.knowledge_dir()
+    if knowledge.is_dir():
+        for store in sorted(knowledge.glob("*.json")):
+            stem = store.stem
+            if stem in pident.RESERVED_KEYS:
+                continue
+            _group(stem)["stores"].append(store.name)
+
+    return groups
+
+
+def cmd_scan(args: argparse.Namespace, out) -> int:
+    """Emit a human-editable label→key plan grouped by canonical key. Writes no registry state.
+
+    Cross-key merge candidates (e.g. a rename pair) are NOT decided here — the
+    plan lists each canonical group, and a human edits it before ``apply``.
+    """
+    groups = _collect_label_groups()
+    plan = {
+        "generated": _now(),
+        "note": (
+            "Review before `identity apply`. Each entry mints one canonical key with the "
+            "listed labels as aliases. To MERGE two keys (a rename), move one entry's labels "
+            "into the other's `aliases` and delete the emptied entry — semantically distinct "
+            "projects must be merged by hand, never automatically."
+        ),
+        "projects": [
+            {
+                "key": key,
+                "display_label": g["labels"][0] if g["labels"] else key,
+                "aliases": sorted(set(g["labels"])),
+                "session_counts": g["session_counts"],
+                "knowledge_stores": g["stores"],
+            }
+            for key, g in sorted(groups.items())
+        ],
+    }
+    dest = Path(args.output).expanduser() if args.output else _trace_home() / f"identity-plan-{_today()}.json"
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_text(json.dumps(plan, indent=2) + "\n")
+    print(f"Scan plan written: {dest}", file=out)
+    print(f"  {len(plan['projects'])} canonical project group(s) found.", file=out)
+    print("  Edit it, then run `identity apply --plan <file>`.", file=out)
+    return 0
+
+
+# ── apply ──────────────────────────────────────────────────────────────────
+
+
+def cmd_apply(args: argparse.Namespace, out) -> int:
+    """Mint a signed-off plan into the registry (idempotent). Requires a snapshot marker."""
+    if not _require_snapshot(out):
+        return 1
+    plan_path = Path(args.plan).expanduser()
+    plan = _read_json(plan_path)
+    if plan is None or "projects" not in plan:
+        print(f"Error: {plan_path} is not a readable identity plan (missing 'projects').", file=out)
+        return 1
+
+    minted, updated, skipped = 0, 0, 0
+    try:
+        with pident.locked_registry() as registry:
+            for entry in plan["projects"]:
+                key = entry.get("key")
+                if not isinstance(key, str) or not key:
+                    continue
+                if key in pident.RESERVED_KEYS:
+                    print(f"  refusing reserved key '{key}' — skipped.", file=out)
+                    skipped += 1
+                    continue
+                display = entry.get("display_label") or key
+                aliases = sorted({a for a in entry.get("aliases", []) if isinstance(a, str)})
+                existing = registry.projects.get(key)
+                if existing is None:
+                    registry.projects[key] = pident.ProjectEntry(
+                        key=key, display_label=display, aliases=aliases, enrolled_by="identity apply"
+                    )
+                    registry.history.append(
+                        pident.RegistryChange(
+                            actor="identity apply", action="mint", details={"key": key, "aliases": aliases}
+                        )
+                    )
+                    _append_migration({"op": "mint", "key": key, "display_label": display, "aliases": aliases})
+                    minted += 1
+                else:
+                    new_aliases = sorted(set(existing.aliases) | set(aliases))
+                    if new_aliases != sorted(existing.aliases):
+                        existing.aliases = new_aliases
+                        registry.history.append(
+                            pident.RegistryChange(
+                                actor="identity apply", action="alias-add", details={"key": key, "aliases": new_aliases}
+                            )
+                        )
+                        _append_migration({"op": "alias-add", "key": key, "aliases": new_aliases})
+                        updated += 1
+                    else:
+                        skipped += 1
+    except pident.RegistryUnavailableError as exc:
+        print(f"Error: registry is unreadable ({exc}); refusing to overwrite it.", file=out)
+        return 1
+    except (TimeoutError, ValueError) as exc:
+        print(f"Error: could not apply plan ({exc}).", file=out)
+        return 1
+
+    print(f"Applied: {minted} minted, {updated} alias-updated, {skipped} unchanged.", file=out)
+    return 0
+
+
+# ── check ──────────────────────────────────────────────────────────────────
+
+
+def cmd_check(args: argparse.Namespace, out) -> int:
+    """Report identity drift. Exit 0 when clean, 1 when findings exist.
+
+    Findings: knowledge stores not backed by a registered key; session labels
+    that resolve to no registered project; and the registry's own health.
+    """
+    status = identity_report.registry_status()
+    findings: list[str] = []
+
+    if status == "unavailable":
+        print("Registry: UNAVAILABLE (corrupt or unknown version) — fix before migrating.", file=out)
+        return 1
+    if status == "absent":
+        print("Registry: absent (no projects enrolled yet). Run scan → apply to create it.", file=out)
+
+    registry = None
+    try:
+        registry = pident.get_registry_cached()
+    except pident.RegistryUnavailableError:
+        pass  # already reported above
+
+    stray = identity_report.find_stray_stores(registry)
+    if stray:
+        findings.append(f"{len(stray)} knowledge store(s) not backed by a registered key: {', '.join(stray)}")
+
+    if registry is not None:
+        unknown_labels: dict[str, int] = {}
+        for path in _iter_session_files():
+            data = _read_json(path)
+            if data is None:
+                continue
+            label = _session_label(data)
+            if label is None:
+                continue
+            if registry.resolve(label) is None:
+                unknown_labels[label] = unknown_labels.get(label, 0) + 1
+        if unknown_labels:
+            shown = ", ".join(f"{lbl!r} ({n})" for lbl, n in sorted(unknown_labels.items()))
+            findings.append(f"{len(unknown_labels)} session label(s) resolve to no registered project: {shown}")
+
+    if not findings:
+        print("identity check: clean — every store and session label resolves to a registered project.", file=out)
+        return 0
+    print("identity check: findings", file=out)
+    for f in findings:
+        print(f"  - {f}", file=out)
+    return 1
+
+
+# ── merge-stores ───────────────────────────────────────────────────────────
+
+
+def _preflight_merge(paths: list[Path], out) -> bool:
+    """Refuse to merge while any writer may be active (fail-closed, physical-first).
+
+    A live lock file, or a store/session touched within the freshness threshold,
+    means another process may be mid-write; grafting under it could lose an
+    update. Returns True only when the store is quiescent.
+    """
+    knowledge = identity_report.knowledge_dir()
+    for lock in knowledge.glob("*.lock"):
+        print(f"Error: knowledge lock present ({lock.name}) — a writer may be active. Aborting.", file=out)
+        return False
+    threshold = float(os.environ.get("TRACE_MERGE_MIN_AGE_SEC", "5"))
+    now = datetime.now(UTC).timestamp()
+    for p in paths:
+        try:
+            age = now - p.stat().st_mtime
+        except OSError:
+            continue
+        if age < threshold:
+            print(
+                f"Error: {p.name} was modified {age:.1f}s ago (< {threshold}s) — a writer may be active. Aborting.",
+                file=out,
+            )
+            return False
+    return True
+
+
+def cmd_merge_stores(args: argparse.Namespace, out) -> int:
+    """Consolidate an alias group's knowledge stores into the canonical-key store.
+
+    Idempotent and reversible: sources are renamed to ``*.json.premerge-<date>``
+    (kept forever), the union is deduped by the existing Jaccard machinery, the
+    embedding sidecar is regenerated (never migrated), and every merge is logged
+    with content hashes. The ``auto`` quarantine is never merged. Requires a
+    snapshot marker.
+
+    The learn extension is imported HERE, lazily, so this core module never
+    imports it at load time (ADR-003).
+    """
+    if not _require_snapshot(out):
+        return 1
+    try:
+        from trace_mcp.extensions.learn import store as learn_store
+        from trace_mcp.extensions.learn.models import KnowledgeStore
+    except ImportError as exc:
+        print(f"Error: the trace-learn extension is unavailable ({exc}); cannot merge stores.", file=out)
+        return 1
+
+    try:
+        registry = pident.get_registry_cached()
+    except pident.RegistryUnavailableError as exc:
+        print(f"Error: registry is unreadable ({exc}); enroll projects before merging.", file=out)
+        return 1
+    if registry is None:
+        print("Error: no registry yet — run scan → apply before merge-stores.", file=out)
+        return 1
+
+    knowledge = identity_report.knowledge_dir()
+    if not knowledge.is_dir():
+        print("Nothing to merge: no knowledge directory.", file=out)
+        return 0
+
+    # Which canonical keys to consolidate: a specific one, or every registered key
+    # that has at least one aliased source store on disk.
+    target_keys = [args.key] if args.key else sorted(registry.projects)
+
+    merged_any = False
+    for key in target_keys:
+        if key in pident.RESERVED_KEYS:
+            continue
+        entry = registry.projects.get(key)
+        if entry is None:
+            print(f"  '{key}' is not a registered key — skipped.", file=out)
+            continue
+
+        # Source stems = every alias/label/key that canonicalizes to a DIFFERENT
+        # on-disk stem than the target and actually has a store file.
+        source_paths: list[Path] = []
+        for ident in {key, entry.display_label, *entry.aliases}:
+            try:
+                ident_key = pident.canonical_project_key(ident)
+            except pident.ProjectKeyError:
+                continue
+            if ident_key == key or ident_key in pident.RESERVED_KEYS:
+                continue
+            candidate = knowledge / f"{ident_key}.json"
+            if candidate.is_file() and candidate not in source_paths:
+                source_paths.append(candidate)
+
+        if not source_paths:
+            continue
+
+        target_path = knowledge / f"{key}.json"
+        involved = [*source_paths, *([target_path] if target_path.is_file() else [])]
+        if not _preflight_merge(involved, out):
+            return 1
+
+        # Load target (or start fresh), union each source in with Jaccard dedup.
+        target_store = learn_store.load_store(key)
+        before_target = len(target_store.learnings)
+        merge_records: list[dict[str, Any]] = []
+        for src in source_paths:
+            raw = _read_json(src)
+            if raw is None:
+                print(f"  skipping unreadable source {src.name}", file=out)
+                continue
+            src_store = KnowledgeStore.model_validate(raw)
+            added, deduped = 0, 0
+            for lrn in src_store.learnings:
+                if learn_store.find_duplicate(target_store, lrn.content) is not None:
+                    deduped += 1
+                    continue
+                new = lrn.model_copy(update={"id": target_store.next_learning_id()})
+                target_store.learnings.append(new)
+                added += 1
+            merge_records.append(
+                {
+                    "source": src.name,
+                    "source_sha256": _sha256(src),
+                    "learnings": len(src_store.learnings),
+                    "added": added,
+                    "deduped": deduped,
+                }
+            )
+
+        # Ensure the merged store declares the canonical key, then persist +
+        # regenerate the sidecar (save_store rewrites the .npy from inline vectors).
+        target_store.project = key
+        learn_store.save_store(target_store)
+        after_target = len(target_store.learnings)
+
+        # Rename sources to premerge backups (kept forever) — reversible by hand.
+        premerges = []
+        for src in source_paths:
+            backup = src.with_name(f"{src.name}.premerge-{_today()}")
+            n = 1
+            while backup.exists():
+                backup = src.with_name(f"{src.name}.premerge-{_today()}-{n}")
+                n += 1
+            src.rename(backup)
+            premerges.append(backup.name)
+            # The source's sidecar is a derived artifact — drop it (regenerated for the target).
+            sidecar = src.with_suffix(".embeddings.npy")
+            if sidecar.exists():
+                sidecar.unlink()
+
+        _append_migration(
+            {
+                "op": "store-merge",
+                "key": key,
+                "target_before": before_target,
+                "target_after": after_target,
+                "target_sha256": _sha256(target_path),
+                "sources": merge_records,
+                "premerge_files": premerges,
+            }
+        )
+        print(
+            f"  merged {len(source_paths)} store(s) into '{key}.json': {before_target} → {after_target} learnings",
+            file=out,
+        )
+        merged_any = True
+
+    if not merged_any:
+        print("Nothing to merge: no aliased source stores found for the target key(s).", file=out)
+    return 0
+
+
+# ── adopt ──────────────────────────────────────────────────────────────────
+
+
+async def adopt_session(storage, session_id: str, target_key: str, reason: str | None) -> str:
+    """Re-home an ``auto`` session into *target_key*, append-shaped (INV-1 writer).
+
+    Records the change as a ``state_change`` event and stamps
+    ``metadata.project_key`` — it never edits the session's history in place, so
+    the operation survives ADR-005 as an ordinary append. Writes through
+    ``locked_disk_session`` against disk truth (INV-1); registered in
+    docs/INVARIANTS.md.
+
+    Raises ``ValueError`` if the session does not resolve to ``auto`` (real→real
+    re-homing is refused — that would be relabeling a captured attribution).
+    """
+    from trace_mcp.schema import Actor, StateChangeData, TraceEvent
+    from trace_mcp.storage.locked import locked_disk_session
+
+    loaded = await storage.get_session(session_id)
+    current_key = pident.session_project_key(loaded.metadata)
+    if current_key not in pident.RESERVED_KEYS:
+        raise ValueError(
+            f"session '{session_id}' resolves to project '{current_key}', not the 'auto' quarantine. "
+            "adopt only re-homes unattributed sessions; it will not relabel a real project."
+        )
+
+    async with locked_disk_session(storage, session_id, fallback=loaded) as write_session:
+        old_project = write_session.metadata.project
+        old_key = pident.session_project_key(write_session.metadata)
+        event = TraceEvent(
+            session_id=session_id,
+            type="state_change",
+            actor=Actor(type="human", id="identity adopt"),
+            state_change=StateChangeData(
+                description=f"Adopted unattributed session into project '{target_key}'.",
+                field="metadata.project_key",
+                old_value=old_key,
+                new_value=target_key,
+                reason=reason or "identity adopt",
+            ),
+        )
+        event.id = write_session.next_event_id()
+        write_session.events.append(event)
+        write_session.metadata.project = target_key
+        write_session.metadata.project_key = target_key
+        await storage.update_session(write_session)
+
+    _append_migration(
+        {
+            "op": "adopt",
+            "session_id": session_id,
+            "old_project": old_project,
+            "old_key": old_key,
+            "new_key": target_key,
+            "reason": reason,
+        }
+    )
+    return f"Adopted session '{session_id}': '{old_key}' → '{target_key}'."
+
+
+def cmd_adopt(args: argparse.Namespace, out) -> int:
+    """CLI wrapper for ``adopt_session``: resolve the target key, then write."""
+    from trace_mcp.storage.json_file import JsonFileStorage
+
+    try:
+        target_key = pident.canonical_project_key(args.project)
+    except pident.ProjectKeyError as exc:
+        print(f"Error: {exc}", file=out)
+        return 1
+    if target_key in pident.RESERVED_KEYS:
+        print(f"Error: '{args.project}' is a reserved key, not an adoptable project.", file=out)
+        return 1
+
+    storage = JsonFileStorage()
+    try:
+        message = asyncio.run(adopt_session(storage, args.session_id, target_key, args.reason))
+    except FileNotFoundError:
+        print(f"Error: session '{args.session_id}' not found.", file=out)
+        return 1
+    except ValueError as exc:
+        print(f"Error: {exc}", file=out)
+        return 1
+    print(message, file=out)
+    return 0
+
+
+# ── bundle ─────────────────────────────────────────────────────────────────
+
+
+def cmd_bundle(args: argparse.Namespace, out) -> int:
+    """Export one project as a self-contained tarball (sessions + store + egress rows + registry entry).
+
+    The client-handover payoff of ADR-006 without physical per-project storage:
+    selection is by canonical match, so a project's whole footprint travels
+    together regardless of which drifted label each artifact was written under.
+    """
+    try:
+        key = pident.canonical_project_key(args.project)
+    except pident.ProjectKeyError as exc:
+        print(f"Error: {exc}", file=out)
+        return 1
+
+    dest = Path(args.bundle).expanduser()
+    staged: list[tuple[Path, str]] = []
+
+    # Sessions whose canonical key matches — direct glob, not list_sessions.
+    session_count = 0
+    for path in _iter_session_files():
+        data = _read_json(path)
+        if data is None:
+            continue
+        if pident.session_matches_project(data.get("metadata") or {}, key):
+            staged.append((path, f"sessions/{path.name}"))
+            session_count += 1
+
+    # Knowledge store + its sidecar.
+    knowledge = identity_report.knowledge_dir()
+    store = knowledge / f"{key}.json"
+    if store.is_file():
+        staged.append((store, f"knowledge/{store.name}"))
+        sidecar = store.with_suffix(".embeddings.npy")
+        if sidecar.is_file():
+            staged.append((sidecar, f"knowledge/{sidecar.name}"))
+
+    # Egress rows attributable to this project (filtered copy of the global ledger).
+    egress_rows = _project_egress_rows(key)
+
+    # Registry entry for the project (so the recipient can resolve its aliases).
+    registry_entry = _registry_entry_json(key)
+
+    if not dest.parent.exists():
+        dest.parent.mkdir(parents=True, exist_ok=True)
+    with tarfile.open(dest, "w:gz") as tar:
+        for src, arcname in staged:
+            tar.add(src, arcname=arcname)
+        _add_bytes(
+            tar, "egress.jsonl", ("\n".join(json.dumps(r) for r in egress_rows) + "\n").encode() if egress_rows else b""
+        )
+        if registry_entry is not None:
+            _add_bytes(tar, "project.json", (json.dumps(registry_entry, indent=2) + "\n").encode())
+
+    print(f"Bundled project '{key}' → {dest}", file=out)
+    print(
+        f"  {session_count} session(s), {'store' if store.is_file() else 'no store'}, {len(egress_rows)} egress row(s)",
+        file=out,
+    )
+    return 0
+
+
+def _egress_log_path() -> Path:
+    """Resolve the egress ledger EXACTLY as the writer (``egress.egress_log_path``) does.
+
+    Mirrored here rather than imported so this core command never pulls the learn
+    extension. Kept byte-for-byte identical to that resolver: ``TRACE_EGRESS_LOG``
+    override, else ``~/.trace/egress.jsonl`` — deriving it from ``_trace_home``
+    instead would read a different file than the writer wrote whenever
+    ``TRACE_SESSIONS_DIR`` points off the default root.
+    """
+    override = os.environ.get("TRACE_EGRESS_LOG")
+    return Path(override).expanduser() if override else Path.home() / ".trace" / "egress.jsonl"
+
+
+def _project_egress_rows(key: str) -> list[dict[str, Any]]:
+    """Egress ledger rows whose project (by key or alias) matches *key*. Read-only."""
+    path = _egress_log_path()
+    if not path.is_file():
+        return []
+    rows: list[dict[str, Any]] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        row_key = row.get("project_key")
+        label = row.get("project")
+        matched = row_key == key or (isinstance(label, str) and pident.key_for_label(label) == key)
+        if matched:
+            rows.append(row)
+    return rows
+
+
+def _registry_entry_json(key: str) -> dict[str, Any] | None:
+    try:
+        registry = pident.get_registry_cached()
+    except pident.RegistryUnavailableError:
+        return None
+    if registry is None:
+        return None
+    entry = registry.projects.get(key)
+    return entry.model_dump(mode="json") if entry is not None else None
+
+
+def _add_bytes(tar: tarfile.TarFile, arcname: str, payload: bytes) -> None:
+    import io
+
+    info = tarfile.TarInfo(name=arcname)
+    info.size = len(payload)
+    tar.addfile(info, io.BytesIO(payload))
+
+
+# ── Dispatch ───────────────────────────────────────────────────────────────
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="trace-mcp identity", description="Project-identity migration tooling (ADR-006)."
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    sub.add_parser("snapshot", help="back up ~/.trace and write the marker later phases require")
+
+    p_scan = sub.add_parser("scan", help="propose a label→key plan (writes nothing)")
+    p_scan.add_argument(
+        "--output", "-o", default=None, help="plan output path (default: ~/.trace/identity-plan-<date>.json)"
+    )
+
+    p_apply = sub.add_parser("apply", help="mint a signed-off plan into the registry")
+    p_apply.add_argument("--plan", required=True, help="path to the reviewed plan file")
+
+    sub.add_parser("check", help="report identity drift (non-zero exit on findings)")
+
+    p_merge = sub.add_parser("merge-stores", help="consolidate an alias group's knowledge stores (reversible)")
+    p_merge.add_argument("--key", default=None, help="a single canonical key to merge (default: every registered key)")
+
+    p_adopt = sub.add_parser("adopt", help="re-home an 'auto' session into a real project")
+    p_adopt.add_argument("session_id", help="the auto session to adopt")
+    p_adopt.add_argument("--project", required=True, help="target project name")
+    p_adopt.add_argument("--reason", default=None, help="why the session is being adopted")
+
+    p_bundle = sub.add_parser("bundle", help="export one project as a self-contained tarball")
+    p_bundle.add_argument("--project", required=True, help="project to export")
+    p_bundle.add_argument("--bundle", required=True, help="output tarball path")
+
+    return parser
+
+
+_COMMANDS = {
+    "snapshot": cmd_snapshot,
+    "scan": cmd_scan,
+    "apply": cmd_apply,
+    "check": cmd_check,
+    "merge-stores": cmd_merge_stores,
+    "adopt": cmd_adopt,
+    "bundle": cmd_bundle,
+}
+
+
+def main(argv: list[str] | None = None, out=None) -> int:
+    """Entry point for ``trace-mcp identity``. Returns a process exit code."""
+    out = out if out is not None else sys.stdout
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return _COMMANDS[args.command](args, out)

--- a/src/trace_mcp/identity_report.py
+++ b/src/trace_mcp/identity_report.py
@@ -1,0 +1,87 @@
+"""Shared project-identity drift detection (ADR-006).
+
+Core module — stdlib + the core identity types only, with **zero imports from
+``extensions/``** (ADR-003). It is the single implementation of "which knowledge
+stores are not backed by a registered project" and "what state is the registry
+in", called by BOTH the ``trace_health_check`` MCP tool and the ``identity check``
+CLI so the two can never report different verdicts about the same store.
+
+Deliberately filesystem-only for the store scan: it globs the knowledge directory
+by name rather than importing the trace-learn store module, so it works with the
+extension absent and never triggers a store load.
+
+Exports:
+    ``registry_status`` — ``"ok"`` / ``"absent"`` / ``"unavailable"``.
+    ``find_stray_stores`` — knowledge-store stems not backed by a registered key.
+    ``knowledge_dir`` — the knowledge directory path (env-aware, no side effects).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Literal
+
+from trace_mcp import project_identity as pident
+
+RegistryStatus = Literal["ok", "absent", "unavailable"]
+
+
+def knowledge_dir(directory: str | None = None) -> Path:
+    """The knowledge directory, resolved the same way the extension resolves it.
+
+    Mirrors ``extensions.learn.store._get_directory`` without importing it, so a
+    core caller never depends on the extension. No side effects.
+    """
+    import os
+
+    return Path(directory or os.environ.get("TRACE_KNOWLEDGE_DIR", "~/.trace/knowledge")).expanduser()
+
+
+def registry_status() -> RegistryStatus:
+    """Classify the project registry: usable, not-yet-created, or damaged.
+
+    ``absent`` (no file) is a normal pre-migration state that degrades
+    gracefully; ``unavailable`` (corrupt or unknown-major) is the fail-closed
+    state that isolation-bearing paths must refuse to proceed past.
+    """
+    try:
+        registry = pident.get_registry_cached()
+    except pident.RegistryUnavailableError:
+        return "unavailable"
+    return "ok" if registry is not None else "absent"
+
+
+def find_stray_stores(
+    registry: pident.ProjectRegistry | None,
+    directory: str | None = None,
+) -> list[str]:
+    """Return knowledge-store stems that no registered project accounts for.
+
+    A stray store is one whose canonical stem is neither a registered key nor a
+    reserved key (``auto``/``shared`` are quarantine/​reserved, not drift). It is
+    the signal that a project's learnings exist on disk under a key the registry
+    has never heard of — either an un-enrolled project or a laggard server that
+    re-minted a raw-label store after a consolidation.
+
+    Filesystem artifacts are excluded by construction: the ``*.json`` glob never
+    matches the ``.embeddings.npy`` sidecar, the ``.json.lock`` lock file, or a
+    ``.json.premerge-<date>`` merge backup.
+
+    Returns ``[]`` when *registry* is ``None`` — without a registry nothing can be
+    classified as stray, and the caller reports the ``absent``/``unavailable``
+    registry state separately rather than flagging every store at once.
+    """
+    if registry is None:
+        return []
+    kdir = knowledge_dir(directory)
+    if not kdir.is_dir():
+        return []
+    stray: list[str] = []
+    for path in kdir.glob("*.json"):
+        stem = path.stem
+        if stem in pident.RESERVED_KEYS:
+            continue
+        if stem in registry.projects:
+            continue
+        stray.append(stem)
+    return sorted(stray)

--- a/src/trace_mcp/server.py
+++ b/src/trace_mcp/server.py
@@ -979,6 +979,11 @@ def main() -> None:
 
         raise SystemExit(print_project_key(sys.argv[2] if len(sys.argv) > 2 else None))
 
+    if len(sys.argv) > 1 and sys.argv[1] == "identity":
+        from trace_mcp.identity_cli import main as identity_main
+
+        raise SystemExit(identity_main(sys.argv[2:]))
+
     if len(sys.argv) > 1 and sys.argv[1] == "validate":
         # In-package validator (schema ships as package data) — the previous
         # repo-relative load of scripts/validate_session.py crashed on any

--- a/src/trace_mcp/tools/query_tools.py
+++ b/src/trace_mcp/tools/query_tools.py
@@ -370,6 +370,32 @@ async def project_summary(
     }
 
 
+def _identity_health() -> dict[str, Any]:
+    """Project-identity fields for the health report (ADR-006).
+
+    Shares its drift logic with the ``identity check`` CLI via
+    ``identity_report`` so a health probe and an explicit check can never
+    disagree about whether the store is clean. Core-only: the stray-store scan
+    globs the knowledge directory rather than importing the learn extension.
+    """
+    from trace_mcp import identity_report, project_identity
+
+    bound = project_identity.get_bound_project()
+    status = identity_report.registry_status()
+    registry = None
+    if status == "ok":
+        try:
+            registry = project_identity.get_registry_cached()
+        except project_identity.RegistryUnavailableError:
+            status = "unavailable"
+    return {
+        "pinned": bound is not None,
+        "bound_project_key": bound.key if bound is not None else None,
+        "registry": status,
+        "stray_knowledge_stores": identity_report.find_stray_stores(registry),
+    }
+
+
 async def health_check(
     storage: TraceStorage,
     *,
@@ -440,6 +466,7 @@ async def health_check(
             "knowledge_dir": knowledge_dir,
             "knowledge_dir_exists": knowledge_dir_exists,
         },
+        "identity": _identity_health(),
         "session_count": len(sessions),
         "sessions_scanned": len(sessions),
         "skipped_sessions": skipped_sessions,

--- a/tests/test_identity_cli.py
+++ b/tests/test_identity_cli.py
@@ -1,0 +1,436 @@
+"""End-to-end tests for `trace-mcp identity` (ADR-006 S6).
+
+Every test runs against an isolated `tmp_path` TRACE home — nothing here touches
+the developer's real `~/.trace`. The seven subcommands are exercised through
+their real dispatch (`identity_cli.main`), so what is tested is what ships.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import tarfile
+from pathlib import Path
+
+import pytest
+
+from trace_mcp import identity_cli
+from trace_mcp import project_identity as pident
+
+
+@pytest.fixture(autouse=True)
+def _isolated_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point every TRACE path at a throwaway home and reset the registry cache."""
+    home = tmp_path / "trace"
+    (home / "sessions").mkdir(parents=True)
+    (home / "knowledge").mkdir(parents=True)
+    monkeypatch.setenv("TRACE_SESSIONS_DIR", str(home / "sessions"))
+    monkeypatch.setenv("TRACE_KNOWLEDGE_DIR", str(home / "knowledge"))
+    monkeypatch.setenv("TRACE_REGISTRY_PATH", str(home / "projects.json"))
+    monkeypatch.setenv("TRACE_EGRESS_LOG", str(home / "egress.jsonl"))
+    monkeypatch.setenv("TRACE_MIGRATIONS_LOG", str(home / "migrations.jsonl"))
+    # Disable the merge freshness gate: tests write a store then merge it in the
+    # same instant, which the production "was this touched < 5s ago?" writer-liveness
+    # check would (racily) treat as an active writer. The lock-file half of the
+    # preflight stays exercised by test_refuses_when_a_lock_is_present.
+    monkeypatch.setenv("TRACE_MERGE_MIN_AGE_SEC", "0")
+    pident._reset_registry_cache()
+    return home
+
+
+def _run(*argv: str) -> tuple[int, str]:
+    out = io.StringIO()
+    code = identity_cli.main(list(argv), out=out)
+    return code, out.getvalue()
+
+
+def _write_session(
+    home: Path, session_id: str, project: str, *, project_key: str | None = None, status: str = "completed"
+) -> Path:
+    meta: dict = {"project": project}
+    if project_key is not None:
+        meta["project_key"] = project_key
+    doc = {
+        "context": "https://trace-protocol.org/v0.3",
+        "trace_version": "0.5.0",
+        "id": session_id,
+        "created": "2026-07-23T00:00:00Z",
+        "status": status,
+        "metadata": meta,
+        "events": [],
+    }
+    path = home / "sessions" / f"{session_id}.json"
+    path.write_text(json.dumps(doc, indent=2))
+    return path
+
+
+def _write_store(home: Path, stem: str, *, learnings: list[str], project: str | None = None) -> Path:
+    store = {
+        "project": project if project is not None else stem,
+        "learnings": [{"id": f"lrn_{i:03d}", "content": c, "category": "learning"} for i, c in enumerate(learnings, 1)],
+    }
+    path = home / "knowledge" / f"{stem}.json"
+    path.write_text(json.dumps(store, indent=2))
+    return path
+
+
+def _enroll(key: str, *, display: str | None = None, aliases: list[str] | None = None) -> None:
+    with pident.locked_registry() as registry:
+        registry.projects[key] = pident.ProjectEntry(key=key, display_label=display or key, aliases=aliases or [])
+    pident._reset_registry_cache()
+
+
+# ── snapshot ───────────────────────────────────────────────────────────────
+
+
+class TestSnapshot:
+    def test_writes_archive_marker_and_counts(self, _isolated_home: Path) -> None:
+        _write_session(_isolated_home, "trace_20260101_a", "alpha")
+        _write_session(_isolated_home, "trace_20260101_b", "beta")
+        _write_store(_isolated_home, "alpha", learnings=["x"])
+
+        code, _ = _run("snapshot")
+        assert code == 0
+        marker = json.loads((_isolated_home / "backups" / ".snapshot-marker.json").read_text())
+        assert marker["counts"] == {"sessions": 2, "knowledge_stores": 1}
+        assert Path(marker["archive"]).is_file()
+
+    def test_counts_by_direct_glob_past_the_500_cap(self, _isolated_home: Path) -> None:
+        """The 500-session query cap would hide the oldest files; snapshot must not."""
+        for i in range(600):
+            _write_session(_isolated_home, f"trace_2026010{i % 9}_{i:04d}", "alpha")
+        code, _ = _run("snapshot")
+        assert code == 0
+        marker = json.loads((_isolated_home / "backups" / ".snapshot-marker.json").read_text())
+        assert marker["counts"]["sessions"] == 600
+
+    def test_rerun_does_not_overwrite_prior_backup(self, _isolated_home: Path) -> None:
+        _write_session(_isolated_home, "trace_20260101_a", "alpha")
+        _run("snapshot")
+        _run("snapshot")
+        archives = list((_isolated_home / "backups").glob("pre-identity-*.tar.gz"))
+        assert len(archives) == 2, "a second snapshot silently overwrote the first"
+
+    def test_archive_excludes_the_backups_dir(self, _isolated_home: Path) -> None:
+        """The archive must not nest a copy of prior archives."""
+        _write_session(_isolated_home, "trace_20260101_a", "alpha")
+        _run("snapshot")
+        _run("snapshot")
+        newest = max((_isolated_home / "backups").glob("*.tar.gz"), key=lambda p: p.stat().st_mtime)
+        with tarfile.open(newest) as tar:
+            assert not [n for n in tar.getnames() if "backups" in n], "archive contains the backups dir"
+
+
+# ── scan ───────────────────────────────────────────────────────────────────
+
+
+class TestScan:
+    def test_groups_drifted_labels_by_canonical_key(self, _isolated_home: Path) -> None:
+        _write_session(_isolated_home, "trace_20260101_a", "TRACE")
+        _write_session(_isolated_home, "trace_20260101_b", "trace")
+        _write_session(_isolated_home, "trace_20260101_c", "Other Project")
+
+        code, _ = _run("scan")
+        assert code == 0
+        plan = json.loads((_isolated_home / f"identity-plan-{identity_cli._today()}.json").read_text())
+        by_key = {p["key"]: p for p in plan["projects"]}
+        assert set(by_key) == {"trace", "other-project"}
+        assert sorted(by_key["trace"]["aliases"]) == ["TRACE", "trace"]
+        assert by_key["trace"]["session_counts"] == {"TRACE": 1, "trace": 1}
+
+    def test_writes_no_registry_state(self, _isolated_home: Path) -> None:
+        _write_session(_isolated_home, "trace_20260101_a", "alpha")
+        _run("scan")
+        assert not (_isolated_home / "projects.json").exists(), "scan must not touch the registry"
+
+    def test_includes_knowledge_store_stems(self, _isolated_home: Path) -> None:
+        _write_store(_isolated_home, "gamma", learnings=["x"])
+        _run("scan", "-o", str(_isolated_home / "plan.json"))
+        plan = json.loads((_isolated_home / "plan.json").read_text())
+        gamma = next(p for p in plan["projects"] if p["key"] == "gamma")
+        assert gamma["knowledge_stores"] == ["gamma.json"]
+
+
+# ── apply ──────────────────────────────────────────────────────────────────
+
+
+class TestApply:
+    def _plan(self, home: Path, projects: list[dict]) -> Path:
+        path = home / "plan.json"
+        path.write_text(json.dumps({"projects": projects}))
+        return path
+
+    def test_requires_a_snapshot_marker(self, _isolated_home: Path) -> None:
+        plan = self._plan(_isolated_home, [{"key": "alpha", "display_label": "Alpha", "aliases": ["ALPHA"]}])
+        code, out = _run("apply", "--plan", str(plan))
+        assert code == 1
+        assert "snapshot" in out.lower()
+        assert not (_isolated_home / "projects.json").exists()
+
+    def test_mints_entries_and_is_idempotent(self, _isolated_home: Path) -> None:
+        _run("snapshot")
+        plan = self._plan(_isolated_home, [{"key": "alpha", "display_label": "Alpha", "aliases": ["ALPHA", "alpha"]}])
+
+        code1, _ = _run("apply", "--plan", str(plan))
+        assert code1 == 0
+        pident._reset_registry_cache()
+        registry = pident.load_registry(required=False)
+        assert registry is not None and "alpha" in registry.projects
+        assert sorted(registry.projects["alpha"].aliases) == ["ALPHA", "alpha"]
+
+        code2, out2 = _run("apply", "--plan", str(plan))
+        assert code2 == 0 and "0 minted" in out2
+        pident._reset_registry_cache()
+        registry2 = pident.load_registry(required=False)
+        assert registry2 is not None
+        assert [h.action for h in registry2.history] == ["mint"], "re-apply mutated the registry"
+
+    def test_refuses_reserved_keys(self, _isolated_home: Path) -> None:
+        _run("snapshot")
+        plan = self._plan(_isolated_home, [{"key": "auto", "display_label": "auto", "aliases": []}])
+        code, out = _run("apply", "--plan", str(plan))
+        assert code == 0 and "reserved" in out.lower()
+        pident._reset_registry_cache()
+        registry = pident.load_registry(required=False)
+        assert registry is None or "auto" not in registry.projects
+
+
+# ── check ──────────────────────────────────────────────────────────────────
+
+
+class TestCheck:
+    def test_clean_when_everything_resolves(self, _isolated_home: Path) -> None:
+        _enroll("alpha", display="Alpha", aliases=["ALPHA"])
+        _write_session(_isolated_home, "trace_20260101_a", "ALPHA")
+        _write_store(_isolated_home, "alpha", learnings=["x"], project="alpha")
+
+        code, out = _run("check")
+        assert code == 0 and "clean" in out.lower()
+
+    def test_flags_a_stray_store(self, _isolated_home: Path) -> None:
+        _enroll("alpha")
+        _write_store(_isolated_home, "orphan", learnings=["x"], project="orphan")
+        code, out = _run("check")
+        assert code == 1
+        assert "orphan" in out and "not backed by a registered key" in out
+
+    def test_flags_an_unknown_session_label(self, _isolated_home: Path) -> None:
+        _enroll("alpha", aliases=["ALPHA"])
+        _write_session(_isolated_home, "trace_20260101_a", "Totally Unenrolled")
+        code, out = _run("check")
+        assert code == 1
+        assert "Totally Unenrolled" in out
+
+    def test_reports_absent_registry(self, _isolated_home: Path) -> None:
+        _, out = _run("check")
+        assert "absent" in out.lower()
+
+    def test_fails_closed_on_a_corrupt_registry(self, _isolated_home: Path) -> None:
+        (_isolated_home / "projects.json").write_text("{not valid json")
+        pident._reset_registry_cache()
+        code, out = _run("check")
+        assert code == 1 and "unavailable" in out.lower()
+
+    def test_ignores_premerge_and_reserved_stores(self, _isolated_home: Path) -> None:
+        _enroll("alpha")
+        (_isolated_home / "knowledge" / "alpha.json.premerge-2026-07-23").write_text("{}")
+        _write_store(_isolated_home, "auto", learnings=["x"], project="auto")
+        code, out = _run("check")
+        assert code == 0, f"premerge/reserved wrongly flagged as stray: {out}"
+
+
+# ── merge-stores ───────────────────────────────────────────────────────────
+
+
+class TestMergeStores:
+    def _prepare(self) -> None:
+        _run("snapshot")
+        _enroll("trace-mcp", display="trace-mcp", aliases=["TRACE"])
+
+    def test_requires_a_snapshot_marker(self, _isolated_home: Path) -> None:
+        _enroll("trace-mcp", aliases=["TRACE"])
+        code, out = _run("merge-stores", "--key", "trace-mcp")
+        assert code == 1 and "snapshot" in out.lower()
+
+    def test_unions_dedupes_and_keeps_premerge_originals(self, _isolated_home: Path) -> None:
+        self._prepare()
+        _write_store(_isolated_home, "trace-mcp", learnings=["shared learning", "target only"], project="trace-mcp")
+        _write_store(_isolated_home, "trace", learnings=["shared learning", "source only"], project="TRACE")
+
+        code, out = _run("merge-stores", "--key", "trace-mcp")
+        assert code == 0, out
+
+        merged = json.loads((_isolated_home / "knowledge" / "trace-mcp.json").read_text())
+        contents = {lrn["content"] for lrn in merged["learnings"]}
+        assert contents == {"shared learning", "target only", "source only"}, "dedup or union wrong"
+        assert (_isolated_home / "knowledge").glob("trace.json.premerge-*"), "source not kept as premerge"
+        assert not (_isolated_home / "knowledge" / "trace.json").exists(), "source store not renamed"
+
+    def test_refuses_when_a_lock_is_present(self, _isolated_home: Path) -> None:
+        self._prepare()
+        _write_store(_isolated_home, "trace-mcp", learnings=["a"], project="trace-mcp")
+        _write_store(_isolated_home, "trace", learnings=["b"], project="TRACE")
+        (_isolated_home / "knowledge" / "trace.json.lock").write_text("held")
+
+        code, out = _run("merge-stores", "--key", "trace-mcp")
+        assert code == 1 and "lock" in out.lower()
+        assert (_isolated_home / "knowledge" / "trace.json").exists(), "source touched despite the lock"
+
+    def test_never_merges_auto(self, _isolated_home: Path) -> None:
+        self._prepare()
+        _write_store(_isolated_home, "auto", learnings=["quarantined"], project="auto")
+        _run("merge-stores")
+        assert (_isolated_home / "knowledge" / "auto.json").exists()
+        assert json.loads((_isolated_home / "knowledge" / "auto.json").read_text())["learnings"], "auto was drained"
+
+    def test_idempotent_and_sweeps_a_reminted_source(self, _isolated_home: Path) -> None:
+        """Re-running after a laggard re-mints a raw-label store must re-merge it."""
+        self._prepare()
+        _write_store(_isolated_home, "trace-mcp", learnings=["a"], project="trace-mcp")
+        _write_store(_isolated_home, "trace", learnings=["b"], project="TRACE")
+        _run("merge-stores", "--key", "trace-mcp")
+
+        # A laggard server re-creates the raw-label store after the merge.
+        import time
+
+        time.sleep(0.01)
+        _write_store(_isolated_home, "trace", learnings=["c-new"], project="TRACE")
+        code, _ = _run("merge-stores", "--key", "trace-mcp")
+        assert code == 0
+        merged = json.loads((_isolated_home / "knowledge" / "trace-mcp.json").read_text())
+        assert "c-new" in {lrn["content"] for lrn in merged["learnings"]}
+
+    def test_logs_hashes_to_migrations(self, _isolated_home: Path) -> None:
+        self._prepare()
+        _write_store(_isolated_home, "trace-mcp", learnings=["a"], project="trace-mcp")
+        _write_store(_isolated_home, "trace", learnings=["b"], project="TRACE")
+        _run("merge-stores", "--key", "trace-mcp")
+        lines = [json.loads(x) for x in (_isolated_home / "migrations.jsonl").read_text().splitlines()]
+        merge = next(r for r in lines if r.get("op") == "store-merge")
+        assert merge["sources"][0]["source_sha256"]
+        assert merge["target_after"] == 2
+
+
+# ── adopt ──────────────────────────────────────────────────────────────────
+
+
+class TestAdopt:
+    def test_adopts_an_auto_session_append_shaped(self, _isolated_home: Path) -> None:
+        _write_session(_isolated_home, "trace_20260101_x", "auto", project_key="auto", status="completed")
+        code, out = _run("adopt", "trace_20260101_x", "--project", "Real Project", "--reason", "belongs to real")
+        assert code == 0, out
+
+        doc = json.loads((_isolated_home / "sessions" / "trace_20260101_x.json").read_text())
+        assert doc["metadata"]["project_key"] == "real-project"
+        assert doc["metadata"]["project"] == "real-project"
+        # Append-shaped: exactly one new state_change event recording old→new.
+        changes = [e for e in doc["events"] if e["type"] == "state_change"]
+        assert len(changes) == 1
+        assert changes[0]["state_change"]["old_value"] == "auto"
+        assert changes[0]["state_change"]["new_value"] == "real-project"
+
+    def test_refuses_a_real_project_session(self, _isolated_home: Path) -> None:
+        _write_session(_isolated_home, "trace_20260101_y", "waggle", project_key="waggle")
+        code, out = _run("adopt", "trace_20260101_y", "--project", "other")
+        assert code == 1 and "not the 'auto'" in out
+
+        doc = json.loads((_isolated_home / "sessions" / "trace_20260101_y.json").read_text())
+        assert doc["metadata"]["project_key"] == "waggle", "a real session was relabeled"
+        assert not [e for e in doc["events"] if e["type"] == "state_change"]
+
+    def test_refuses_a_reserved_target(self, _isolated_home: Path) -> None:
+        _write_session(_isolated_home, "trace_20260101_z", "auto", project_key="auto")
+        code, out = _run("adopt", "trace_20260101_z", "--project", "auto")
+        assert code == 1 and "reserved" in out.lower()
+
+    def test_missing_session_is_reported(self, _isolated_home: Path) -> None:
+        code, out = _run("adopt", "trace_nonexistent", "--project", "real")
+        assert code == 1 and "not found" in out.lower()
+
+
+# ── bundle ─────────────────────────────────────────────────────────────────
+
+
+class TestBundle:
+    def test_contains_only_the_target_project(self, _isolated_home: Path) -> None:
+        _enroll("waggle", display="Waggle", aliases=["WAGGLE"])
+        _write_session(_isolated_home, "trace_20260101_a", "WAGGLE")  # alias of the target
+        _write_session(_isolated_home, "trace_20260101_b", "waggle", project_key="waggle")
+        _write_session(_isolated_home, "trace_20260101_c", "other-project")  # foreign
+        _write_store(_isolated_home, "waggle", learnings=["w"], project="waggle")
+
+        dest = _isolated_home / "waggle-bundle.tar.gz"
+        code, out = _run("bundle", "--project", "waggle", "--bundle", str(dest))
+        assert code == 0, out
+
+        with tarfile.open(dest) as tar:
+            names = tar.getnames()
+        session_names = sorted(n for n in names if n.startswith("sessions/"))
+        assert session_names == ["sessions/trace_20260101_a.json", "sessions/trace_20260101_b.json"], names
+        assert "knowledge/waggle.json" in names
+        assert "project.json" in names
+
+    def test_filters_egress_rows_by_project(self, _isolated_home: Path) -> None:
+        _enroll("waggle")
+        (_isolated_home / "egress.jsonl").write_text(
+            "\n".join(
+                json.dumps(r)
+                for r in [
+                    {"project_key": "waggle", "purpose": "extraction"},
+                    {"project": "waggle", "purpose": "matching"},
+                    {"project_key": "other", "purpose": "extraction"},
+                ]
+            )
+            + "\n"
+        )
+        dest = _isolated_home / "b.tar.gz"
+        _run("bundle", "--project", "waggle", "--bundle", str(dest))
+        with tarfile.open(dest) as tar:
+            member = tar.extractfile("egress.jsonl")
+            assert member is not None
+            rows = [json.loads(x) for x in member.read().decode().splitlines() if x.strip()]
+        assert len(rows) == 2, f"foreign egress rows leaked into the bundle: {rows}"
+        assert all(r.get("project_key") == "waggle" or r.get("project") == "waggle" for r in rows)
+
+
+# ── dispatch ───────────────────────────────────────────────────────────────
+
+
+def test_bundle_egress_path_matches_the_writer(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """bundle must read the ledger from the same path the extension writes it to.
+
+    Deriving the ledger from TRACE_SESSIONS_DIR (rather than mirroring the
+    writer's resolver) would read a different file whenever the sessions dir is
+    off the default root, silently omitting every egress row from the bundle.
+    """
+    from trace_mcp.extensions.learn.egress import egress_log_path
+
+    monkeypatch.delenv("TRACE_EGRESS_LOG", raising=False)
+    monkeypatch.setenv("TRACE_SESSIONS_DIR", str(tmp_path / "elsewhere" / "sessions"))
+    assert identity_cli._egress_log_path() == egress_log_path()
+
+    monkeypatch.setenv("TRACE_EGRESS_LOG", str(tmp_path / "custom.jsonl"))
+    assert identity_cli._egress_log_path() == egress_log_path()
+
+
+def test_unknown_subcommand_errors() -> None:
+    with pytest.raises(SystemExit):
+        identity_cli.main(["not-a-command"])
+
+
+def test_server_dispatches_identity(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`trace-mcp identity …` must reach the CLI, not fall through to the server."""
+    import trace_mcp.server as server
+
+    called: dict = {}
+
+    def _fake_main(argv: list[str]) -> int:
+        called["argv"] = argv
+        return 0
+
+    monkeypatch.setattr("trace_mcp.identity_cli.main", _fake_main)
+    monkeypatch.setattr(server.sys, "argv", ["trace-mcp", "identity", "check"])
+    with pytest.raises(SystemExit) as exc:
+        server.main()
+    assert exc.value.code == 0
+    assert called["argv"] == ["check"]

--- a/tests/test_invariants.py
+++ b/tests/test_invariants.py
@@ -31,6 +31,10 @@ INV1_REGISTERED_WRITERS = {
     ("tools/session_tools.py", "append_event"),
     ("tools/session_tools.py", "end_session"),
     ("tools/decision_tools.py", "resolve_decision"),
+    # ADR-006 S6: `adopt` re-homes an auto session into a real project. It is a
+    # session write (stamps project_key + appends a state_change) and therefore
+    # routes through locked_disk_session like every other writer.
+    ("identity_cli.py", "adopt_session"),
 }
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -2145,7 +2145,7 @@ wheels = [
 
 [[package]]
 name = "trace-mcp"
-version = "0.4.2"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "mcp" },


### PR DESCRIPTION
Implements ADR-006 step S6 — the migration/repair tooling. Follows #32 (identity core + enforcement), #34 (hooks + init pin), and #35 (schema v0.5 + `project_key`). This PR ships **tools only**; it does not run them against any live store. Executing the migration against a real `~/.trace` is the separate, human-gated S8 runbook.

## Summary

Seven `trace-mcp identity` subcommands, plus identity fields on the health check:

| Command | What it does |
|---|---|
| `snapshot` | back up the store (counting by direct glob) and write the marker the destructive phases require |
| `scan` | group drifted labels by canonical key into a human-editable plan; writes no registry state |
| `apply` | mint the reviewed plan into the registry (idempotent; snapshot-gated) |
| `check` | report drift (stray stores, unresolved labels, registry health); non-zero exit on findings |
| `merge-stores` | consolidate an alias group's knowledge stores — reversible, logged, live-writer-gated |
| `adopt` | re-home an `auto` session into a real project, append-shaped |
| `bundle` | export one project as a self-contained tarball |

`trace_health_check` gains a `pinned` / `bound_project_key` / `registry` / `stray_knowledge_stores` block.

## Design commitments (from ADR-006)

**Capture records are never rewritten.** `scan`/`apply` only build the alias index. `adopt` is the one session-touching command and it is append-shaped — it records old→new as a `state_change` event and stamps `project_key`, never an in-place edit — so it survives the ADR-005 journal as an ordinary append. It re-homes only `auto`-quarantine sessions and will not relabel a real project's record.

**The store is enumerated by direct glob, never `list_sessions`.** The query layer caps at 500 files, which would hide the oldest sessions — exactly the ones most likely to carry drifted labels. A 600-session fixture test pins this.

**Reversible and gated.** `merge-stores` keeps sources as `*.premerge-<date>`, regenerates the embedding sidecar rather than migrating it, logs every merge to `migrations.jsonl` with content hashes, is idempotent (re-runnable to sweep a laggard-re-minted store), and refuses to run while any knowledge lock is held or a store was just written. Both `apply` and `merge-stores` refuse without a snapshot marker. The `auto` quarantine is never merged.

**One drift detector, two callers.** `check` (CLI) and `trace_health_check` (tool) share a single core `identity_report` function, so a health probe and an explicit check can never disagree about whether a store is clean.

## Invariants

- `adopt_session` is a session writer: it routes through the fail-closed `locked_disk_session` helper and is registered as an **INV-1** write path (`docs/INVARIANTS.md` + the enumeration guard). Because it appends to a typically-completed quarantine session, it is also recorded as the **second sanctioned INV-2 post-completion mutation**, gated on the session resolving to a reserved key rather than on status.
- `identity_cli` is core. `merge-stores` imports the trace-learn store **lazily inside its own function body**, so the module never imports the extension at load time (**ADR-003**); `check` scans stray stores by filename glob and needs no learn import. The core/extension boundary guard passes.

## Verification

- Full suite **1198 passed, 11 skipped** (up from 1167; 31 new identity-CLI tests).
- Every CLI test runs against a throwaway `tmp_path` home — **nothing touches a real `~/.trace`**.
- Coverage includes: the 600-session direct-glob scan-cap regression; live-writer and reserved-store merge refusals; merge dedup + premerge preservation + idempotent re-sweep + hash logging; adopt's append shape, real-project refusal, and reserved-target refusal; bundle project-only selection and egress-row filtering; and a guard that `bundle` reads the egress ledger from the exact path the writer resolves.
- `ruff check` + `ruff format --check` + `pyright` (0 errors) + the INV-1/boundary guards + `uv build` + packaging artifacts all pass.
- The built wheel's `trace-mcp identity` runs end-to-end from a clean install (all seven subcommands present; `snapshot` and `check` functional).

## Note on the run environment

A stale editable install in the dev virtualenv was making heavy imports (`numpy`) take ~16s each, which surfaced as apparent test hangs and one load-induced e2e handshake timeout during a saturated run. A clean reinstall dropped it to ~0.03s; the erroring tests all pass in isolation and the definitive full run is green in 94s. The included `uv.lock` change is the `0.4.2 → 0.5.0` version bump that belongs with the schema release.

## Risks / rollback

Additive: a new CLI surface plus four fields on the health response; no existing tool signature changes. Nothing here mutates a store on import or on the server's normal paths — the commands act only when explicitly invoked. Reverting the commit removes the CLI cleanly. Running the tooling against real data is out of scope for this PR and remains human-gated (S8).