### PR TITLE
feat(learn): per-project privacy ratchet, attributed egress, fail-closed stores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Egress ledger rows carry a `project_key` column (all three purposes).** The
+  matching and embedding attest sites sit in layers that deliberately know
+  nothing about projects, so their rows were unattributable; the canonical key
+  now travels from the tool boundary in a context variable (`egress_project`)
+  and every row is attributed. The extraction site passes the key explicitly,
+  resolved through the alias registry so an aliased legacy label attributes to
+  its real project. Rows written before v0.5 carry no key and are never
+  rewritten. The ledger stays one global append-only file.
+- **Per-project privacy ratchet is now applied** (`effective_learn_config`).
+  A project's registry entry (`local_only` / `llm_enabled` /
+  `embedding_backend_max`) tightens the machine-global config at all three
+  egress decision points — extraction, LLM matching, and embedding-backend
+  selection — for that project's calls, pinned or not. Restrict-only: an entry
+  can force a confidentiality-bound project fully local against a permissive
+  global, never loosen a global restriction. If the registry exists but is
+  unreadable, learn tools fail closed (the posture that would forbid the
+  egress may live in the unreadable file) while session capture is unaffected;
+  the auto-recall/extract hooks skip loudly instead of raising, because they
+  run inside capture paths that must complete.
+- **Project-wide extraction enumerates the store by direct glob.** It
+  previously went through the query layer, whose 500-file scan cap silently
+  hid the oldest sessions of a large store — exactly the ones a project-wide
+  extraction exists to mine. Matching is by canonical key; storage backends
+  without a filesystem location fall back to the query path.
+
+### Changed
+
+- **`load_store` fails closed on a corrupt knowledge store.** A file that
+  exists but cannot be parsed or validated now raises `StoreLoadError` instead
+  of returning a fresh empty store. The silent fallback meant the next save
+  atomically replaced the damaged-but-recoverable original with an empty
+  store, and read to callers as "this project has no learnings" when the truth
+  was "this project's learnings are unreadable". A missing file still returns
+  a fresh store (normal first use). Read aggregates (`project_summary`,
+  self-cost) skip-and-report the damage rather than aborting; the learn tools
+  surface a clear error with the file untouched.
+
 - **`trace-mcp identity` migration tooling (ADR-006 S6).** Seven subcommands turn
   the identity enforcement machinery into an operator can run against a store that
   predates canonical keys, without ever rewriting a capture record:

--- a/docs/embeddings.md
+++ b/docs/embeddings.md
@@ -101,11 +101,43 @@ strict config (`TRACE_STRICT_LLM=true`) it raises. This is INV-5 in
 OpenAI call site appears without an attestation, so the ledger stays complete
 by construction.
 
+**Project attribution (v0.5)**: every row also carries a `project_key` column —
+the canonical project key the call was made on behalf of. The matching and
+embedding rows were previously unattributable (their call sites sit in layers
+that know nothing about projects); the key now travels from the tool boundary
+in a context variable, so all three purposes write attributed rows. Rows
+written before v0.5 have no `project_key` and are never rewritten — resolve
+their `project` display label through the alias registry instead.
+
 To inspect your machine's egress history:
 
 ```bash
 cat ~/.trace/egress.jsonl | python3 -m json.tool --json-lines
 ```
+
+To audit one project's egress (joining old label-only rows via the registry is
+the consumer's job; for post-v0.5 rows the key column suffices):
+
+```bash
+python3 - <<'EOF'
+import json, pathlib
+key = "my-project"
+for line in pathlib.Path.home().joinpath(".trace/egress.jsonl").read_text().splitlines():
+    row = json.loads(line)
+    if row.get("project_key") == key:
+        print(row["ts"], row["purpose"], row["endpoint"], row["item_count"])
+EOF
+```
+
+**Per-project privacy ratchet (v0.5)**: a project's registry entry
+(`~/.trace/projects.json`) can carry `{"local_only": true}`,
+`{"llm_enabled": false}`, or `{"embedding_backend_max": "local"}` under its
+`config` key. These apply at all three egress decision points as a
+**restrict-only** ratchet: an entry can force a confidentiality-bound project
+fully local against a permissive machine-global config, but can never loosen a
+global restriction. If the registry exists but is unreadable, learn operations
+fail closed for every project — the posture that would forbid the egress may
+live in the unreadable file.
 
 ## Switching backends re-embeds your store
 

--- a/src/trace_mcp/extensions/learn/__init__.py
+++ b/src/trace_mcp/extensions/learn/__init__.py
@@ -17,10 +17,16 @@ from typing import TYPE_CHECKING, cast, get_args
 from trace_mcp import project_identity as pident
 from trace_mcp.extension_hooks import register_extract_hook, register_recall_hook
 from trace_mcp.extensions.learn import extraction, matching, store
-from trace_mcp.extensions.learn.config import load_config
+from trace_mcp.extensions.learn.config import effective_learn_config, load_config
+from trace_mcp.extensions.learn.egress import egress_project
 from trace_mcp.extensions.learn.embeddings import get_embedding_provider
 from trace_mcp.extensions.learn.matching import DecayParams
 from trace_mcp.extensions.learn.models import KnowledgeStore, Learning, LearningCategory
+
+if TYPE_CHECKING:
+    from trace_mcp.extensions.learn.config import LearnConfig
+    from trace_mcp.extensions.learn.embeddings import EmbeddingProvider
+    from trace_mcp.extensions.learn.matching import MatchingBackend
 
 _VALID_CATEGORIES = get_args(LearningCategory)
 
@@ -61,8 +67,44 @@ def register(mcp: FastMCP, storage: TraceStorage) -> None:
         evergreen_floor=_config.evergreen_floor,
     )
 
