### PR TITLE
feat(server): honest session orientation, per-key scratchpads, complete require-pin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Honest bounded session orientation.** `session_brief` scans newest-first up
+  to a `read_ceiling` (default 200 files), stopping early at `scan_cap`
+  matches, and reports `window_exhausted` when the ceiling was hit with more
+  files beyond it. The previous single 25-file window made the session-start
+  orientation assert a false absolute — a project whose newest session sat 26
+  files back in a busy shared store read as "No prior TRACE sessions". The
+  bootstrap now says "no sessions found in the newest ~N (older history not
+  scanned)" in that case; the absolute claim survives only when the whole
+  store was actually seen. `session_brief` is also promoted onto the
+  `TraceStorage` contract with an honest generic default, so a non-file
+  backend cannot silently lack orientation.
+- **`TRACE_REQUIRE_PIN` closes the auto-create path.** The flag previously
+  gated only `trace_start_session`, so on a require-pin fleet an unpinned
+  stray process still auto-created quarantine sessions on its first logging
+  call — the exact capture the operator opted to fail closed on. Both
+  session-creation paths now refuse; using an *existing* session by explicit
+  id keeps working, and the flag remains default-off (capture-over-attribution
+  stays the default posture).
+- **Per-project scratchpad fallback.** The global fallback directory
+  (`~/.trace/scratchpads/`) is shared by every project, and the scratchpad is
+  most-recent-session-only — so whichever project ended a session last
+  silently clobbered another project's context-restoration buffer. Fallback
+  files are now named by canonical project key (registry-aware, so an aliased
+  legacy label lands in its real project's buffer). A project checkout's
+  `.claude/` and an explicit `TRACE_SCRATCHPAD_DIR` keep the stable
+  `SCRATCHPAD.md` name — those locations are per-project by construction.
 - **Egress ledger rows carry a `project_key` column (all three purposes).** The
   matching and embedding attest sites sit in layers that deliberately know
   nothing about projects, so their rows were unattributable; the canonical key

--- a/src/trace_mcp/scratchpad.py
+++ b/src/trace_mcp/scratchpad.py
@@ -28,23 +28,35 @@ logger = logging.getLogger(__name__)
 _SCRATCHPAD_DIR_ENV = "TRACE_SCRATCHPAD_DIR"
 
 
-def _scratchpad_path() -> Path:
+def _scratchpad_path(project_key: str | None = None) -> Path:
     """Resolve the SCRATCHPAD.md path.
 
     Priority: $TRACE_SCRATCHPAD_DIR > cwd/.claude/ > ~/.trace/scratchpads/
+
+    The first two locations are per-project by construction (an explicit
+    operator choice; a project checkout). The global fallback directory is
+    shared by EVERY project on the machine, and the scratchpad is
+    most-recent-session-only — so a single shared filename there meant
+    whichever project ended a session last silently clobbered another
+    project's context-restoration buffer. In the fallback, the file is
+    therefore named by the canonical *project_key* when one is known.
     """
     env_dir = os.environ.get(_SCRATCHPAD_DIR_ENV)
     if env_dir:
         base = Path(env_dir)
+        name = "SCRATCHPAD.md"
     else:
         cwd_claude = Path.cwd() / ".claude"
         if cwd_claude.is_dir():
             base = cwd_claude
+            name = "SCRATCHPAD.md"
         else:
             base = Path(os.path.expanduser("~/.trace/scratchpads"))
+            # The canonical key is filesystem-safe by construction.
+            name = f"{project_key}.md" if project_key else "SCRATCHPAD.md"
 
     base.mkdir(parents=True, exist_ok=True)
-    return base / "SCRATCHPAD.md"
+    return base / name
 
 
 # ── Session Summary Builder ──────────────────────────────────────────────
@@ -200,7 +212,12 @@ def write_scratchpad(session: Session) -> Path:
 
     Returns the path to the SCRATCHPAD.md file.
     """
-    path = _scratchpad_path()
+    # Registry-aware key (a stamped project_key wins; an aliased legacy label
+    # resolves to its real project) — bare canonicalization would split a
+    # renamed project's buffer across two files in the shared fallback dir.
+    from trace_mcp.project_identity import session_project_key
+
+    path = _scratchpad_path(session_project_key(session.metadata) or None)
 
     section = _build_session_section(session)
     header = (

--- a/src/trace_mcp/server.py
+++ b/src/trace_mcp/server.py
@@ -194,7 +194,10 @@ async def _ensure_session(session_id: str | None) -> tuple[Session, str]:
     tool response.
 
     Raises ``FileNotFoundError`` when an explicit *session_id* is given
-    but does not exist (preserving existing error behaviour).
+    but does not exist (preserving existing error behaviour), and
+    ``ProjectMismatchError`` when the session belongs to another project's
+    pin OR when ``TRACE_REQUIRE_PIN=1`` on an unpinned process would force
+    auto-creation (every caller already surfaces this as its error string).
     """
     global _current_session_id
 
@@ -243,6 +246,15 @@ async def _ensure_session(session_id: str | None) -> tuple[Session, str]:
             _current_session_id = None
 
     # 3. Auto-create a new session
+    # TRACE_REQUIRE_PIN closes BOTH session-creation paths. It previously gated
+    # only trace_start_session, so on a require-pin fleet an unpinned stray
+    # process still auto-created quarantine sessions on its first logging call —
+    # the exact capture the operator opted to fail closed on. Capture-over-
+    # attribution is the DEFAULT posture; this flag is the explicit opt-out,
+    # and a hole in an explicit opt-out is a broken promise, not a kindness.
+    pin_error = _require_pin_error()
+    if pin_error:
+        raise pident.ProjectMismatchError(pin_error)
     project = await _infer_project()
     session = await session_tools.create_session(
         storage,

--- a/src/trace_mcp/storage/base.py
+++ b/src/trace_mcp/storage/base.py
@@ -55,3 +55,35 @@ class TraceStorage(ABC):
         override with the concrete path.
         """
         return f"session:{session_id}"
+
+    async def session_brief(
+        self, project: str | None = None, scan_cap: int = 25, read_ceiling: int = 200
+    ) -> dict[str, Any]:
+        """Cheap, BOUNDED session orientation for the start_session bootstrap.
+
+        Part of the storage contract (not an accident of the JSON backend) so
+        every backend answers "has this project been here before?" honestly:
+        the answer feeds the bootstrap's orientation line, and an unbounded or
+        falsely-absolute answer is what this method exists to prevent.
+
+        Returns a dict with ``matched``, ``most_recent`` (lightweight brief of
+        the newest match, or None), ``scanned``, ``capped`` (results may exist
+        beyond what was examined), ``window_exhausted`` (a bounded backend hit
+        its read ceiling with more records beyond it), and ``read_ceiling``.
+
+        This default rides ``list_sessions`` and never claims completeness:
+        ``capped`` is True whenever the limit came back full, and
+        ``window_exhausted`` mirrors it — a generic backend cannot cheaply know
+        the store's true extent, and claiming "none exist" without knowing is
+        the false absolute the JSON backend's override was built to retire.
+        """
+        summaries = await self.list_sessions(project=project, limit=scan_cap)
+        hit_limit = len(summaries) >= scan_cap
+        return {
+            "matched": len(summaries),
+            "most_recent": summaries[0] if summaries else None,
+            "scanned": len(summaries),
+            "capped": hit_limit,
+            "window_exhausted": hit_limit,
+            "read_ceiling": read_ceiling,
+        }

--- a/src/trace_mcp/storage/json_file.py
+++ b/src/trace_mcp/storage/json_file.py
@@ -286,20 +286,31 @@ class JsonFileStorage(TraceStorage):
                 logger.warning("Skipping malformed session file: %s", path)
         return summaries
 
-    async def session_brief(self, project: str | None = None, scan_cap: int = 25) -> dict[str, Any]:
+    async def session_brief(
+        self, project: str | None = None, scan_cap: int = 25, read_ceiling: int = 200
+    ) -> dict[str, Any]:
         """Cheap, BOUNDED session orientation for the start_session bootstrap.
 
-        Scans at most ``scan_cap`` most-recent session files (never the whole
-        history) so the opening assistant turn is not tempted to fan out into
+        Newest-first scan that stops at ``scan_cap`` matches or after examining
+        ``read_ceiling`` files, whichever comes first — never the whole history,
+        so the opening assistant turn is not tempted to fan out into
         ``trace_list_sessions``/``trace_get_events``/``trace_health_check`` —
         the per-turn block-count inflation behind the Claude Code thinking-block
         400 (see docs/upstream-claude-code-thinking-block-400.md).
 
-        Returns: ``matched`` (matching sessions found within the scan window),
-        ``most_recent`` (brief of the newest match, or None), ``scanned`` (files
-        read), and ``capped`` (True when more files exist beyond the window).
+        The former single ``scan_cap``-file window made the brief assert a false
+        absolute: a project whose newest session sat 26 files back in a busy
+        shared store read as "no prior sessions". Matches are now sought through
+        a much deeper (still bounded) window, and when even that window ends
+        with more files beyond it, ``window_exhausted`` says so — the caller can
+        report "none found in the newest N" instead of "none exist".
 
-        Side effects: reads up to ``scan_cap`` files from the sessions directory.
+        Returns: ``matched``, ``most_recent`` (brief of the newest match, or
+        None), ``scanned`` (files read), ``capped`` (more files exist beyond
+        what was scanned), ``window_exhausted`` (the read ceiling was hit with
+        more files beyond it), and ``read_ceiling``.
+
+        Side effects: reads up to ``read_ceiling`` files from the sessions dir.
         """
         # INV-4: canonical-key match, same as list_sessions (lazy import breaks
         # the json_file <-> project_identity cycle).
@@ -312,7 +323,9 @@ class JsonFileStorage(TraceStorage):
         scanned = 0
         matched = 0
         most_recent: dict[str, Any] | None = None
-        for path in files[:scan_cap]:
+        for path in files[:read_ceiling]:
+            if matched >= scan_cap:
+                break
             scanned += 1
             try:
                 with open(path) as f:
@@ -336,7 +349,9 @@ class JsonFileStorage(TraceStorage):
             "matched": matched,
             "most_recent": most_recent,
             "scanned": scanned,
-            "capped": total > scan_cap,
+            "capped": total > scanned,
+            "window_exhausted": scanned >= read_ceiling and total > read_ceiling,
+            "read_ceiling": read_ceiling,
         }
 
     async def delete_session(self, session_id: str) -> None:

--- a/src/trace_mcp/tools/session_tools.py
+++ b/src/trace_mcp/tools/session_tools.py
@@ -486,6 +486,15 @@ def format_bootstrap_message(
             f"'{project}'; most recent: {mr['id']} ({mr.get('event_count', 0)} events"
             f"{', ' + created if created else ''})."
         )
+    elif brief and brief.get("window_exhausted"):
+        # The bounded scan hit its read ceiling with more files beyond it: the
+        # honest claim is "none found in the window", never "none exist" — the
+        # project's newest session may simply sit deeper in a busy shared store.
+        ceiling = brief.get("read_ceiling") or brief.get("scanned", 0)
+        orientation = (
+            f"Prior context: no sessions for '{project}' found in the newest "
+            f"~{ceiling} session files (older history not scanned)."
+        )
     else:
         orientation = f"Prior context: No prior TRACE sessions recorded for '{project}'."
 

--- a/tests/test_server_identity_polish.py
+++ b/tests/test_server_identity_polish.py
@@ -1,0 +1,230 @@
+"""Server identity polish (ADR-006 S3 deferred items + the require-pin hole).
+
+Four behaviors: the honest bounded session brief (window-exhausted wording
+instead of a false "no prior sessions"), session_brief as part of the storage
+contract, the per-key scratchpad fallback, and TRACE_REQUIRE_PIN gating the
+auto-create path it previously missed.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from trace_mcp import project_identity as pident
+from trace_mcp import server
+from trace_mcp.schema import Session, SessionMetadata
+from trace_mcp.storage.base import TraceStorage
+from trace_mcp.storage.json_file import JsonFileStorage
+
+
+@pytest.fixture(autouse=True)
+def _isolated(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setenv("TRACE_SESSIONS_DIR", str(tmp_path / "sessions"))
+    monkeypatch.setenv("TRACE_REGISTRY_PATH", str(tmp_path / "projects.json"))
+    monkeypatch.delenv("TRACE_PROJECT", raising=False)
+    monkeypatch.delenv("TRACE_REQUIRE_PIN", raising=False)
+    pident._reset_registry_cache()
+    # server.storage is constructed at import time — env changes alone do not
+    # move it, so the module global is swapped for a tmp-backed store.
+    monkeypatch.setattr(server, "storage", JsonFileStorage(str(tmp_path / "sessions")))
+    monkeypatch.setattr(server, "_current_session_id", None)
+    return tmp_path
+
+
+def _write_session_file(sessions: Path, session_id: str, project: str) -> None:
+    sessions.mkdir(parents=True, exist_ok=True)
+    (sessions / f"{session_id}.json").write_text(
+        json.dumps(
+            {
+                "id": session_id,
+                "created": "2026-07-23T00:00:00Z",
+                "status": "completed",
+                "metadata": {"project": project},
+                "events": [],
+            }
+        )
+    )
+
+
+# ── honest bounded session_brief ──────────────────────────────────────────
+
+
+class TestHonestSessionBrief:
+    async def test_match_beyond_the_old_25_file_window_is_found(self, _isolated: Path) -> None:
+        """The defect: a project 26 files deep in a busy store read as absent."""
+        sessions = _isolated / "sessions"
+        # 30 newer sessions from OTHER projects bury ours.
+        _write_session_file(sessions, "trace_20260101_ours00", "my-proj")
+        for i in range(30):
+            _write_session_file(sessions, f"trace_20260log2_{i:04d}", "noisy-neighbor")
+
+        brief = await JsonFileStorage(str(sessions)).session_brief("my-proj")
+        assert brief["matched"] == 1, "a session inside the read ceiling was missed"
+        assert brief["most_recent"]["id"] == "trace_20260101_ours00"
+        assert brief["window_exhausted"] is False
+
+    async def test_window_exhaustion_is_reported_not_asserted_absent(self, _isolated: Path) -> None:
+        sessions = _isolated / "sessions"
+        _write_session_file(sessions, "trace_20260101_ours00", "my-proj")  # oldest
+        for i in range(10):
+            _write_session_file(sessions, f"trace_20260log2_{i:04d}", "noisy-neighbor")
+
+        brief = await JsonFileStorage(str(sessions)).session_brief("my-proj", read_ceiling=5)
+        assert brief["matched"] == 0
+        assert brief["window_exhausted"] is True, "hitting the ceiling with files beyond it must be reported"
+        assert brief["read_ceiling"] == 5
+
+    async def test_scan_stops_at_the_match_cap(self, _isolated: Path) -> None:
+        """Bounded in both directions: enough matches ends the scan early."""
+        sessions = _isolated / "sessions"
+        for i in range(40):
+            _write_session_file(sessions, f"trace_20260log2_{i:04d}", "my-proj")
+
+        brief = await JsonFileStorage(str(sessions)).session_brief("my-proj", scan_cap=3)
+        assert brief["matched"] == 3
+        assert brief["scanned"] < 40, "the scan kept reading after the match cap"
+        assert brief["capped"] is True
+
+    async def test_bootstrap_wording_for_an_exhausted_window(self, _isolated: Path) -> None:
+        """End-to-end: the orientation line must never claim 'none exist' when
+        the scan simply ran out of window."""
+        sessions = _isolated / "sessions"
+        for i in range(210):  # exceed the default 200-file read ceiling
+            _write_session_file(sessions, f"trace_20260log2_{i:04d}", "noisy-neighbor")
+
+        out = await server.trace_start_session(project="brand-new-proj", description="d")
+        assert "No prior TRACE sessions" not in out, "asserted an absolute the scan cannot know"
+        assert "older history not scanned" in out
+
+    async def test_bootstrap_wording_for_a_truly_empty_store(self, _isolated: Path) -> None:
+        """The absolute claim is still correct when the whole store was seen."""
+        out = await server.trace_start_session(project="first-ever", description="d")
+        assert "No prior TRACE sessions" in out
+
+    async def test_brief_is_part_of_the_storage_contract(self) -> None:
+        """A minimal non-file backend gets an honest default, not an AttributeError."""
+
+        class _MinimalBackend(TraceStorage):
+            async def create_session(self, session: Session) -> str:
+                return session.id
+
+            async def update_session(self, session: Session) -> None: ...
+
+            async def get_session(self, session_id: str) -> Session:
+                raise FileNotFoundError(session_id)
+
+            async def list_sessions(self, project: str | None = None, limit: int = 50) -> list[dict[str, Any]]:
+                return [{"id": "trace_x", "project": project or "p"}]
+
+            async def delete_session(self, session_id: str) -> None: ...
+
+        brief = await _MinimalBackend().session_brief("p")
+        assert brief["matched"] == 1
+        assert brief["most_recent"]["id"] == "trace_x"
+        assert "window_exhausted" in brief and "capped" in brief
+
+
+# ── scratchpad per-key fallback ───────────────────────────────────────────
+
+
+class TestScratchpadPerKeyFallback:
+    def _session(self, project: str, project_key: str | None = None) -> Session:
+        return Session(
+            id="trace_20260723_pad001",
+            metadata=SessionMetadata(project=project, project_key=project_key),
+        )
+
+    def test_global_fallback_is_keyed_per_project(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The shared fallback dir must not let project B clobber project A's buffer."""
+        from trace_mcp import scratchpad
+
+        monkeypatch.delenv("TRACE_SCRATCHPAD_DIR", raising=False)
+        monkeypatch.chdir(tmp_path)  # no .claude/ here → global fallback path
+        fallback = tmp_path / "trace-home" / "scratchpads"
+        monkeypatch.setattr("os.path.expanduser", lambda p: str(fallback) if "scratchpads" in p else p)
+
+        scratchpad.write_scratchpad(self._session("Alpha Project"))
+        scratchpad.write_scratchpad(self._session("beta", project_key="beta"))
+
+        names = sorted(p.name for p in fallback.glob("*.md"))
+        assert names == ["alpha-project.md", "beta.md"], (
+            f"projects share one fallback file (last writer clobbers): {names}"
+        )
+
+    def test_project_local_claude_dir_keeps_the_stable_filename(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A checkout's .claude/ is per-project by construction — name unchanged."""
+        from trace_mcp import scratchpad
+
+        monkeypatch.delenv("TRACE_SCRATCHPAD_DIR", raising=False)
+        (tmp_path / ".claude").mkdir()
+        monkeypatch.chdir(tmp_path)
+
+        path = scratchpad.write_scratchpad(self._session("Alpha Project"))
+        assert path == tmp_path / ".claude" / "SCRATCHPAD.md"
+
+    def test_env_override_keeps_the_stable_filename(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        from trace_mcp import scratchpad
+
+        monkeypatch.setenv("TRACE_SCRATCHPAD_DIR", str(tmp_path / "override"))
+        path = scratchpad.write_scratchpad(self._session("Alpha Project"))
+        assert path.name == "SCRATCHPAD.md"
+
+
+# ── TRACE_REQUIRE_PIN closes the auto-create path ─────────────────────────
+
+
+class TestRequirePinGatesAutoCreate:
+    async def test_unpinned_auto_create_fails_closed_under_require_pin(
+        self, _isolated: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The hole: require-pin previously gated only trace_start_session, so a
+        stray unpinned process still auto-created sessions on its first logging
+        call — the exact capture the operator opted to fail closed on."""
+        monkeypatch.setenv("TRACE_REQUIRE_PIN", "1")
+
+        result = await server.trace_log_annotation(category="observation", content="x")
+        assert "Error" in result and "TRACE_REQUIRE_PIN" in result
+        assert server._current_session_id is None
+        assert not list((_isolated / "sessions").glob("trace_*.json")), "a session file was created anyway"
+
+    async def test_pinned_auto_create_still_works_under_require_pin(
+        self, _isolated: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        with pident.locked_registry() as registry:
+            registry.projects["waggle"] = pident.ProjectEntry(key="waggle", display_label="waggle")
+        pident._reset_registry_cache()
+        monkeypatch.setenv("TRACE_PROJECT", "waggle")
+        monkeypatch.setenv("TRACE_REQUIRE_PIN", "1")
+
+        result = await server.trace_log_annotation(category="observation", content="x")
+        assert "Error" not in result
+        assert server._current_session_id is not None
+        session = await server.storage.get_session(server._current_session_id)
+        assert session.metadata.project_key == "waggle"
+
+    async def test_default_off_keeps_capture_over_attribution(self, _isolated: Path) -> None:
+        """Without the flag, unpinned auto-create still works — the flag is an
+        explicit opt-out from the default capture-first posture, not a new default."""
+        result = await server.trace_log_annotation(category="observation", content="x")
+        assert "Error" not in result
+        assert server._current_session_id is not None
+
+    async def test_explicit_session_still_usable_under_require_pin(
+        self, _isolated: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The gate closes CREATION, not use: logging into an existing session by
+        explicit id must keep working on an unpinned require-pin process."""
+        result = await server.trace_start_session(project="waggle", description="d")
+        assert "Error" not in result
+        session_id = result.split("Session: ")[1].split("\n")[0].strip()
+        server._current_session_id = None
+
+        monkeypatch.setenv("TRACE_REQUIRE_PIN", "1")
+        out = await server.trace_log_annotation(category="observation", content="x", session_id=session_id)
+        assert "Error" not in out


### PR DESCRIPTION
The final code PR of the project-identity series (#32, #34–#38). Closes the three server-side polish items deferred from the isolation foundation. Each is a place the server asserted or implied something it could not know.

## Summary

- **Honest bounded `session_brief`**: newest-first scan up to a `read_ceiling` (default 200 files), early-stop at the match cap, `window_exhausted` reported; the bootstrap orientation says *"no sessions found in the newest ~N (older history not scanned)"* instead of falsely asserting "No prior TRACE sessions". The absolute wording survives only when the whole store was actually seen — where it is true.
- **`session_brief` on the `TraceStorage` contract** with an honest generic default, so orientation is part of what a backend *is*, not an accident of the JSON one.
- **`TRACE_REQUIRE_PIN` closes the auto-create path** it previously missed: an unpinned stray process on a require-pin fleet could still auto-create quarantine sessions on its first logging call — the exact capture the operator opted to fail closed on. Using an *existing* session by explicit id keeps working; the flag stays default-off (capture-over-attribution remains the default posture).
- **Per-key scratchpad fallback**: the shared `~/.trace/scratchpads/` directory + a most-recent-session-only file meant whichever project ended a session last silently clobbered another project's context-restoration buffer. Fallback files are now named by canonical key (registry-aware, so aliased legacy labels land in their real project's buffer). A checkout's `.claude/` and an explicit `TRACE_SCRATCHPAD_DIR` keep the stable `SCRATCHPAD.md` name — per-project by construction.

## Why the orientation change matters

The brief's one-line verdict is presented to the model as ground truth at the start of every session. With a single 25-file window over a store holding hundreds of sessions across dozens of projects, a project whose newest session sat 26 files back read as *never seen before* — a false absolute that shaped the assistant's behavior for the whole session. The fix is bounded in both directions (read ceiling and match cap), so the cheap-bootstrap property that motivated the window is preserved.

## Verification

- Full suite **1219 passed, 11 skipped** (13 new tests): deep-window match, window-exhausted reporting + wording, match-cap early stop, the truly-empty absolute case, the storage-contract default on a minimal non-file backend, per-key fallback naming beside the two stable-name locations, and require-pin closing auto-create while explicit-id use and the default-off posture stay intact.
- `ruff check` + `ruff format --check` + `pyright` (0 errors) + invariant registry guard + core/extension boundary guard.
- The existing bootstrap-wording guard passes unchanged — the absolute claim is retained for the genuinely-empty store, where it is correct.

## Risks / rollback

No storage-format or tool-signature changes (`session_brief` gains a defaulted parameter; response dicts gain additive keys). Two visible behavior changes are deliberate: the exhausted-window wording, and require-pin refusing auto-create — both surfaced with explicit guidance. Revert the commit to restore prior behavior.

With this merged, the remaining project-identity work is operational, not code: the human-gated migration runbook (snapshot → scan → signed plan → apply → merge-stores → fleet re-init → verify) and the post-observation hardening flip.