### PR TITLE
fix(identity): canonicalize knowledge-store filename stems in scan and stray detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`identity scan` and stray-store detection canonicalize the store filename
+  stem.** A knowledge store written before canonical keying keeps a legacy
+  filename — an uppercase or separator-bearing stem such as `REAP.json` — that a
+  case-insensitive filesystem still serves as its canonical project's store.
+  `scan` grouped stores by the raw stem, minting a phantom `REAP` group distinct
+  from the `reap` session group; the two then collided on `apply`'s
+  alias-uniqueness check. `find_stray_stores` compared the raw stem to registry
+  keys (its docstring said "canonical stem" but the code did not), so such a
+  store was reported stray even when its canonical key was registered — which
+  would make `identity check` fail its exit-0 verification permanently. Both
+  sites now classify by canonical key; the stray report still names the actual
+  filename so the operator can find it.
 - **`identity apply` no longer logs mints that never happened.** Migration
   records were appended to `migrations.jsonl` inside the registry transaction;
   when the write failed (e.g. an alias-uniqueness violation), the registry

--- a/src/trace_mcp/identity_cli.py
+++ b/src/trace_mcp/identity_cli.py
@@ -241,10 +241,20 @@ def _collect_label_groups() -> dict[str, dict[str, Any]]:
     knowledge = identity_report.knowledge_dir()
     if knowledge.is_dir():
         for store in sorted(knowledge.glob("*.json")):
-            stem = store.stem
-            if stem in pident.RESERVED_KEYS:
+            # Group by the store's CANONICAL key, not its raw filename stem. A
+            # legacy store written before canonical keying keeps an uppercase or
+            # separator-bearing filename (e.g. REAP.json, created by the old
+            # case-preserving sanitizer; a case-insensitive filesystem still
+            # serves it as reap's store). Grouping by the raw stem would mint a
+            # phantom 'REAP' group distinct from the 'reap' session group, and
+            # the two would then collide on apply's alias-uniqueness check.
+            try:
+                key = pident.canonical_project_key(store.stem)
+            except pident.ProjectKeyError:
                 continue
-            _group(stem)["stores"].append(store.name)
+            if key in pident.RESERVED_KEYS:
+                continue
+            _group(key)["stores"].append(store.name)
 
     return groups
 

