### PR TITLE
fix(cli): harden identity migration tooling against audit and data-loss defects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`identity apply` no longer logs mints that never happened.** Migration
+  records were appended to `migrations.jsonl` inside the registry transaction;
+  when the write failed (e.g. an alias-uniqueness violation), the registry
+  correctly persisted nothing while the append-only audit log already claimed
+  the mints occurred. Records are now buffered and written only after the
+  registry commit — a migration log that lies is worse than no log at all.
+- **`identity merge-stores` refuses a corrupt target store.** The non-strict
+  loader returned a fresh store on corruption, so the merged result silently
+  replaced the damaged-but-recoverable original — the one file the merge keeps
+  no premerge backup of. The target is now loaded strictly and corruption
+  aborts the merge with the original untouched.
+- **`identity check` and `identity scan` treat the `auto` quarantine as an
+  expected population, not drift.** `check` flagged every `auto` session as an
+  unregistered label, so a store holding any auto session could never reach the
+  exit-0 verification the migration runbook requires; `scan` proposed a plan
+  entry for the reserved key that `apply` then re-refused. Reserved-key labels
+  are now excluded from both.
+- **`identity adopt` no longer rewrites the captured display label.** It
+  stamped `project_key` and also overwrote `metadata.project` — an in-place
+  mutation of a captured field beyond what the alias-table-first rule
+  sanctions. Only the additive key is stamped now; every identity-aware
+  consumer resolves the session through it while the record keeps showing what
+  was originally captured.
+- **`identity scan` refuses to overwrite an existing plan file.** The plan is
+  where the operator's decisions live between `scan` and `apply`; a re-run
+  silently clobbered those edits.
+- **`identity snapshot` archives a relocated knowledge directory.** With
+  `TRACE_KNOWLEDGE_DIR` outside the TRACE home, stores were counted in the
+  manifest but absent from the archive — and the marker the snapshot writes is
+  what green-lights the destructive merge phase. The external directory is now
+  included and the manifest records its location.
+- **`identity merge-stores` holds the target store's lock** for the
+  load→union→save→rename span (the mtime/lock preflight is advisory and racy),
+  and `--key` now resolves aliases and display labels to the registered key
+  instead of skipping them.
 - **The project registry did not resolve an entry by its own display label.**
   `ProjectRegistry.resolve()` matched a label against an entry's key and aliases but
   not its display label, so an entry whose display label does not canonicalize to its

--- a/src/trace_mcp/identity_cli.py
+++ b/src/trace_mcp/identity_cli.py
@@ -165,10 +165,17 @@ def cmd_snapshot(args: argparse.Namespace, out) -> int:
     session_files = list(_iter_session_files())
     knowledge = identity_report.knowledge_dir()
     knowledge_files = sorted(knowledge.glob("*.json")) if knowledge.is_dir() else []
+    # A relocated knowledge dir (TRACE_KNOWLEDGE_DIR outside the home) must be
+    # archived TOO: the marker this snapshot writes is what green-lights the
+    # destructive merge phase, and merge-stores destroys knowledge sources — a
+    # backup that counted those stores without containing them would be a lie.
+    knowledge_external = knowledge.is_dir() and not knowledge.resolve().is_relative_to(home.resolve())
 
     with tarfile.open(archive, "w:gz") as tar:
         # Exclude the backups dir itself so the archive never contains prior archives.
         tar.add(home, arcname=home.name, filter=lambda ti: None if "/backups/" in ti.name + "/" else ti)
+        if knowledge_external:
+            tar.add(knowledge, arcname=f"{home.name}-external-knowledge")
 
     manifest = {
         "created": _now(),
@@ -179,6 +186,8 @@ def cmd_snapshot(args: argparse.Namespace, out) -> int:
             "knowledge_stores": len(knowledge_files),
         },
         "trace_home": str(home),