-    async def _embed_learnings(learnings: list[Learning]) -> bool:
+    # Per-project ratcheted (config, backend, provider) triples. Keyed by the
+    # canonical key PLUS the entry's posture fields, so an edited registry entry
+    # takes effect on its next call rather than serving a stale triple for the
+    # life of the process. Only ratcheted projects land here — the common
+    # unrestricted path returns the process-wide globals via `eff is _config`.
+    _ratchet_cache: dict[tuple, tuple[LearnConfig, MatchingBackend, EmbeddingProvider | None]] = {}
+
+    def _effective(project: str) -> tuple[LearnConfig, MatchingBackend, EmbeddingProvider | None]:
+        """The (config, matching backend, embedding provider) to use for *project*.
+
+        Applies the registry's restrict-only privacy ratchet (ADR-006 §6).
+        Raises ``RegistryUnavailableError`` when the registry exists but cannot
+        be read — the caller's knowledge/egress path must fail closed, because
+        the posture that would forbid the egress may live in the unreadable file.
+        """
+        eff = effective_learn_config(_config, project)
+        if eff is _config:
+            return _config, _backend, _embedding_provider
+        cache_key = (
+            pident.key_for_label(project),
+            eff.local_only,
+            eff.llm_enabled,
+            eff.embedding_backend,
+        )
+        cached = _ratchet_cache.get(cache_key)
+        if cached is None:
+            cached = (eff, matching.get_default_backend(eff), get_embedding_provider(eff))
+            _ratchet_cache[cache_key] = cached
+        return cached
+
+    async def _embed_learnings(
+        learnings: list[Learning],
+        provider: EmbeddingProvider | None = None,
+    ) -> bool:
         """Generate embeddings for learnings that need them.  Returns True if any were updated.
+
+        *provider* is the (possibly ratchet-downgraded) provider for the calling
+        project; ``None`` falls back to the process-wide one.
 
         Raises ``LLMFallbackError`` in strict mode when the embedding provider
         fails, rather than silently saving un-embedded learnings (which would
@@ -70,45 +112,78 @@ def register(mcp: FastMCP, storage: TraceStorage) -> None:
         """
         from trace_mcp.extensions.learn.config import LLMFallbackError
 
-        if _embedding_provider is None or not learnings:
+        active = provider if provider is not None else _embedding_provider
+        if active is None or not learnings:
             return False
         try:
             texts = [lrn.content for lrn in learnings]
-            vecs = await _embedding_provider.embed_texts(texts)
+            vecs = await active.embed_texts(texts)
             for lrn, vec in zip(learnings, vecs, strict=True):
                 lrn.embedding = vec
-                lrn.embedding_model = _embedding_provider.model_name
+                lrn.embedding_model = active.model_name
             return True
         except Exception as exc:
             if _config.strict_llm:
                 logger.error(
                     "Embedding generation failed in strict mode (provider=%s) — "
                     "refusing to silently save un-embedded learnings.",
-                    getattr(_embedding_provider, "model_name", "unknown"),
+                    getattr(active, "model_name", "unknown"),
                 )
                 raise LLMFallbackError(
                     f"Embedding generation failed "
-                    f"(provider={getattr(_embedding_provider, 'model_name', 'unknown')}): "
+                    f"(provider={getattr(active, 'model_name', 'unknown')}): "
                     f"{exc}. Strict mode is ON — set TRACE_STRICT_LLM=false to "
                     f"allow saving un-embedded learnings."
                 ) from exc
             logger.warning(
                 "Failed to generate embeddings (provider=%s) — "
                 "saving learnings without embeddings. Strict mode is OFF.",
-                getattr(_embedding_provider, "model_name", "unknown"),
+                getattr(active, "model_name", "unknown"),
                 exc_info=True,
             )
             return False
 
-    def _needs_embedding(ks: KnowledgeStore) -> list[Learning]:
-        """Return learnings that need (re-)embedding."""
-        if _embedding_provider is None:
+    def _needs_embedding(ks: KnowledgeStore, provider: EmbeddingProvider | None = None) -> list[Learning]:
+        """Return learnings that need (re-)embedding under *provider* (default: process-wide)."""
+        active = provider if provider is not None else _embedding_provider
+        if active is None:
             return []
-        return [
-            lrn
-            for lrn in ks.learnings
-            if lrn.embedding is None or lrn.embedding_model != _embedding_provider.model_name
-        ]
+        return [lrn for lrn in ks.learnings if lrn.embedding is None or lrn.embedding_model != active.model_name]
+
+    def _registry_unavailable_error(project: str, exc: Exception) -> str:
+        return json.dumps(
+            {
+                "error": "project registry unreadable — learn operations fail closed",
+                "detail": str(exc),
+                "project": project,
+            }
+        )
+
+    async def _project_session_ids(project: str) -> list[str]:
+        """Every session id belonging to *project*, by DIRECT GLOB of the store.
+
+        The query layer's ``list_sessions`` caps its scan (500 files) and its
+        result set, silently hiding the OLDEST sessions of a large store —
+        exactly the ones a project-wide extraction exists to mine. Enumerate
+        the directory instead and match by canonical key. Falls back to the
+        query path for storage backends that expose no filesystem location.
+        """
+        from pathlib import Path
+
+        loc = getattr(storage, "location", lambda: "unknown")()
+        if loc == "unknown" or not Path(loc).is_dir():
+            summaries = await storage.list_sessions(project=project, limit=1000)
+            return [s["id"] for s in summaries]
+        key = pident.key_for_label(project)
+        ids: list[str] = []
+        for path in sorted(Path(loc).glob("trace_*.json")):
+            try:
+                meta = json.loads(path.read_text(encoding="utf-8")).get("metadata") or {}
+            except (json.JSONDecodeError, OSError):
+                continue
+            if pident.session_matches_project(meta, key):
+                ids.append(path.stem)
+        return ids
 
     # ── Register hooks so core tools can auto-recall/extract ──
 
@@ -118,23 +193,32 @@ def register(mcp: FastMCP, storage: TraceStorage) -> None:
         tags: list[str] | None,
         limit: int,
     ) -> list[dict]:
+        # Fail loudly-but-open on registry damage: hooks run inside session
+        # capture (start/decision), and capture must never be blocked by a
+        # damaged registry (ADR-006 §6 split) — but with the posture unreadable
+        # no egress-capable backend may run, so recall is skipped entirely.
+        try:
+            _eff, backend, provider = _effective(project)
+        except pident.RegistryUnavailableError as exc:
+            logger.error("Registry unreadable — skipping auto-recall for %r (fail closed on egress): %s", project, exc)
+            return []
         # Lock the full load→embed→save read-modify-write span. This is
         # the highest-frequency knowledge-store mutator (core auto-recall);
         # leaving it unlocked allowed a concurrent locked add to be
         # clobbered (a lost update).
