### PR TITLE
fix(config): align this checkout's launch args with the canonical form

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -11,9 +11,8 @@
         "numpy",
         "--with",
         "model2vec",
-        "--with",
-        "filelock",
-        "--refresh",
+        "--refresh-package",
+        "trace-mcp",
         "trace-mcp"
       ],
       "env": {


### PR DESCRIPTION
## Summary

Two argument changes to this checkout's own `.mcp.json`:

- `--refresh` → `--refresh-package trace-mcp`
- drop `--with filelock`

## Why

Both changes bring this file onto the same form `trace-mcp-init` generates, so re-running init here will not reintroduce drift.

The flag change is the substantive one. `--refresh` and `--refresh-package trace-mcp` both rebuild the server from the working tree on every start, but `--refresh` additionally re-resolves the entire dependency tree each time. That is the mechanism by which an upstream major release reaches every consumer the moment it is published, rather than when this package next changes — the propagation path behind the `mcp` 2.0.0 outage fixed in #41. `TestMCPConfiguration::test_mcp_json_uses_uvx` explicitly accepts either refresh form.

`--with filelock` was redundant — already a declared dependency, and measurably no difference to the registered tool set.

## `--from .` deliberately unchanged

An earlier revision of this PR replaced `--from .` with an absolute path, on the mistaken premise that the relative path was a latent defect because it resolves only when the client's working directory is this repo. That was wrong on two counts, and CI caught it:

1. It is the **load-bearing local-only guarantee** asserted by `test_mcp_json_uses_uvx` — the source after `--from` must never be a PyPI spec, because the name `trace-mcp` there belongs to an unrelated project.
2. A relative path is the only machine-agnostic option for a config that lives *inside* the repo. An absolute path would commit one developer's home directory into a public tree.

Consumer projects use absolute paths because their configs live outside this repo and are not tracked here. The two cases are correctly different, not inconsistent.

## Deliberately not changed

The extras `openai`, `numpy`, `model2vec` are kept even though `trace-mcp-init` omits them. Without them the trace-learn extension does not load and the server registers **17 tools instead of 22**, with no error raised. That divergence is a defect in the config `init_project.py` generates, tracked separately.

## Verification

- `uv run pytest tests/test_installation_health.py` — 25 passed, 1 skipped.
- Server launched from this config through a real MCP stdio handshake (`initialize` → `tools/list` → `trace_health_check`): 22 tools, version 0.5.0, `pinned=true`, `bound_project_key=trace-mcp`.