### PR TITLE
docs: finalize the 0.5.0 changelog and refresh the deployment figures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+> **On the 0.4.1 and 0.4.2 sections.** Both were written up here but never
+> tagged, so no git tag or GitHub Release exists for either and neither has a
+> comparison link. Their changes ship in the v0.5.0 tag, whose comparison link
+> therefore spans from v0.4.0.
+
 ## [Unreleased]
 
-## [0.5.0] — 2026-07-24
+## [0.5.0] — 2026-07-30
 
 ### Added
+
+- **A shipped-launch-path guard.** `TestShippedLaunchPath` installs the built
+  wheel into a clean virtualenv with no lockfile — the dependency resolution a
+  consumer actually gets — and asserts the server imports and registers its core
+  tools. The existing `uvx` check covers the same path but passes
+  `--refresh-package trace-mcp`, which refreshes the package and not its
+  transitive dependencies, so a machine whose cache already held a working
+  environment stayed green while a cold-cache consumer got a dead server. The
+  new guard cannot be masked that way, and it asserts that tools *register*
+  rather than only that the module imports.
+- **A provenance figure generated from real capture data.** `scripts/make_provenance_animation.py`
+  renders any session file as a self-contained animated SVG plus a still frame,
+  with light and dark styling and no external assets. Event type, category,
+  actor, direction/execution, disposition and correction targets are copied
+  verbatim; only descriptions are shortened, at a word boundary.
 
 - **Honest bounded session orientation.** `session_brief` scans newest-first up
   to a `read_ceiling` (default 200 files), stopping early at `scan_cap`
@@ -150,6 +170,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   against the v0.4 schema (`additionalProperties` is permitted throughout).
 
 ### Fixed
+
+- **The `mcp` dependency is bounded below 2.0.** `mcp` 2.0.0 removed
+  `mcp.server.fastmcp`, which `server.py` imports at module scope, so the
+  previously unbounded `mcp>=1.0.0` resolved to a release the server cannot
+  import — it died before registering a single tool, which a client reports as
+  a total absence of TRACE tools. Consumers launch with `uvx --refresh`, which
+  ignores the lockfile and re-resolves on every server start, so the break
+  reached every project the day the upstream major was published. Lifting the
+  bound requires porting to the `mcp` 2.x API (`mcp.server.mcpserver`).
+- **This checkout's own launch arguments match the canonical form.**
+  `--refresh` became `--refresh-package trace-mcp`, so a server start rebuilds
+  TRACE from the working tree without re-resolving the whole dependency tree,
+  and the redundant `--with filelock` was dropped. The relative `--from .` is
+  unchanged: it is the local-only guarantee asserted by
+  `test_mcp_json_uses_uvx`, since the `trace-mcp` name on PyPI belongs to an
+  unrelated project.
+
 
 - **`identity scan` and stray-store detection canonicalize the store filename
   stem.** A knowledge store written before canonical keying keeps a legacy
@@ -625,9 +662,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Knowledge persistence, behavioral checks, checkpoints.
 
 [Unreleased]: https://github.com/Thru-Echoes/TRACE/compare/v0.5.0...HEAD
-[0.5.0]: https://github.com/Thru-Echoes/TRACE/compare/v0.4.2...v0.5.0
-[0.4.2]: https://github.com/Thru-Echoes/TRACE/compare/v0.4.1...v0.4.2
-[0.4.1]: https://github.com/Thru-Echoes/TRACE/compare/v0.4.0...v0.4.1
+[0.5.0]: https://github.com/Thru-Echoes/TRACE/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/Thru-Echoes/TRACE/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/Thru-Echoes/TRACE/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/Thru-Echoes/TRACE/compare/v0.1.0...v0.2.0

--- a/README.md
+++ b/README.md
@@ -60,22 +60,25 @@ Three events from a real `corp-sus-report-extractor` session: a human-proposed s
 
 ## Preliminary deployment results
 
-Since the v0.3 release (2026-03-19), TRACE has been used across **5 research workflows**:
+Between 2026-03-18 and 2026-07-30, TRACE was used across **8 sustained research and development projects**:
 
-| Project | Domain | Sessions | Events | Decisions | Corrections |
+| Project | Domain | Sessions | Decisions | Contributions | Corrections |
 |---|---|---:|---:|---:|---:|
-| When-Algorithms-Meet-Artists | Computational art / cultural studies | 22 | 114 | 27 | 4 |
-| corp-sus-report-extractor | Corporate sustainability disclosure | 11 | 56 | 17 | 3 |
-| TRACE (self-host / meta) | Protocol research | 9 | 54 | 16 | 6 |
-| REAP | Environmental discourse analysis | 3 | 53 | 22 | 3 |
-| green-narrative | Environmental narrative analysis | 7 | 50 | 19 | 5 |
-| **Total** | | **52** | **327** | **101** | **21** |
+| trace-mcp (self-host / meta) | Protocol research | 88 | 132 | 205 | 25 |
+| trace-meeting-recorder | Speech transcription / diarization | 72 | 108 | 156 | 25 |
+| corp-sus-report-extractor | Corporate sustainability disclosure | 54 | 91 | 132 | 18 |
+| REAP | Environmental discourse analysis | 38 | 65 | 112 | 18 |
+| When-Algorithms-Meet-Artists | Computational art / cultural studies | 31 | 56 | 95 | 5 |
+| trace-research | Manuscript / literature synthesis | 30 | 48 | 76 | 18 |
+| waggle | Applied agentic tooling | 24 | 31 | 76 | 6 |
+| green-narrative | Environmental narrative analysis | 23 | 38 | 40 | 8 |
+| **Total** | | **360** | **569** | **892** | **123** |
 