-        with store.project_lock(project):
+        with store.project_lock(project), egress_project(pident.key_for_label(project) or None):
             ks = store.load_store(project)
             if not ks.learnings:
                 return []
-            stale = _needs_embedding(ks)
-            embedded = await _embed_learnings(stale) if stale else False
+            stale = _needs_embedding(ks, provider)
+            embedded = await _embed_learnings(stale, provider) if stale else False
             results = await matching.recall_learnings(
                 ks.learnings,
                 context=context,
                 context_tags=tags,
                 threshold=None,  # Use backend's default_threshold
                 limit=limit,
-                backend=_backend,
+                backend=backend,
                 decay_config=_decay_params,
             )
             if results or embedded:
@@ -146,14 +230,22 @@ def register(mcp: FastMCP, storage: TraceStorage) -> None:
         # (closes the cross-wired-extract bleed, which would also send one
         # project's store to the cloud as another's dedup context).
         await pident.validate_project_session(storage, project, session_id)
-        with store.project_lock(project):  # lock the full read-modify-write span
+        try:
+            eff, _backend_unused, provider = _effective(project)
+        except pident.RegistryUnavailableError as exc:
+            # end_session must complete (capture over attribution); with the
+            # privacy posture unreadable, extraction — an egress-capable path —
+            # is skipped loudly instead of running on the global config.
+            logger.error("Registry unreadable — skipping extraction for %r (fail closed on egress): %s", project, exc)
+            return []
+        with store.project_lock(project), egress_project(pident.key_for_label(project) or None):
             ks = store.load_store(project)
             sess = await storage.get_session(session_id)
-            new_ids = await extraction.extract_from_session_auto(ks, sess, _config)
+            new_ids = await extraction.extract_from_session_auto(ks, sess, eff)
             if new_ids:
                 new_set = set(new_ids)
                 to_embed = [lrn for lrn in ks.learnings if lrn.id in new_set and lrn.embedding is None]
-                await _embed_learnings(to_embed)
+                await _embed_learnings(to_embed, provider)
                 store.save_store(ks)
         return new_ids
 
@@ -183,9 +275,10 @@ def register(mcp: FastMCP, storage: TraceStorage) -> None:
             guard = _reserved_project_error(project)
             if guard:
                 return guard
+            _eff, backend, provider = _effective(project)
             # Lock the full span (recall may backfill
             # embeddings and save — a read-modify-write).
-            with store.project_lock(project):
+            with store.project_lock(project), egress_project(pident.key_for_label(project) or None):
                 ks = store.load_store(project)
                 if not ks.learnings:
                     return json.dumps({"project": project, "results": [], "total": 0})
@@ -193,20 +286,22 @@ def register(mcp: FastMCP, storage: TraceStorage) -> None:
                     results = store.list_learnings(ks)
                     return json.dumps({"project": project, "results": results[:limit], "total": len(results)})
                 # Lazy-embed: generate (or regenerate) embeddings for learnings that need them
-                stale = _needs_embedding(ks)
-                embedded = await _embed_learnings(stale) if stale else False
+                stale = _needs_embedding(ks, provider)
+                embedded = await _embed_learnings(stale, provider) if stale else False
                 results = await matching.recall_learnings(
                     ks.learnings,
                     context=context or "",
                     context_tags=tags,
                     threshold=threshold,
                     limit=limit,
-                    backend=_backend,
+                    backend=backend,
                     decay_config=_decay_params,
                 )
                 if results or embedded:
                     store.save_store(ks)
                 return json.dumps({"project": project, "results": results, "total": len(results)})
+        except pident.RegistryUnavailableError as exc:
+            return _registry_unavailable_error(project, exc)
         except Exception as exc:
             from trace_mcp.extensions.learn.config import LLMFallbackError
 
@@ -249,10 +344,11 @@ def register(mcp: FastMCP, storage: TraceStorage) -> None:
                         "error": f"Invalid category '{category}'. Must be one of: {_VALID_CATEGORIES}",
                     }
                 )
+            _eff, _bk, provider = _effective(project)
             # Lock the full load->mutate->save span so concurrent
             # multi-session adds to the same project don't lose updates
             # (last-writer-wins on the shared store).
-            with store.project_lock(project):
+            with store.project_lock(project), egress_project(pident.key_for_label(project) or None):
                 ks = store.load_store(project)
                 if _config.dedup_enabled:
                     result = store.add_learning_dedup(
@@ -284,9 +380,11 @@ def register(mcp: FastMCP, storage: TraceStorage) -> None:
                         tags=tags,
                         extraction_method="manual",
                     )
-                await _embed_learnings([lrn])
+                await _embed_learnings([lrn], provider)
                 store.save_store(ks)
                 return json.dumps({"added": store.learning_to_dict(lrn)})
+        except pident.RegistryUnavailableError as exc:
+            return _registry_unavailable_error(project, exc)
         except Exception as exc:
             from trace_mcp.extensions.learn.config import LLMFallbackError
 
@@ -377,21 +475,21 @@ def register(mcp: FastMCP, storage: TraceStorage) -> None:
             # project's whole store to the cloud alongside another's events).
             if session_id:
                 await pident.validate_project_session(storage, project, session_id)
+            eff, _bk, provider = _effective(project)
             # Lock the full multi-session extract→embed→save span.
-            with store.project_lock(project):
+            with store.project_lock(project), egress_project(pident.key_for_label(project) or None):
                 ks = store.load_store(project)
                 all_new_ids: list[str] = []
 
                 if session_id:
                     session = await storage.get_session(session_id)
-                    new_ids = await extraction.extract_from_session_auto(ks, session, _config)
+                    new_ids = await extraction.extract_from_session_auto(ks, session, eff)
                     all_new_ids.extend(new_ids)
                 else:
-                    summaries = await storage.list_sessions(project=project, limit=1000)
-                    for s in summaries:
+                    for sid in await _project_session_ids(project):
                         try:
-                            session = await storage.get_session(s["id"])
-                            new_ids = await extraction.extract_from_session_auto(ks, session, _config)
+                            session = await storage.get_session(sid)
+                            new_ids = await extraction.extract_from_session_auto(ks, session, eff)
                             all_new_ids.extend(new_ids)
                         except FileNotFoundError:
                             continue
@@ -400,7 +498,7 @@ def register(mcp: FastMCP, storage: TraceStorage) -> None:
                 if all_new_ids:
                     new_set = set(all_new_ids)
                     to_embed = [lrn for lrn in ks.learnings if lrn.id in new_set and lrn.embedding is None]
-                    await _embed_learnings(to_embed)
+                    await _embed_learnings(to_embed, provider)
                     store.save_store(ks)
 
                 return json.dumps(
@@ -411,6 +509,8 @@ def register(mcp: FastMCP, storage: TraceStorage) -> None:
                         "total_learnings": len(ks.learnings),
                     }
                 )
+        except pident.RegistryUnavailableError as exc:
+            return _registry_unavailable_error(project, exc)
         except (pident.ProjectMismatchError, pident.ProjectKeyError) as exc:
             return json.dumps(
                 {"error": "project/session coherence check failed", "detail": str(exc), "project": project}

--- a/src/trace_mcp/extensions/learn/config.py
+++ b/src/trace_mcp/extensions/learn/config.py
@@ -230,3 +230,76 @@ def load_config() -> LearnConfig:
         embedding_model=merged.get("TRACE_EMBEDDING_MODEL", "text-embedding-3-small"),
         embedding_base_url=merged.get("TRACE_OPENAI_BASE_URL") or merged.get("OPENAI_BASE_URL") or None,
     )
+
+
+def effective_learn_config(base: LearnConfig, project: str) -> LearnConfig:
+    """Apply the project's registry privacy posture to *base* — a RESTRICT-ONLY ratchet.
+
+    A registry entry may TIGHTEN the machine-global config for one project (force
+    a confidentiality-bound client project local-only against a permissive
+    global) but can never loosen a global restriction: fields here are only ever
+    set to their more-restrictive value (ADR-006 §6). ``.env``/env-var precedence
+    inside ``load_config`` is untouched — this layers on top of its result.
+
+    Applied per call at the three egress decision points (extraction, LLM
+    matching, embedding-backend selection), pinned or not: the learn tools
+    resolve their ``project`` argument either way, so a restrictive entry
+    protects the project from every process that touches it.
+
+    Returns *base* itself (identity, not a copy) when no restriction applies —
+    callers use ``eff is base`` to keep the common path on the process-wide
+    backend instead of constructing per-project ones.
+
+    Raises:
+        RegistryUnavailableError: the registry exists but cannot be read. The
+            posture that would forbid egress may live in that unreadable file,
+            so knowledge/egress paths must fail closed rather than proceed on
+            the global config. (An ABSENT registry is the normal pre-migration
+            state and applies no restriction.) Session capture never calls
+            this, so capture is never blocked by registry damage.
+    """
+    from trace_mcp.project_identity import get_registry_cached, key_for_label
+
+    key = key_for_label(project)
+    if not key:
+        return base
+    registry = get_registry_cached()  # raises RegistryUnavailableError on damage
+    if registry is None:
+        return base
+    entry = registry.projects.get(key)
+    if entry is None:
+        return base
+
+    pc = entry.config
+    force_local = bool(pc.local_only)
+    force_llm_off = force_local or pc.llm_enabled is False
+    downgrade_embedding = (force_local or pc.embedding_backend_max == "local") and base.embedding_backend == "openai"
+
+    if (
+        not (force_local and not base.local_only)
+        and not (force_llm_off and base.llm_enabled)
+        and not downgrade_embedding
+    ):
+        return base
+
+    from dataclasses import replace
+
+    eff = base
+    if force_local and not base.local_only:
+        # Mirror load_config's own TRACE_LOCAL_ONLY semantics: one switch, all
+        # three egress paths.
+        eff = replace(eff, local_only=True, llm_enabled=False)
+        if eff.embedding_backend == "openai":
+            eff = replace(eff, embedding_backend="auto")
+    if force_llm_off and eff.llm_enabled:
+        eff = replace(eff, llm_enabled=False)
+    if downgrade_embedding and eff.embedding_backend == "openai":
+        eff = replace(eff, embedding_backend="auto")
+    logger.info(
+        "Per-project privacy ratchet active for '%s': local_only=%s llm_enabled=%s embedding_backend=%s",
+        key,
+        eff.local_only,
+        eff.llm_enabled,
+        eff.embedding_backend,
+    )
+    return eff

--- a/src/trace_mcp/extensions/learn/egress.py
+++ b/src/trace_mcp/extensions/learn/egress.py
@@ -2,6 +2,14 @@
 
 Records the FACT of egress — provider, endpoint, model, purpose, item count,
 and project/session when known at the call site — never the content itself.
+
+Project attribution (v0.5): every ledger row carries a ``project_key`` column.
+The matching and embedding call sites sit in layers that deliberately know
+nothing about projects, so the key travels in a context variable set at the
+tool boundary (``egress_project``) rather than being threaded through every
+signature between the tool and the provider. Context variables propagate
+through ``await``, so the attribution survives the async call chain. Rows
+written before v0.5 carry no ``project_key`` and are never rewritten.
 One JSONL line is appended BEFORE each cloud call (an intent attestation):
 if the attestation cannot be written, the cloud call must not happen.
 Unrecorded egress is the exact failure mode this ledger exists to prevent, so
@@ -24,16 +32,37 @@ Exports: ``attest_egress`` (the pre-call writer), ``egress_log_path``
 
 from __future__ import annotations
 
+import contextlib
 import json
 import os
+from collections.abc import Iterator
+from contextvars import ContextVar
 from datetime import UTC, datetime
 from pathlib import Path
 