+        "knowledge_dir": str(knowledge),
+        "knowledge_dir_external": knowledge_external,
     }
     marker = _snapshot_marker()
     marker.parent.mkdir(parents=True, exist_ok=True)
@@ -218,6 +227,11 @@ def _collect_label_groups() -> dict[str, dict[str, Any]]:
         try:
             key = pident.canonical_project_key(label)
         except pident.ProjectKeyError:
+            continue
+        if key in pident.RESERVED_KEYS:
+            # The auto quarantine is an expected population, not drift, and it is
+            # never enrolled: a plan entry for it would only be re-refused by
+            # `apply` and confuse the operator into thinking it needs deciding.
             continue
         g = _group(key)
         if label not in g["labels"]:
@@ -262,6 +276,15 @@ def cmd_scan(args: argparse.Namespace, out) -> int:
         ],
     }
     dest = Path(args.output).expanduser() if args.output else _trace_home() / f"identity-plan-{_today()}.json"
+    if dest.exists():
+        # A plan file is where the human's decisions live between scan and apply.
+        # Overwriting one on a re-run would silently destroy those edits.
+        print(
+            f"Error: {dest} already exists — refusing to overwrite a possibly-edited plan. "
+            "Move it aside or pass a different --output path.",
+            file=out,
+        )
+        return 1
     dest.parent.mkdir(parents=True, exist_ok=True)
     dest.write_text(json.dumps(plan, indent=2) + "\n")
     print(f"Scan plan written: {dest}", file=out)
@@ -284,6 +307,12 @@ def cmd_apply(args: argparse.Namespace, out) -> int:
         return 1
 
     minted, updated, skipped = 0, 0, 0
+    # Migration records are BUFFERED and appended only after the registry write
+    # commits. locked_registry persists on clean exit and discards everything on
+    # failure (e.g. an alias-uniqueness violation) — logging inside the block
+    # would record mints that never happened, and a migration log that lies is
+    # worse than no log at all.
+    pending_records: list[dict[str, Any]] = []
     try:
         with pident.locked_registry() as registry:
             for entry in plan["projects"]:
@@ -306,7 +335,7 @@ def cmd_apply(args: argparse.Namespace, out) -> int:
                             actor="identity apply", action="mint", details={"key": key, "aliases": aliases}
                         )
                     )
-                    _append_migration({"op": "mint", "key": key, "display_label": display, "aliases": aliases})
+                    pending_records.append({"op": "mint", "key": key, "display_label": display, "aliases": aliases})
                     minted += 1
                 else:
                     new_aliases = sorted(set(existing.aliases) | set(aliases))
@@ -317,7 +346,7 @@ def cmd_apply(args: argparse.Namespace, out) -> int:
                                 actor="identity apply", action="alias-add", details={"key": key, "aliases": new_aliases}
                             )
                         )
-                        _append_migration({"op": "alias-add", "key": key, "aliases": new_aliases})
+                        pending_records.append({"op": "alias-add", "key": key, "aliases": new_aliases})
                         updated += 1
                     else:
                         skipped += 1
@@ -325,8 +354,10 @@ def cmd_apply(args: argparse.Namespace, out) -> int:
         print(f"Error: registry is unreadable ({exc}); refusing to overwrite it.", file=out)
         return 1
     except (TimeoutError, ValueError) as exc:
-        print(f"Error: could not apply plan ({exc}).", file=out)
+        print(f"Error: could not apply plan ({exc}); nothing was written.", file=out)
         return 1
+    for record in pending_records:
+        _append_migration(record)
 
     print(f"Applied: {minted} minted, {updated} alias-updated, {skipped} unchanged.", file=out)
     return 0
@@ -369,6 +400,15 @@ def cmd_check(args: argparse.Namespace, out) -> int:
             label = _session_label(data)
             if label is None:
                 continue