-Decisions: **45% AI-proposed / 55% human-proposed**. Of resolved decisions, 86% accepted, 6% revised, 8% rejected — plus 21 separately-logged corrections. The acceptance rate is not rubber-stamping; the corrections, revisions, and rejections are the active human steering this protocol is designed to surface.
+Decisions: **67% AI-proposed / 33% human-proposed**. Of the 421 *resolved* decisions, 90% accepted, 6% revised, 4% rejected; a further 148 remain in the `proposed` state, because an AI may not resolve its own proposal and not every proposal gets answered. The acceptance rate is not rubber-stamping — the 27 revisions, 15 rejections, and 123 separately-logged corrections are the active human steering this protocol exists to surface, and each one is an alternative that a commit history would have discarded.
 
-Contributions: **73% human-directed → AI-executed, 20% collaborative-directed, 8% AI-directed**. Pure AI-directed-and-executed work is a minority; the dominant pattern is human direction with AI execution — which existing attribution norms cannot describe.
+Contributions: **70% human-directed, 22% collaborative, 8% AI-directed**; 66% are human-directed *and* AI-executed. Pure AI-directed-and-executed work is a small minority. The dominant pattern is human direction with AI execution — which existing authorship and attribution norms cannot describe.
 
-> These figures are aggregated from per-session TRACE logs in `~/.trace/sessions/`, which are not committed to this repository (they contain project-internal content). They are reproducible from those logs via `trace_project_summary`; an aggregated, de-identified export can be provided on request.
+> **What these counts include.** Figures are aggregated from per-session logs in `~/.trace/sessions/`, which are not committed here (they contain project-internal content), and cover the eight named projects only. The store also holds meeting-transcription namespaces, throwaway test keys, and short exploratory sessions; those are excluded, since a transcript namespace accumulates thousands of machine-written annotation events and no decisions, and including them would inflate a raw event count by more than an order of magnitude without adding a single act of provenance. Counts here are the deliberately logged event types. Sessions recorded before v0.5 under the display label `TRACE` are counted under `trace-mcp`, which is the same project under its canonical key. Reproducible from those logs via `trace_project_summary`; an aggregated, de-identified export can be provided on request.
 
 ## Architecture
 


### PR DESCRIPTION
## Summary

Two release-readiness fixes to the documents a first-time visitor reads.

- **CHANGELOG** — record the work that landed after the 0.5.0 section was drafted, date it to the intended tag date, and repair three comparison links that resolved to nothing.
- **README** — replace the v0.3-era deployment table with current figures over an explicitly named project set.

## Why

**The changelog links were broken.** `[0.5.0]`, `[0.4.2]` and `[0.4.1]` pointed at `compare/…` URLs referencing **tags that do not exist** — only v0.1.0 through v0.4.0 were ever tagged. 0.4.1 and 0.4.2 were documented but never released, so those two sections have no comparison range at all. The 0.5.0 link now spans from v0.4.0, and a note explains the gap rather than leaving a reader to hit a 404.

**The deployment table was four months stale.** It reported 52 sessions and 327 events across 5 workflows, measured at the v0.3 release in March, and understated the record by roughly sevenfold. It is also the first quantitative claim a visitor meets.

| | was | now |
|---|---:|---:|
| Projects | 5 | 8 |
| Sessions | 52 | 360 |
| Decisions | 101 | 569 |
| Contributions | — | 892 |
| Corrections | 21 | 123 |

## What is counted, and what is deliberately not

The **Events column is gone**, replaced by Contributions. A raw event count is not a measure of provenance: the store's largest event producers are meeting-transcription namespaces that accumulate thousands of machine-written annotations and *no decisions at all*. One such namespace holds over 10,000 events and a single decision. Including them would have inflated the headline by more than an order of magnitude without adding one act of provenance. The table now reports only deliberately logged types, and the note states which categories are excluded and why.

The eight projects are those with sustained use. Transcript namespaces, throwaway test keys, short exploratory sessions, and case-variant duplicates are excluded. Sessions written before v0.5 under the display label `TRACE` are counted under `trace-mcp` — the same project under its canonical key, which is exactly the identity rule v0.5 introduced.

The narrative figures move with the data: decisions are now 67% AI-proposed against the previous 45%, and the resolved split is 90/6/4 rather than 86/6/8. The **148 decisions still in `proposed`** are now stated rather than omitted — an AI may not resolve its own proposal, so that backlog is a designed property of the protocol, not missing data.

## Verification

- `uv run ruff format --check .` and `uv run ruff check .` — clean.
- `uv run pytest tests/test_invariants.py tests/test_installation_health.py` — 35 passed, 1 skipped, covering INV-10 so the 0.5.0 version declarations stay consistent.
- Figures recomputed directly from the session store; every number in the table and the two narrative paragraphs derives from the same pass.

## Not included

No version bump — package and schema are already 0.5.0 and the section was never released. Tagging, the GitHub Release, and PyPI are separate deliberate steps; `release.yml` has no push or tag trigger, so nothing here can publish anything.