-__all__ = ["EgressAttestationError", "attest_egress", "egress_log_path"]
+__all__ = ["EgressAttestationError", "attest_egress", "egress_log_path", "egress_project"]
+
+_current_project_key: ContextVar[str | None] = ContextVar("trace_egress_project_key", default=None)
 
 
 class EgressAttestationError(RuntimeError):
     """The egress ledger could not be written; the cloud call must not proceed."""
+
+
+@contextlib.contextmanager
+def egress_project(project_key: str | None) -> Iterator[None]:
+    """Attribute every egress attested inside this context to *project_key*.
+
+    Set at the tool/hook boundary (the one layer that knows the project), read
+    by ``attest_egress`` in whatever provider layer the cloud call happens.
+    ``None`` — e.g. a degenerate label that yields no canonical key — leaves
+    rows unattributed rather than guessing.
+    """
+    token = _current_project_key.set(project_key)
+    try:
+        yield
+    finally:
+        _current_project_key.reset(token)
 
 
 def egress_log_path() -> Path:
@@ -59,8 +88,15 @@ def attest_egress(
     project: str | None = None,
     session_id: str | None = None,
     base_url: str | None = None,
+    project_key: str | None = None,
 ) -> None:
     """Append one intent record to the egress ledger, BEFORE the cloud call.
+
+    ``project_key`` is the canonical-key attribution column (additive, v0.5).
+    An explicit argument wins; otherwise the value set by the enclosing
+    ``egress_project`` context applies — which is how the matching/embedding
+    sites, whose layers know nothing about projects, still write attributed
+    rows. ``project`` remains the display label as before.
 
     Inputs describe the call about to be made: ``provider`` (e.g. "openai"),
     ``endpoint`` ("chat.completions" | "embeddings"), ``model``, ``purpose``
@@ -88,6 +124,7 @@ def attest_egress(
         "project": project,
         "session_id": session_id,
         "base_url": base_url,
+        "project_key": project_key if project_key is not None else _current_project_key.get(),
     }
     line = json.dumps(entry, separators=(",", ":")) + "\n"
     path = egress_log_path()

--- a/src/trace_mcp/extensions/learn/extraction.py
+++ b/src/trace_mcp/extensions/learn/extraction.py
@@ -323,6 +323,12 @@ async def extract_from_session_llm(
         # Egress-as-provenance: record the fact of the cloud call before making
         # it. Attestation failure is handled by this try's strict/permissive
         # logic like any LLM failure — and no content leaves the machine.
+        # This site knows the session, so the canonical key is passed explicitly
+        # (registry-aware: an aliased legacy label resolves to its real key).
+        # The matching/embedding sites can't do this and rely on the
+        # egress_project context set at the tool boundary instead.
+        from trace_mcp.project_identity import session_project_key
+
         attest_egress(
             provider="openai",
             endpoint="chat.completions",
@@ -332,6 +338,7 @@ async def extract_from_session_llm(
             item_count=len(session.events),
             project=session.metadata.project,
             session_id=session.id,
+            project_key=session_project_key(session.metadata) or None,
         )
         client = AsyncOpenAI(api_key=config.openai_api_key)
         response = await client.chat.completions.create(

--- a/src/trace_mcp/extensions/learn/store.py
+++ b/src/trace_mcp/extensions/learn/store.py
@@ -93,13 +93,17 @@ def _assert_store_identity(ks: KnowledgeStore, project: str, path: Path) -> None
 def load_store(
     project: str,
     directory: str | None = None,
-    *,
-    strict: bool = False,
 ) -> KnowledgeStore:
     """Load a project's knowledge store from disk.
 
