### PR TITLE
fix(init): load the trace-learn extension, and move the README badges to the top

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.21711455.svg)](https://doi.org/10.5281/zenodo.21711455) [![CI](https://github.com/Thru-Echoes/TRACE/actions/workflows/ci.yml/badge.svg)](https://github.com/Thru-Echoes/TRACE/actions/workflows/ci.yml) [![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://github.com/Thru-Echoes/TRACE/blob/main/LICENSE) [![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-blue.svg)](https://github.com/Thru-Echoes/TRACE/blob/main/pyproject.toml)
+
 # Why TRACE? 
 
 In the age of AI, how do we know *who* proposed *what* in a scientific or coding dev workflow? Was the idea for that methodological decision made by *AI* or by a *human*? And when decisions are proposed by AI, are they being accepted, rejected, or iterated on? 
@@ -26,11 +28,6 @@ to be wrong. Regenerate it from any session with
 3. `trace_start_session` runs there, learnings auto-recall, and a five-item task plan emerges.
 
 ## **TRACE: Transparent Recording of AI-assisted Collaboration Experiments**
-
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.21711455.svg)](https://doi.org/10.5281/zenodo.21711455)
-[![CI](https://github.com/Thru-Echoes/TRACE/actions/workflows/ci.yml/badge.svg)](https://github.com/Thru-Echoes/TRACE/actions/workflows/ci.yml)
-[![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://github.com/Thru-Echoes/TRACE/blob/main/LICENSE)
-[![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-blue.svg)](https://github.com/Thru-Echoes/TRACE/blob/main/pyproject.toml)
 
 TRACE is an MCP server that provides a standardized audit trail for AI-assisted research workflows. It records tool calls, decisions, annotations, contributions, and actor attribution — who proposed what, who accepted or revised it, and why.
 

--- a/src/trace_mcp/init_project.py
+++ b/src/trace_mcp/init_project.py
@@ -82,6 +82,21 @@ def _resolve_trace_source() -> str:
     )
 
 
+LEARN_EXTRAS: tuple[str, ...] = ("openai", "numpy", "model2vec")
+"""Optional dependencies the trace-learn extension needs in order to register.
+
+`uvx --from <src> trace-mcp` installs the base package only, so without these
+the extension does not load and the server comes up with the 17 core tools
+instead of the documented 22 — silently, because a missing optional dependency
+is not an error. They are `--with` flags rather than a hard dependency so the
+core install stays `mcp` + `pydantic`.
+
+Installing `openai` does not enable cloud calls: LLM matching and extraction
+remain opt-in behind `TRACE_LLM_ENABLED` and an API key, and the local
+`model2vec` backend is the default.
+"""
+
+
 def _mcp_server_config(project_key: str | None = None) -> dict:
     """Build the `.mcp.json` ``mcpServers`` entry for TRACE.
 
@@ -95,9 +110,12 @@ def _mcp_server_config(project_key: str | None = None) -> dict:
     writes are refused rather than silently accepted.
     """
     source = _resolve_trace_source()
+    with_flags: list[str] = []
+    for pkg in LEARN_EXTRAS:
+        with_flags += ["--with", pkg]
     entry: dict = {
         "command": "uvx",
-        "args": ["--from", source, "--refresh-package", "trace-mcp", "trace-mcp"],
+        "args": ["--from", source, *with_flags, "--refresh-package", "trace-mcp", "trace-mcp"],
     }
     if project_key:
         entry["env"] = {"TRACE_PROJECT": project_key}
@@ -276,11 +294,18 @@ def _rebuild_args(fresh_args: list[str], with_packages: list[str]) -> list[str]:
 
     ``fresh_args`` ends with the tool name (the uvx command); preserved
     ``--with`` flags are inserted just before it so uvx option order stays valid.
+
+    Packages the fresh args already carry are dropped from *with_packages*
+    rather than appended again: the canonical entry now ships the trace-learn
+    extras itself, so re-running init over a config that already had them would
+    otherwise duplicate every one on each run.
     """
-    if not with_packages:
+    already = set(_extract_with_packages(fresh_args))
+    extra = [pkg for pkg in with_packages if pkg not in already]
+    if not extra:
         return list(fresh_args)
     with_flags: list[str] = []
-    for pkg in with_packages:
+    for pkg in extra:
         with_flags += ["--with", pkg]
     return fresh_args[:-1] + with_flags + fresh_args[-1:]
 

--- a/tests/test_init_project.py
+++ b/tests/test_init_project.py
@@ -59,7 +59,22 @@ def test_fresh_init_shape(tmp_path: Path) -> None:
     assert "wrote" in status
     entry = _read(tmp_path)["mcpServers"]["trace"]
     assert entry["command"] == "uvx"
-    assert entry["args"] == ["--from", _SOURCE, "--refresh-package", "trace-mcp", "trace-mcp"]
+    # The trace-learn extras are part of the canonical entry: without them the
+    # extension does not register and the server comes up with 17 tools instead
+    # of the documented 22, with no error to explain the gap.
+    assert entry["args"] == [
+        "--from",
+        _SOURCE,
+        "--with",
+        "openai",
+        "--with",
+        "numpy",
+        "--with",
+        "model2vec",
+        "--refresh-package",
+        "trace-mcp",
+        "trace-mcp",
+    ]
     assert "env" not in entry  # no empty env block on a fresh install
 
 
@@ -89,12 +104,37 @@ def test_reinit_preserves_with_extras(tmp_path: Path) -> None:
     assert "updated" in status
 
     args = _read(tmp_path)["mcpServers"]["trace"]["args"]
-    # Canonical source is rebuilt (old /old/TRACE gone), the command stays last,
-    # and the hand-added extras are preserved in order.
-    assert args[:4] == ["--from", _SOURCE, "--refresh-package", "trace-mcp"]
+    # Canonical source is rebuilt (old /old/TRACE gone) and the command stays last.
+    assert args[:2] == ["--from", _SOURCE]
     assert args[-1] == "trace-mcp"
+    assert "--refresh-package" in args and "--refresh" not in args
+    # These three are now canonical, so they must appear exactly once each —
+    # the existing entry carried the same packages, and re-running init must
+    # not append a second copy of every one.
     with_pkgs = [args[i + 1] for i, a in enumerate(args) if a == "--with"]
     assert with_pkgs == ["openai", "numpy", "model2vec"]
+
+
+def test_reinit_preserves_hand_added_extra_alongside_canonical(tmp_path: Path) -> None:
+    """A package the user added themselves survives, appended after the canonical set."""
+    existing = {
+        "mcpServers": {
+            "trace": {
+                "command": "uvx",
+                "args": ["--from", "/old/TRACE", "--with", "numpy", "--with", "pandas", "--refresh", "trace-mcp"],
+            }
+        }
+    }
+    (tmp_path / ".mcp.json").write_text(json.dumps(existing))
+
+    _write_mcp_json(tmp_path)
+
+    args = _read(tmp_path)["mcpServers"]["trace"]["args"]
+    with_pkgs = [args[i + 1] for i, a in enumerate(args) if a == "--with"]
+    assert with_pkgs == ["openai", "numpy", "model2vec", "pandas"], (
+        "canonical extras first, no duplicate of the overlapping one, hand-added package kept"
+    )
+    assert args[-1] == "trace-mcp"
 
 
 def test_reinit_preserves_env_block(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- `trace-mcp-init` now writes the three `--with` packages the trace-learn extension needs, and re-running it no longer duplicates them.
- The README badge row moves above the title.

## The init defect

The generated entry was:

```
uvx --from <src> --refresh-package trace-mcp trace-mcp
```

That installs the base distribution only. The trace-learn extension cannot import its optional dependencies, so it never registers and the server comes up with **17 tools where the documentation promises 22**. Nothing reports the gap — a missing optional dependency is not an error, so the five tools are simply absent and a user has no way to connect the two facts.

This arrived by the *documented onboarding path*, which makes it the first experience of the project for anyone following the README. It also explains a fault previously written off as one project's stale config: a consumer found on 2026-07-24 exposing 17 tools was not misconfigured by hand, it was configured by this function.

### What changed

- `LEARN_EXTRAS = ("openai", "numpy", "model2vec")` is now part of the canonical entry. They remain `--with` flags rather than hard dependencies, so a core install stays `mcp` + `pydantic`. Installing `openai` does not enable cloud calls: LLM matching and extraction stay opt-in behind `TRACE_LLM_ENABLED` and an API key, and the local `model2vec` backend is the default.
- `_rebuild_args` drops packages the fresh args already carry. Without this, re-running init over a config that already lists the same extras — which every existing consumer config does — would append a second copy of each on every run.

### Verification

End-to-end rather than by string comparison: generated a config through `_mcp_server_config` and launched it over a real MCP stdio handshake (`initialize` → `tools/list` → `trace_health_check`).

```
tools=22  version=0.5.0  pinned=True  key=inittest-probe
```

- The fresh-init shape test asserts the extras and records why they are load-bearing.
- A new test covers re-running init over a config carrying both an overlapping canonical package and a hand-added one, asserting no duplication and that the hand-added package survives in place.
- Full suite: 1251 passed, 11 skipped. `ruff format --check`, `ruff check`, and `pyright` on the changed module all clean.

## Badge placement

The badges added in #46 sat under the project heading, about thirty lines down — after the opening argument and two figures. A reader had to scroll past both images before seeing the DOI, the licence, or the build status, which defeats the purpose of a badge row. They now sit above the first heading.

The DOI badge remains repeated in the Citation section, where it reads as context for the BibTeX entry rather than as a status indicator.