+            try:
+                if pident.canonical_project_key(label) in pident.RESERVED_KEYS:
+                    # The auto quarantine is an expected, permanently-unenrolled
+                    # population — flagging it would make a store holding ANY auto
+                    # session fail `check` forever, and exit-0 is the migration
+                    # runbook's verification criterion.
+                    continue
+            except pident.ProjectKeyError:
+                pass  # degenerate label: fall through and report it as unknown
             if registry.resolve(label) is None:
                 unknown_labels[label] = unknown_labels.get(label, 0) + 1
         if unknown_labels:
@@ -449,9 +489,19 @@ def cmd_merge_stores(args: argparse.Namespace, out) -> int:
         print("Nothing to merge: no knowledge directory.", file=out)
         return 0
 
-    # Which canonical keys to consolidate: a specific one, or every registered key
-    # that has at least one aliased source store on disk.
-    target_keys = [args.key] if args.key else sorted(registry.projects)
+    # Which canonical keys to consolidate: a specific one (resolving an alias or
+    # display label to its key, so `--key TRACE` reaches the trace-mcp entry
+    # instead of being skipped), or every registered key with aliased sources.
+    if args.key:
+        resolved = registry.resolve(args.key)
+        if resolved is None:
+            print(f"Error: '{args.key}' resolves to no registered project.", file=out)
+            return 1
+        if resolved != args.key:
+            print(f"  '{args.key}' resolved to registered key '{resolved}'.", file=out)
+        target_keys = [resolved]
+    else:
+        target_keys = sorted(registry.projects)
 
     merged_any = False
     for key in target_keys:
@@ -484,54 +534,75 @@ def cmd_merge_stores(args: argparse.Namespace, out) -> int:
         if not _preflight_merge(involved, out):
             return 1
 
-        # Load target (or start fresh), union each source in with Jaccard dedup.
-        target_store = learn_store.load_store(key)
-        before_target = len(target_store.learnings)
-        merge_records: list[dict[str, Any]] = []
-        for src in source_paths:
-            raw = _read_json(src)
-            if raw is None:
-                print(f"  skipping unreadable source {src.name}", file=out)
-                continue
-            src_store = KnowledgeStore.model_validate(raw)
-            added, deduped = 0, 0
-            for lrn in src_store.learnings:
-                if learn_store.find_duplicate(target_store, lrn.content) is not None:
-                    deduped += 1
-                    continue
-                new = lrn.model_copy(update={"id": target_store.next_learning_id()})
-                target_store.learnings.append(new)
-                added += 1
-            merge_records.append(
-                {
-                    "source": src.name,
-                    "source_sha256": _sha256(src),
-                    "learnings": len(src_store.learnings),
-                    "added": added,
-                    "deduped": deduped,
-                }
-            )
+        # The preflight is advisory (a writer could arrive between it and the
+        # write), so the whole load→union→save→rename span additionally holds
+        # the target's own store lock — the same lock every learn writer takes.
+        # Acquired AFTER the preflight, whose global lock scan would otherwise
+        # refuse on our own lock file. A concurrent holder makes this raise
+        # (fail closed) rather than merge under them.
+        try:
+            with learn_store.project_lock(key):
+                # Fail closed on a corrupt TARGET: the non-strict loader would
+                # hand back a fresh store, and saving the union over it would
+                # replace the damaged-but-recoverable original — the one file
+                # this command does not keep a premerge copy of.
+                try:
+                    target_store = learn_store.load_store(key, strict=True)
+                except learn_store.StoreLoadError as exc:
+                    print(f"Error: target store for '{key}' is unreadable ({exc}). Repair or move it first.", file=out)
+                    return 1
+                before_target = len(target_store.learnings)
+                merge_records: list[dict[str, Any]] = []
+                for src in source_paths:
+                    raw = _read_json(src)
+                    if raw is None:
+                        print(f"  skipping unreadable source {src.name}", file=out)
+                        continue
+                    src_store = KnowledgeStore.model_validate(raw)
+                    added, deduped = 0, 0
+                    for lrn in src_store.learnings:
+                        if learn_store.find_duplicate(target_store, lrn.content) is not None:
+                            deduped += 1
+                            continue
+                        new = lrn.model_copy(update={"id": target_store.next_learning_id()})
+                        target_store.learnings.append(new)
+                        added += 1
+                    merge_records.append(
+                        {
+                            "source": src.name,
+                            "source_sha256": _sha256(src),
+                            "learnings": len(src_store.learnings),
+                            "added": added,
+                            "deduped": deduped,
+                        }
+                    )
 