-    If *strict* is True, raises StoreLoadError on parse failures instead
-    of silently returning a fresh store (useful for testing / diagnostics).
+    A missing file returns a fresh empty store — that is the normal first-use
+    state, not damage. A file that EXISTS but cannot be parsed or validated
+    raises ``StoreLoadError`` (fail closed): the previous silent fresh-store
+    fallback meant the next save atomically REPLACED the corrupt original with
+    the empty store — destroying a recoverable file and reading to the caller
+    as "this project has no learnings" when the truth was "this project's
+    learnings are unreadable". A missed integrity failure must be visible to
+    the caller, not buried in a log line.
     """
     path = _store_path(project, directory)
     if not path.exists():
@@ -108,17 +112,15 @@ def load_store(
         raw = json.loads(path.read_text(encoding="utf-8"))
         ks = KnowledgeStore.model_validate(raw)
     except json.JSONDecodeError as exc:
-        msg = f"Corrupt JSON in knowledge store {path}: {exc}"
-        logger.warning(msg)
-        if strict:
-            raise StoreLoadError(msg) from exc
-        return KnowledgeStore(project=project)
+        raise StoreLoadError(
+            f"Corrupt JSON in knowledge store {path}: {exc}. Repair or move the file — "
+            "proceeding would replace it with an empty store on the next save."
+        ) from exc
     except Exception as exc:
-        msg = f"Failed to validate knowledge store {path}: {exc}"
-        logger.warning(msg)
-        if strict:
-            raise StoreLoadError(msg) from exc
-        return KnowledgeStore(project=project)
+        raise StoreLoadError(
+            f"Failed to validate knowledge store {path}: {exc}. Repair or move the file — "
+            "proceeding would replace it with an empty store on the next save."
+        ) from exc
     _assert_store_identity(ks, project, path)
     return ks
 

--- a/src/trace_mcp/identity_cli.py
+++ b/src/trace_mcp/identity_cli.py
@@ -542,12 +542,13 @@ def cmd_merge_stores(args: argparse.Namespace, out) -> int:
         # (fail closed) rather than merge under them.
         try:
             with learn_store.project_lock(key):
-                # Fail closed on a corrupt TARGET: the non-strict loader would
-                # hand back a fresh store, and saving the union over it would
-                # replace the damaged-but-recoverable original — the one file
-                # this command does not keep a premerge copy of.
+                # Fail closed on a corrupt TARGET: replacing the
+                # damaged-but-recoverable original — the one file this command
+                # keeps no premerge copy of — would be silent data loss.
+                # (load_store raises on corruption for every caller now; the
+                # explicit handling here turns it into operator guidance.)
                 try:
-                    target_store = learn_store.load_store(key, strict=True)
+                    target_store = learn_store.load_store(key)
                 except learn_store.StoreLoadError as exc:
                     print(f"Error: target store for '{key}' is unreadable ({exc}). Repair or move it first.", file=out)
                     return 1

--- a/src/trace_mcp/tools/query_tools.py
+++ b/src/trace_mcp/tools/query_tools.py
@@ -193,7 +193,21 @@ def _compute_knowledge_metrics(project: str) -> dict[str, Any]:
             "avg_recall_count": 0.0,
         }
 
-    store = load_store(project)
+    try:
+        store = load_store(project)
+    except Exception as exc:  # noqa: BLE001 — read aggregates skip-and-report, never abort
+        # load_store now fails closed on a corrupt store. A summary is a read
+        # aggregate: it reports the damage rather than aborting the whole
+        # summary (mirroring the skipped_sessions pattern).
+        logger.warning("project_summary: knowledge store for %r unreadable: %s", project, exc)
+        return {
+            "total": 0,
+            "by_category": {},
+            "most_surfaced": [],
+            "never_surfaced": 0,
+            "avg_recall_count": 0.0,
+            "store_unreadable": True,
+        }
     if not store.learnings:
         return {
             "total": 0,

--- a/tests/test_learn_privacy.py
+++ b/tests/test_learn_privacy.py
@@ -1,0 +1,233 @@
+"""Privacy hardening for the learn extension (ADR-006 deferred S4 items).
+
+Covers the egress `project_key` attribution column, the per-project
+restrict-only config ratchet, and their fail-closed behavior on registry
+damage. All against tmp_path stores and a spy ledger — no cloud calls.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from trace_mcp import project_identity as pident
+from trace_mcp.extensions.learn.config import LearnConfig, effective_learn_config
+from trace_mcp.extensions.learn.egress import attest_egress, egress_project
+from trace_mcp.extensions.learn.matching import BM25Backend, EmbeddingBackend, LLMBackend, get_default_backend
+
+
+@pytest.fixture(autouse=True)
+def _isolated(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setenv("TRACE_EGRESS_LOG", str(tmp_path / "egress.jsonl"))
+    monkeypatch.setenv("TRACE_REGISTRY_PATH", str(tmp_path / "projects.json"))
+    monkeypatch.setenv("TRACE_KNOWLEDGE_DIR", str(tmp_path / "knowledge"))
+    pident._reset_registry_cache()
+    return tmp_path
+
+
+def _ledger_rows(tmp_path: Path) -> list[dict[str, Any]]:
+    path = tmp_path / "egress.jsonl"
+    if not path.exists():
+        return []
+    return [json.loads(x) for x in path.read_text().splitlines() if x.strip()]
+
+
+def _enroll(key: str, **config: Any) -> None:
+    with pident.locked_registry() as registry:
+        registry.projects[key] = pident.ProjectEntry(key=key, display_label=key, config=pident.ProjectConfig(**config))
+    pident._reset_registry_cache()
+
+
+def _attest(**overrides: Any) -> None:
+    kwargs: dict[str, Any] = {
+        "provider": "openai",
+        "endpoint": "embeddings",
+        "model": "test-model",
+        "purpose": "embedding",
+        "content_class": "learning-or-query-text",
+        "item_count": 1,
+    }
+    kwargs.update(overrides)
+    attest_egress(**kwargs)
+
+
+# ── project_key attribution ───────────────────────────────────────────────
+
+
+class TestEgressProjectKey:
+    def test_context_attributes_rows_written_inside_it(self, _isolated: Path) -> None:
+        """The provider layer knows nothing about projects; the context does."""
+        with egress_project("waggle"):
+            _attest()
+        _attest()  # outside any context — must stay unattributed, not inherit
+
+        rows = _ledger_rows(_isolated)
+        assert [r["project_key"] for r in rows] == ["waggle", None]
+
+    def test_explicit_argument_wins_over_the_context(self, _isolated: Path) -> None:
+        with egress_project("wrong-project"):
+            _attest(project_key="right-project")
+        assert _ledger_rows(_isolated)[0]["project_key"] == "right-project"
+
+    def test_context_restores_on_exception(self, _isolated: Path) -> None:
+        """A failed span must not leak its attribution into later calls."""
+        with pytest.raises(RuntimeError), egress_project("doomed"):
+            raise RuntimeError("boom")
+        _attest()
+        assert _ledger_rows(_isolated)[0]["project_key"] is None
+
+    async def test_context_survives_the_async_call_chain(self, _isolated: Path) -> None:
+        """contextvars propagate through await — the mechanism the design rests on."""
+        import asyncio
+
+        async def _deep_provider_layer() -> None:
+            await asyncio.sleep(0)
+            _attest()
+
+        with egress_project("waggle"):
+            await _deep_provider_layer()
+        assert _ledger_rows(_isolated)[0]["project_key"] == "waggle"
+
+    def test_rows_keep_the_display_label_column(self, _isolated: Path) -> None:
+        """`project` (display label) and `project_key` are separate columns."""
+        with egress_project("trace-mcp"):
+            _attest(project="TRACE", session_id="trace_20260101_x")
+        row = _ledger_rows(_isolated)[0]
+        assert row["project"] == "TRACE"
+        assert row["project_key"] == "trace-mcp"
+
+
+# ── the restrict-only ratchet ─────────────────────────────────────────────
+
+
+def _permissive_config() -> LearnConfig:
+    return LearnConfig(
+        openai_api_key="sk-test-fake",
+        llm_enabled=True,
+        strict_llm=False,
+        local_only=False,
+        embedding_backend="openai",
+    )
+
+
+class TestEffectiveLearnConfig:
+    def test_no_registry_is_a_no_op(self) -> None:
+        base = _permissive_config()
+        assert effective_learn_config(base, "waggle") is base
+
+    def test_unenrolled_project_is_a_no_op(self) -> None:
+        _enroll("other-project", local_only=True)
+        base = _permissive_config()
+        assert effective_learn_config(base, "waggle") is base
+
+    def test_unrestrictive_entry_returns_base_identity(self) -> None:
+        """`eff is base` is the fast path callers use to keep the global backend."""
+        _enroll("waggle")  # default ProjectConfig: no restrictions
+        base = _permissive_config()
+        assert effective_learn_config(base, "waggle") is base
+
+    def test_local_only_entry_forces_everything_local(self) -> None:
+        _enroll("client-proj", local_only=True)
+        eff = effective_learn_config(_permissive_config(), "client-proj")
+        assert eff.local_only is True
+        assert eff.llm_enabled is False
+        assert eff.embedding_backend != "openai"
+
+    def test_llm_enabled_false_entry_disables_llm_only(self) -> None:
+        _enroll("client-proj", llm_enabled=False)
+        eff = effective_learn_config(_permissive_config(), "client-proj")
+        assert eff.llm_enabled is False
+        assert eff.embedding_backend == "openai", "llm_enabled=False must not touch embeddings"
+
+    def test_embedding_backend_max_local_downgrades_openai(self) -> None:
+        _enroll("client-proj", embedding_backend_max="local")
+        eff = effective_learn_config(_permissive_config(), "client-proj")
+        assert eff.embedding_backend == "auto"
+        assert eff.llm_enabled is True, "embedding_backend_max must not touch the LLM switch"
+
+    def test_ratchet_never_loosens_a_global_restriction(self) -> None:
+        """A permissive entry against a restrictive global changes nothing."""
+        _enroll("open-proj", llm_enabled=None, local_only=False, embedding_backend_max="any")
+        base = replace(_permissive_config(), local_only=True, llm_enabled=False, embedding_backend="auto")
+        eff = effective_learn_config(base, "open-proj")
+        assert eff is base
+
+    def test_alias_resolves_to_the_entry(self) -> None:
+        """A drifted display label must reach its project's posture."""
+        with pident.locked_registry() as registry:
+            registry.projects["trace-mcp"] = pident.ProjectEntry(
+                key="trace-mcp",
+                display_label="trace-mcp",
+                aliases=["TRACE"],
+                config=pident.ProjectConfig(local_only=True),
+            )
+        pident._reset_registry_cache()
+
+        eff = effective_learn_config(_permissive_config(), "TRACE")
+        assert eff.local_only is True
+
+    def test_unreadable_registry_fails_closed(self, _isolated: Path) -> None:
+        """The posture that forbids the egress may live in the unreadable file."""
+        (_isolated / "projects.json").write_text("{not valid json")
+        pident._reset_registry_cache()
+        with pytest.raises(pident.RegistryUnavailableError):
+            effective_learn_config(_permissive_config(), "waggle")
+
+    def test_ratcheted_config_selects_a_local_backend(self) -> None:
+        """The backend built from a ratcheted config cannot egress.
+
+        The permissive config would select the LLM/OpenAI tier; the ratcheted
+        one must land on a local tier (embedding-local or BM25) instead.
+        """
+        _enroll("client-proj", local_only=True)
+        eff = effective_learn_config(_permissive_config(), "client-proj")
+        backend = get_default_backend(eff)
+        assert not isinstance(backend, LLMBackend), "local_only project still got the LLM backend"
+        if isinstance(backend, EmbeddingBackend):
+            provider_name = getattr(backend._provider, "model_name", "")
+            assert "text-embedding" not in provider_name, "local_only project still got OpenAI embeddings"
+        else:
+            assert isinstance(backend, BM25Backend)
+
+
+# ── fail-closed store load (moved behavior, integration view) ─────────────
+
+
+class TestStoreFailClosed:
+    async def test_tool_surfaces_a_corrupt_store_instead_of_masking_it(self, _isolated: Path) -> None:
+        """End-to-end through the real registered tool: corrupt store → clear error,
+        file untouched — not "this project has no learnings"."""
+        from typing import cast
+
+        from trace_mcp.extension_hooks import clear_hooks
+        from trace_mcp.extensions import learn as learn_ext
+
+        class _FakeMCP:
+            def __init__(self) -> None:
+                self.tools: dict[str, Any] = {}
+
+            def tool(self):
+                def deco(fn):
+                    self.tools[fn.__name__] = fn
+                    return fn
+
+                return deco
+
+        clear_hooks()
+        try:
+            fake = _FakeMCP()
+            learn_ext.register(cast(Any, fake), cast(Any, None))  # storage unused by list
+
+            knowledge = _isolated / "knowledge"
+            knowledge.mkdir(exist_ok=True)
+            (knowledge / "waggle.json").write_text("{not valid json")
+
+            result = json.loads(await fake.tools["trace_learn_list"]("waggle"))
+            assert "error" in result
+            assert (knowledge / "waggle.json").read_text() == "{not valid json"
+        finally:
+            clear_hooks()

--- a/tests/test_learn_store.py
+++ b/tests/test_learn_store.py
@@ -43,35 +43,27 @@ class TestLoadStore:
         assert loaded.learnings[0].content == "persisted insight"
         assert loaded.learnings[0].tags == ["test"]
 
-    def test_corrupt_json_returns_empty(self, tmp_path):
-        """Corrupt file → fresh store (default lenient mode)."""
-        path = tmp_path / "corrupt.json"
-        path.write_text("{invalid json!!!", encoding="utf-8")
-        ks = load_store("corrupt", directory=str(tmp_path))
-        assert ks.project == "corrupt"
-        assert ks.learnings == []
+    def test_corrupt_json_raises(self, tmp_path):
+        """Corrupt file → StoreLoadError, and the original stays on disk.
 
-    def test_corrupt_json_strict_raises(self, tmp_path):
-        """Corrupt file → StoreLoadError in strict mode."""
+        The former lenient fresh-store fallback meant the next save atomically
+        replaced the damaged-but-recoverable original with an empty store —
+        the last silent integrity degrade in the learn extension.
+        """
         path = tmp_path / "corrupt.json"
         path.write_text("{invalid json!!!", encoding="utf-8")
         with pytest.raises(StoreLoadError, match="Corrupt JSON"):
-            load_store("corrupt", directory=str(tmp_path), strict=True)
+            load_store("corrupt", directory=str(tmp_path))
+        assert path.read_text(encoding="utf-8") == "{invalid json!!!", "the corrupt file was touched"
 
-    def test_invalid_schema_returns_empty(self, tmp_path):
-        """Valid JSON but wrong schema → fresh store."""
+    def test_invalid_schema_raises(self, tmp_path):
+        """Valid JSON but wrong schema → StoreLoadError (fail closed)."""
         # File name must be the canonical store path (ADR-006: stores are
         # keyed by canonical project key; 'bad-schema' is already canonical).
         path = tmp_path / "bad-schema.json"
         path.write_text('{"not_a_valid_field": 42}', encoding="utf-8")
-        ks = load_store("bad-schema", directory=str(tmp_path))
-        assert ks.learnings == []
-
-    def test_invalid_schema_strict_raises(self, tmp_path):
-        path = tmp_path / "bad-schema.json"
-        path.write_text('{"not_a_valid_field": 42}', encoding="utf-8")
         with pytest.raises(StoreLoadError, match="Failed to validate"):
-            load_store("bad-schema", directory=str(tmp_path), strict=True)
+            load_store("bad-schema", directory=str(tmp_path))
 
 
 class TestSaveStore:
@@ -292,17 +284,9 @@ class TestStorePathSanitized:
         assert str(tmp_path) in str(path)
         assert ".." not in path.name
 
-    def test_load_corrupt_json_non_strict(self, tmp_path):
-        """Corrupt JSON returns fresh store in default mode."""
-        path = tmp_path / "corrupt.json"
-        path.write_text("{broken json!!!", encoding="utf-8")
-        ks = load_store("corrupt", directory=str(tmp_path))
-        assert ks.project == "corrupt"
-        assert ks.learnings == []
-
-    def test_load_corrupt_json_strict_raises(self, tmp_path):
-        """Corrupt JSON with strict=True raises StoreLoadError."""
+    def test_load_corrupt_json_raises(self, tmp_path):
+        """Corrupt JSON raises StoreLoadError — fail-closed is the only mode."""
         path = tmp_path / "corrupt.json"
         path.write_text("{broken json!!!", encoding="utf-8")
         with pytest.raises(StoreLoadError, match="Corrupt JSON"):
-            load_store("corrupt", directory=str(tmp_path), strict=True)
+            load_store("corrupt", directory=str(tmp_path))


### PR DESCRIPTION
Closes the four learn-extension privacy/attribution gaps deferred from the isolation foundation (#32) as additive-not-bleed items. Follows #34–#37. With this, every item ADR-006 assigns to the learn extension is implemented.

## Summary

1. **Every egress-ledger row carries `project_key`.** The matching and embedding rows were previously unattributable.
2. **The per-project privacy ratchet is enforced.** A registry entry's `local_only` / `llm_enabled` / `embedding_backend_max` now actually tightens the config at all three egress decision points; previously the fields were carried but never applied.
3. **`load_store` fails closed on a corrupt store** — the last silent integrity degrade in the extension.
4. **Project-wide extraction enumerates the store by direct glob**, past the query layer's scan cap.

## Design notes

**Attribution via context variable, not signature threading.** The matching/embedding call sites sit in layers that deliberately know nothing about projects. Threading an optional key through `recall_learnings` → `MatchingBackend.score_batch` → `EmbeddingProvider.embed_texts` would change a Protocol and every implementation to carry a value none of them uses. Instead the canonical key is set at the tool/hook boundary (`egress_project(...)`) in a `contextvars.ContextVar` and read by `attest_egress` wherever the call happens. Context variables propagate through `await` — pinned by a test that attests from a nested async layer. An explicit argument wins over the context; the extraction site (which knows its session) passes the key explicitly, resolved through the alias registry so a session recorded under a drifted label attributes to its real project. Rows written before v0.5 have no key and are never rewritten.

**Restrict-only, pin-independent, absent≠unreadable.** The ratchet applies whenever the resolved project has a registry entry — the learn tools resolve their `project` argument pinned or not, so a restrictive entry protects the project from every process that touches it. It only ever tightens: a permissive entry against a restrictive global changes nothing (tested in both directions). An **absent** registry is the normal pre-migration state and applies no restriction; a **present-but-unreadable** registry fails the five learn tools closed with a precise error — the posture that would forbid the egress may live in the unreadable file. The auto-recall/auto-extract hooks are the one exception: they run inside session-capture paths (start/decision/end) that must complete, so they skip loudly (error log + empty result) rather than raise — isolation is the learn/egress contract; capture is never blocked by registry damage.

**Ratcheted projects get per-call backend/provider triples**, cached by (key, posture) so an edited registry entry takes effect on its next call rather than being served stale for the process lifetime. The unrestricted common path keeps the process-wide backend via an identity check.

**Fail-closed store loads.** The old lenient path returned a fresh empty store on corruption, which meant: (a) the next save atomically replaced the damaged-but-recoverable original, and (b) every caller read "no learnings" when the truth was "unreadable". Now `StoreLoadError` is raised; a missing file still returns a fresh store (normal first use). Callers were reviewed: the learn tools surface a clear error with the file untouched (verified end-to-end through a registered tool); `project_summary` and self-cost skip-and-report per the read-aggregate invariant; the identity CLI's merge already handled it explicitly.

## Verification

- Full suite **1219 passed, 11 skipped** (up from 1206; 16 new tests, 2 corrupt-store tests updated to the fail-closed contract).
- New coverage: attribution context (exception restoration, await propagation, explicit-wins, label/key column separation), the ratchet matrix (each field in isolation, both loosening directions, alias resolution, absent-vs-unreadable split), backend downgrade under a ratcheted config (permissive global would pick LLM/OpenAI; ratcheted must land local), and the corrupt-store path end-to-end.
- `ruff check` + `ruff format --check` + `pyright` (0 errors) + invariant guards (INV-5 egress sites unchanged and still attest-first) + core/extension boundary guard.

## Risks / rollback

The ledger column and the glob change are additive. Two behavior changes are deliberate tightenings: a corrupt knowledge store now errors instead of silently reading as empty (the error names the file and the remedy), and a project whose registry entry restricts egress now actually gets that restriction. Revert the commit to restore prior behavior.