--- a/src/trace_mcp/identity_report.py
+++ b/src/trace_mcp/identity_report.py
@@ -78,10 +78,21 @@ def find_stray_stores(
         return []
     stray: list[str] = []
     for path in kdir.glob("*.json"):
-        stem = path.stem
-        if stem in pident.RESERVED_KEYS:
+        # Classify by the store's CANONICAL key — a legacy uppercase or
+        # separator-bearing filename (REAP.json, created before canonical
+        # keying) belongs to key 'reap' and is NOT stray once 'reap' is
+        # registered. Comparing the raw stem to registry keys would flag such a
+        # file forever, breaking the `identity check` exit-0 verification. The
+        # reported value stays the actual filename stem, so the operator can
+        # find the file.
+        try:
+            key = pident.canonical_project_key(path.stem)
+        except pident.ProjectKeyError:
+            stray.append(path.stem)  # a filename yielding no key belongs to no project
             continue
-        if stem in registry.projects:
+        if key in pident.RESERVED_KEYS:
             continue
-        stray.append(stem)
+        if key in registry.projects:
+            continue
+        stray.append(path.stem)
     return sorted(stray)

--- a/tests/test_identity_cli.py
+++ b/tests/test_identity_cli.py
@@ -150,6 +150,24 @@ class TestScan:
         gamma = next(p for p in plan["projects"] if p["key"] == "gamma")
         assert gamma["knowledge_stores"] == ["gamma.json"]
 
+    def test_legacy_uppercase_store_groups_under_its_canonical_key(self, _isolated_home: Path) -> None:
+        """A store file written before canonical keying keeps an uppercase stem.
+
+        Grouping it by the raw stem mints a phantom 'REAP' group distinct from
+        the 'reap' session group, and the two collide on apply's alias-uniqueness
+        check. The store must fold into its canonical session group instead.
+        """
+        _write_session(_isolated_home, "trace_20260101_a", "REAP")  # -> key 'reap'
+        _write_store(_isolated_home, "REAP", learnings=["x"])  # legacy uppercase filename
+
+        _run("scan", "-o", str(_isolated_home / "plan.json"))
+        plan = json.loads((_isolated_home / "plan.json").read_text())
+        keys = [p["key"] for p in plan["projects"]]
+        assert "REAP" not in keys, f"phantom uppercase group leaked into the plan: {keys}"
+        reap = next(p for p in plan["projects"] if p["key"] == "reap")
+        assert reap["knowledge_stores"] == ["REAP.json"]
+        assert sum(reap["session_counts"].values()) == 1
+
 
 # ── apply ──────────────────────────────────────────────────────────────────
 
@@ -220,6 +238,19 @@ class TestCheck:
         code, out = _run("check")
         assert code == 1
         assert "Totally Unenrolled" in out
+
+    def test_legacy_uppercase_store_is_not_stray_when_its_key_is_registered(self, _isolated_home: Path) -> None:
+        """A store whose canonical key is registered must not read as stray.
+
+        `find_stray_stores` classified by the raw filename stem, so REAP.json
+        was flagged even with 'reap' registered — which would make `identity
+        check` fail exit-0 forever and break S8's verification criterion.
+        """
+        _enroll("reap", display="REAP")
+        _write_store(_isolated_home, "REAP", learnings=["x"], project="REAP")  # legacy uppercase file
+
+        code, out = _run("check")
+        assert code == 0, f"a registered project's legacy-cased store was flagged stray: {out}"
 
     def test_reports_absent_registry(self, _isolated_home: Path) -> None:
         _, out = _run("check")


### PR DESCRIPTION
Found while preparing the S8 migration against the live store: running the alias-uniqueness check over the generated scan plan (before any `apply`) surfaced two real defects in the shipped identity tooling. Both have the same root cause — a knowledge-store filename stem read raw instead of canonicalized — and both are triggered by **legacy uppercase store filenames** (`REAP.json`, `TRACE.json`) created before canonical keying, which a case-insensitive filesystem still serves as their canonical project's store.

## The two defects

**`identity scan` mints a phantom group.** `_collect_label_groups` grouped stores by `store.stem`, so `REAP.json` → group key `REAP`, distinct from the `reap` group built from that project's sessions. On `apply`, the two collide on the alias-uniqueness check and the entire plan is refused. That fail-closed is correct, but the plan should never have carried the collision.

**`find_stray_stores` reports a false stray — and this one is the real blocker.** It compared `path.stem` to registry keys (the docstring said "canonical stem"; the code didn't canonicalize), so `REAP.json` was flagged stray even with `reap` registered. `identity check` surfaces stray stores and exits non-zero on any finding, so the check would fail **permanently** on a correctly-registered project — breaking the migration runbook's own "`identity check` exits 0" verification step. A correct plan alone cannot fix this; it needs the code change.

## The fix

Both sites classify a store by `canonical_project_key(stem)` now (degenerate stems that yield no key are still reported). The stray report keeps the actual filename stem so an operator can find the file.

## Verification

- Full suite **1234 passed, 11 skipped** — two regression guards using the real-world shape (a legacy uppercase `REAP.json`): `scan` folds it into the canonical `reap` group with no phantom, and `check` does not flag it once `reap` is registered.
- Confirmed on the live store (read-only re-scan): the phantom `REAP`/`TRACE` groups are gone, `REAP.json` groups under `reap` (38 sessions), `TRACE.json` under `trace` (5), plan drops 42→40 groups, and the alias-uniqueness check is clean.
- `ruff check` + `ruff format --check` + `pyright` (0 errors) + invariant + boundary guards.

## Context

This blocks completing the S8 project-identity migration: the store being migrated contains exactly these legacy-cased files. No behavior change for stores already named canonically. Additive/corrective only — no schema or signature changes.