-        # Ensure the merged store declares the canonical key, then persist +
-        # regenerate the sidecar (save_store rewrites the .npy from inline vectors).
-        target_store.project = key
-        learn_store.save_store(target_store)
-        after_target = len(target_store.learnings)
+                # Ensure the merged store declares the canonical key, then persist +
+                # regenerate the sidecar (save_store rewrites the .npy from inline
+                # vectors). Still under the target lock: the save and the source
+                # renames are one unit a concurrent writer must not interleave.
+                target_store.project = key
+                learn_store.save_store(target_store)
+                after_target = len(target_store.learnings)
 
-        # Rename sources to premerge backups (kept forever) — reversible by hand.
-        premerges = []
-        for src in source_paths:
-            backup = src.with_name(f"{src.name}.premerge-{_today()}")
-            n = 1
-            while backup.exists():
-                backup = src.with_name(f"{src.name}.premerge-{_today()}-{n}")
-                n += 1
-            src.rename(backup)
-            premerges.append(backup.name)
-            # The source's sidecar is a derived artifact — drop it (regenerated for the target).
-            sidecar = src.with_suffix(".embeddings.npy")
-            if sidecar.exists():
-                sidecar.unlink()
+                # Rename sources to premerge backups (kept forever) — reversible by hand.
+                premerges = []
+                for src in source_paths:
+                    backup = src.with_name(f"{src.name}.premerge-{_today()}")
+                    n = 1
+                    while backup.exists():
+                        backup = src.with_name(f"{src.name}.premerge-{_today()}-{n}")
+                        n += 1
+                    src.rename(backup)
+                    premerges.append(backup.name)
+                    # The source's sidecar is a derived artifact — drop it
+                    # (regenerated for the target).
+                    sidecar = src.with_suffix(".embeddings.npy")
+                    if sidecar.exists():
+                        sidecar.unlink()
+        except TimeoutError as exc:
+            print(f"Error: could not acquire the store lock for '{key}' ({exc}). Aborting.", file=out)
+            return 1
 
         _append_migration(
             {
@@ -598,7 +669,13 @@ async def adopt_session(storage, session_id: str, target_key: str, reason: str |
         )
         event.id = write_session.next_event_id()
         write_session.events.append(event)
-        write_session.metadata.project = target_key
+        # Stamp the ADDITIVE key only. The captured display label (`project`,
+        # here the 'auto' sentinel) is left verbatim: ADR-006 §7 sanctions
+        # stamping project_key and appending the state_change, nothing more, and
+        # rewriting a captured field is exactly what alias-table-first forbids.
+        # Every consumer resolves identity through session_project_key, which
+        # prefers the stamp — so the session reads as the target project
+        # everywhere while its record still shows what was originally captured.
         write_session.metadata.project_key = target_key
         await storage.update_session(write_session)
 

--- a/tests/test_identity_cli.py
+++ b/tests/test_identity_cli.py
@@ -322,12 +322,17 @@ class TestAdopt:
 
         doc = json.loads((_isolated_home / "sessions" / "trace_20260101_x.json").read_text())
         assert doc["metadata"]["project_key"] == "real-project"
-        assert doc["metadata"]["project"] == "real-project"
+        # The captured display label is NEVER rewritten (ADR-006 §7 sanctions
+        # stamping the additive key + appending the event, nothing more) — the
+        # record keeps showing what was originally captured.
+        assert doc["metadata"]["project"] == "auto", "adopt rewrote the captured display label"
         # Append-shaped: exactly one new state_change event recording old→new.
         changes = [e for e in doc["events"] if e["type"] == "state_change"]
         assert len(changes) == 1
         assert changes[0]["state_change"]["old_value"] == "auto"
         assert changes[0]["state_change"]["new_value"] == "real-project"
+        # And every identity-aware consumer resolves the session to the target.
+        assert pident.session_project_key(doc["metadata"]) == "real-project"
 
     def test_refuses_a_real_project_session(self, _isolated_home: Path) -> None:
         _write_session(_isolated_home, "trace_20260101_y", "waggle", project_key="waggle")
@@ -434,3 +439,153 @@ def test_server_dispatches_identity(monkeypatch: pytest.MonkeyPatch) -> None:
         server.main()
     assert exc.value.code == 0
     assert called["argv"] == ["check"]
+
+
+# ── adversarial-review regression guards ───────────────────────────────────
+
+
+class TestReservedQuarantineHandling:
+    """The auto quarantine is an expected population, not drift.
+
+    Before these guards, scan proposed a plan entry for the reserved `auto` key
+    (which apply then re-refused, confusingly), and check flagged every auto
+    session as an unknown label — so a store holding ANY auto session could
+    never pass the migration runbook's `identity check` exit-0 criterion.
+    """
+
+    def test_scan_excludes_reserved_session_labels(self, _isolated_home: Path) -> None:
+        _write_session(_isolated_home, "trace_20260101_a", "auto")
+        _write_session(_isolated_home, "trace_20260101_b", "waggle")
+
+        _run("scan", "-o", str(_isolated_home / "plan.json"))
+        plan = json.loads((_isolated_home / "plan.json").read_text())
+        keys = [p["key"] for p in plan["projects"]]
+        assert keys == ["waggle"], f"reserved keys leaked into the plan: {keys}"
+
+    def test_check_passes_with_auto_sessions_present(self, _isolated_home: Path) -> None:
+        _enroll("waggle")
+        _write_session(_isolated_home, "trace_20260101_a", "auto")
+        _write_session(_isolated_home, "trace_20260101_b", "waggle")
+
+        code, out = _run("check")
+        assert code == 0, f"the auto quarantine was reported as drift: {out}"
+
+
+class TestApplyAuditAtomicity:
+    def test_failed_apply_logs_no_mint_records(self, _isolated_home: Path) -> None:
+        """The migration log must record what HAPPENED, not what was attempted.
+
+        An alias-collision plan makes the registry write fail atomically; a mint
+        record for an entry that never persisted would make the repair's own
+        audit trail lie.
+        """
+        _run("snapshot")
+        plan = _isolated_home / "plan.json"
+        plan.write_text(
+            json.dumps(
+                {
+                    "projects": [
+                        {"key": "alpha", "display_label": "Alpha", "aliases": ["SHARED-NAME"]},
+                        {"key": "beta", "display_label": "Beta", "aliases": ["shared-name"]},
+                    ]
+                }
+            )
+        )
+        code, out = _run("apply", "--plan", str(plan))
+        assert code == 1 and "could not apply" in out
+
+        pident._reset_registry_cache()
+        assert pident.load_registry(required=False) is None, "a partial registry was persisted"
+        lines = [json.loads(x) for x in (_isolated_home / "migrations.jsonl").read_text().splitlines()]
+        mints = [r for r in lines if r.get("op") == "mint"]
+        assert mints == [], f"the audit log recorded mints that never persisted: {mints}"
+
+
+class TestMergeTargetSafety:
+    def test_merge_refuses_a_corrupt_target(self, _isolated_home: Path) -> None:
+        """A corrupt target must abort the merge, not be silently replaced.
+
+        The non-strict loader hands back a fresh store on corruption; saving the
+        union over it would destroy the damaged-but-recoverable original — the
+        one file merge-stores keeps no premerge copy of.
+        """
+        _run("snapshot")
+        _enroll("trace-mcp", aliases=["TRACE"])
+        corrupt = _isolated_home / "knowledge" / "trace-mcp.json"
+        corrupt.write_text("{THIS IS NOT JSON")
+        _write_store(_isolated_home, "trace", learnings=["from source"], project="TRACE")
+
+        code, out = _run("merge-stores", "--key", "trace-mcp")
+        assert code == 1 and "unreadable" in out
+        assert corrupt.read_text() == "{THIS IS NOT JSON", "the corrupt target was overwritten"
+        assert (_isolated_home / "knowledge" / "trace.json").exists(), "a source was renamed despite the abort"
+
+    def test_merge_key_resolves_an_alias(self, _isolated_home: Path) -> None:
+        _run("snapshot")
+        _enroll("trace-mcp", aliases=["TRACE"])
+        _write_store(_isolated_home, "trace-mcp", learnings=["a"], project="trace-mcp")
+        _write_store(_isolated_home, "trace", learnings=["b"], project="TRACE")
+
+        code, out = _run("merge-stores", "--key", "TRACE")
+        assert code == 0, out
+        assert "resolved to registered key 'trace-mcp'" in out
+        merged = json.loads((_isolated_home / "knowledge" / "trace-mcp.json").read_text())
+        assert {lrn["content"] for lrn in merged["learnings"]} == {"a", "b"}
+
+    def test_merge_fails_closed_when_the_target_lock_appears_after_preflight(
+        self, _isolated_home: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The preflight is advisory; the store lock is the guarantee.
+
+        Simulates the race by disabling the preflight and pre-holding the
+        target's lock: the merge must abort without touching anything.
+        """
+        _run("snapshot")
+        _enroll("trace-mcp", aliases=["TRACE"])
+        _write_store(_isolated_home, "trace-mcp", learnings=["a"], project="trace-mcp")
+        source = _write_store(_isolated_home, "trace", learnings=["b"], project="TRACE")
+        monkeypatch.setattr(identity_cli, "_preflight_merge", lambda paths, out: True)
+        monkeypatch.setenv("TRACE_LOCK_TIMEOUT", "0.2")
+        # Pre-hold the target's lock as a live writer would.
+        (_isolated_home / "knowledge" / "trace-mcp.json.lock").write_text(f"{__import__('os').getpid()}:1")
+
+        code, out = _run("merge-stores", "--key", "trace-mcp")
+        assert code == 1 and "store lock" in out
+        assert source.exists(), "a source was renamed despite the held lock"
+        merged = json.loads((_isolated_home / "knowledge" / "trace-mcp.json").read_text())
+        assert {lrn["content"] for lrn in merged["learnings"]} == {"a"}, "the target was written under a held lock"
+
+
+class TestScanPlanPreservation:
+    def test_scan_refuses_to_overwrite_an_existing_plan(self, _isolated_home: Path) -> None:
+        """A plan file holds the human's decisions between scan and apply."""
+        _write_session(_isolated_home, "trace_20260101_a", "waggle")
+        plan = _isolated_home / "plan.json"
+        assert _run("scan", "-o", str(plan))[0] == 0
+        plan.write_text('{"projects": [], "HUMAN_EDITS": true}')
+
+        code, out = _run("scan", "-o", str(plan))
+        assert code == 1 and "refusing to overwrite" in out
+        assert "HUMAN_EDITS" in plan.read_text(), "the edited plan was clobbered"
+
+
+class TestSnapshotExternalKnowledge:
+    def test_external_knowledge_dir_is_archived(
+        self, _isolated_home: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The marker green-lights destructive merges; the backup it attests to
+        must actually contain the knowledge the merge will destroy."""
+        external = tmp_path / "external-knowledge"
+        external.mkdir()
+        monkeypatch.setenv("TRACE_KNOWLEDGE_DIR", str(external))
+        (external / "waggle.json").write_text(json.dumps({"project": "waggle", "learnings": []}))
+
+        code, _ = _run("snapshot")
+        assert code == 0
+        marker = json.loads((_isolated_home / "backups" / ".snapshot-marker.json").read_text())
+        assert marker["knowledge_dir_external"] is True
+        assert marker["counts"]["knowledge_stores"] == 1
+        with tarfile.open(marker["archive"]) as tar:
+            assert any("waggle.json" in n for n in tar.getnames()), (
+                "the external knowledge store was counted but not archived"
+            )


### PR DESCRIPTION
Hardening pass over the `trace-mcp identity` CLI (merged in #36) before the tooling is ever pointed at a live store. Each command was fault-injected against the edge states a real migration will encounter — a populated `auto` quarantine, corrupted files, re-run commands, relocated data directories, held locks, colliding plans. Eight defects surfaced; all are fixed here with a regression guard apiece.

## The two serious ones

**The migration log could lie.** `apply` appended mint records to `migrations.jsonl` *inside* the registry transaction. On a failing plan (alias-uniqueness violations reject the whole write atomically), the registry correctly persisted nothing — while the append-only audit log already recorded the mints as having happened. For a tool whose whole purpose is provenance-honest repair, an audit trail that records events that never occurred is the worst available failure mode. Records are now buffered and written only after the registry commit.

**A corrupt target store was silently destroyed.** `merge-stores` loaded the merge target with the non-strict loader, which returns a fresh empty store on corruption; saving the merged union then replaced the damaged-but-recoverable original — the one file the merge keeps no premerge backup of. The target is now loaded strictly; corruption aborts the merge with the original byte-untouched.

## The other six

- **`check` could never pass on the live store**: it flagged every `auto` session as an unregistered label, and exit-0 from `check` is the migration runbook's verification criterion. `scan` likewise proposed a plan entry for the reserved key that `apply` then re-refused. Both now treat reserved-key labels as the expected quarantine population they are.
- **`adopt` rewrote the captured display label** in addition to stamping `project_key`. The design sanctions the additive stamp plus the appended `state_change`, nothing more — rewriting a captured field is precisely what alias-table-first forbids. Only the key is stamped now; identity-aware consumers resolve through it while the record keeps showing what was captured.
- **`scan` silently overwrote an existing plan file** — the file holding the operator's decisions between `scan` and `apply`. It now refuses with guidance.
- **`snapshot` counted knowledge stores it did not archive** when `TRACE_KNOWLEDGE_DIR` sits outside the TRACE home — and the marker it writes green-lights the destructive merge phase. The external directory is now archived and the manifest records its location.
- **`merge-stores` now holds the target store's own lock** across load→union→save→rename. The mtime/lock preflight is advisory (a writer can arrive between it and the write); the lock is the guarantee, verified by a test that pre-holds it and asserts a fail-closed abort.
- **`merge-stores --key` resolves aliases**: `--key TRACE` reaches the `trace-mcp` entry instead of being skipped as "not a registered key".

## Verified clean (no change needed)

Backup-exclusion filtering in the snapshot tar, learning-id minting under sparse ids (max-based), event-id assignment under adopt's per-session lock, bundle behavior on missing directories and unenrolled projects, canonical-key charsets as tar arcnames, and adoption of still-active sessions.

## Verification

- Full suite **1206 passed, 11 skipped** (8 new regression guards — each one is the fault injection that surfaced its defect, made permanent).
- `ruff check` + `ruff format --check` + `pyright` (0 errors) + invariant registry guard + core/extension boundary guard.
- The `adopt` display-label test was corrected along with the behavior: it previously asserted the rewrite.

## Risks / rollback

Strictly tightening: every change converts a silent wrong outcome into either a refusal with guidance or a correct one. No schema, tool-signature, or storage-format changes. Revert the commit to restore prior behavior.