### PR TITLE
fix(learn): enforce the TRACE_PROJECT pin and honest recall on all learn tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Learn tools now enforce the `TRACE_PROJECT` pin (INV-9, ADR-006).** All
+  five `trace_learn_*` tools resolve their `project` argument through the same
+  scope rule as `trace_start_session`: under a pin, an omitted `project`
+  resolves to the pinned project and a label resolving to any other key errors
+  naming both keys; unpinned, an explicit label is required. Previously a
+  pinned server accepted any foreign label on the learn surface — a
+  cross-project read/write bypass of the documented fail-closed guarantee.
+  `project` is now optional on all five tools (it was required), which is
+  backwards-compatible for MCP callers, which pass arguments by name. When a
+  pinned call is accepted through a registry alias whose canonical form
+  differs from the pinned key, the operation is keyed to the pinned project's
+  store — an accepted alias can never open a different store file than the
+  project it was authorized against.
+- **`trace_learn_recall` no longer returns unranked listings dressed as
+  results.** A call with neither `context`/`query` nor `tags` previously
+  returned the store's first N learnings in insertion order under a
+  `"results"` key, with no scores and no warning — indistinguishable from a
+  ranked match. It now returns an explicit error pointing at
+  `trace_learn_list`; whitespace-only query text and blank tag elements are
+  treated as absent rather than ranked against; and every ranked recall
+  response carries a `backend` field naming the engine selected for the
+  ranking (`bm25`, `embedding:<model>`, `llm:<model>` — the embedding backend
+  scores learnings that lack embeddings through its internal BM25 fallback),
+  so a degraded backend configuration is visible to the caller. This is a
+  protocol-visible behavioral change: a caller that relied on the no-query
+  listing must switch to `trace_learn_list`.
+- **`trace_learn_recall` accepts `query` as an alias for `context`.** MCP
+  argument models silently drop unknown fields, so a client sending
+  `query=...` used to have its query text ignored entirely (surfacing as
+  insertion-order "results"). Either name works now; passing both with
+  different values is an error, never a silent preference.
+
 ## [0.5.0] — 2026-07-30
 
 ### Added

--- a/docs/INVARIANTS.md
+++ b/docs/INVARIANTS.md
@@ -215,19 +215,27 @@ temp file, a caller exception writes nothing).
 
 ---
 
-## INV-9 — Every learn tool guards its free-form project label  · ENFORCED
+## INV-9 — Every learn tool resolves its project label against the pin  · ENFORCED
 
 **Statement.** Each `@mcp.tool` in `extensions/learn` that takes a `project`
-parameter calls `_reserved_project_error` at entry, so a reserved-key
-(`auto`/`shared`) or degenerate label returns an error and never reaches a
-knowledge store. Combined with the canonical `_store_path`, a free-form label
-can neither open a quarantine store nor create a mis-keyed one.
+parameter calls `_resolve_project` at entry, which delegates to
+`project_identity.resolve_scoped_project` — the same scope rule
+`trace_start_session` uses. Under a `TRACE_PROJECT` pin, an omitted project
+resolves to the pin and a label resolving to any other key errors naming both
+keys; unpinned, an explicit non-empty label is required; a reserved-key
+(`auto`/`shared`) or degenerate label is rejected in both modes. Combined with
+the canonical `_store_path`, a free-form label can neither cross the pin, open
+a quarantine store, nor create a mis-keyed one. (Before this rule, learn tools
+accepted any foreign label on a pinned server — a cross-project read/write
+bypass of the documented fail-closed guarantee.)
 
 **Sites:** `src/trace_mcp/extensions/learn/__init__.py` (`trace_learn_recall`,
 `trace_learn_add`, `trace_learn_list`, `trace_learn_forget`,
-`trace_learn_extract`).
+`trace_learn_extract`); `src/trace_mcp/server.py` (`_resolve_start_project`,
+by delegation).
 
 **Guard:** `tests/test_invariants.py :: test_inv9_learn_tools_guard_reserved_projects`
+(structural) + `tests/test_learn_pin_scope.py` (behavioral).
 (AST enumeration — a new learn tool with a `project` param that does not call
 `_reserved_project_error` fails, with a positive control against pattern rot).
 

--- a/src/trace_mcp/extensions/learn/__init__.py
+++ b/src/trace_mcp/extensions/learn/__init__.py
@@ -38,20 +38,35 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _reserved_project_error(project: str) -> str | None:
-    """JSON error if *project* is degenerate or resolves to a reserved key, else None.
+def _resolve_project(project: str | None) -> tuple[str, str | None]:
+    """Resolve *project* against the process pin; ``(label, None)`` or ``("", error-JSON)``.
 
-    The usage-ban half of ADR-006 (INV-9): reserved keys (auto/shared) are
-    quarantine stores, not projects a learn tool may operate on. Every learn
-    tool calls this at entry so a free-form label cannot reach a reserved store.
+    The scope gate for every learn tool (INV-9, ADR-006): pin resolution
+    (``None`` → the pin), foreign-label rejection on a pinned server (the error
+    names both keys), and the reserved-key usage ban all happen here — before
+    any knowledge store is touched. Unpinned, an explicit non-empty label is
+    required.
+
+    The returned label is STORE-SAFE: knowledge-store filenames key on
+    ``canonical_project_key(label)`` (registry-independent), so when a pinned
+    call is accepted through a registry ALIAS whose canonical form differs from
+    the pinned key (or the pin's display label itself diverges), the pinned KEY
+    is returned instead — otherwise the accepted alias would silently open a
+    different store file than the project it was authorized against.
     """
     try:
-        key = pident.canonical_project_key(project)
+        label = pident.resolve_scoped_project(project)
+        bound = pident.get_bound_project()
+        if bound is not None:
+            if pident.canonical_project_key(label) != bound.key:
+                label = bound.key
+        elif pident.key_for_label(label) in pident.RESERVED_KEYS:
+            # Defense in depth: a registry alias must not smuggle a benign-looking
+            # label into a reserved quarantine store on an unpinned server.
+            raise pident.ProjectKeyError(f"{label!r} resolves to a reserved project key and cannot be used.")
+        return label, None
     except pident.ProjectKeyError as exc:
-        return json.dumps({"error": str(exc), "project": project})
-    if key in pident.RESERVED_KEYS:
-        return json.dumps({"error": f"'{project}' is a reserved project key and cannot be used", "project": project})
-    return None
+        return "", json.dumps({"error": str(exc), "project": project or ""})
 
 
 def register(mcp: FastMCP, storage: TraceStorage) -> None:
@@ -150,12 +165,12 @@ def register(mcp: FastMCP, storage: TraceStorage) -> None:
             return []
         return [lrn for lrn in ks.learnings if lrn.embedding is None or lrn.embedding_model != active.model_name]
 
-    def _registry_unavailable_error(project: str, exc: Exception) -> str:
+    def _registry_unavailable_error(project: str | None, exc: Exception) -> str:
         return json.dumps(
             {
                 "error": "project registry unreadable — learn operations fail closed",
                 "detail": str(exc),
-                "project": project,
+                "project": project or "",
             }
         )
 
@@ -254,16 +269,25 @@ def register(mcp: FastMCP, storage: TraceStorage) -> None:
 
     @mcp.tool()
     async def trace_learn_recall(
-        project: str,
+        project: str | None = None,
         context: str | None = None,
         tags: list[str] | None = None,
         threshold: float | None = None,
         limit: int = 10,
+        query: str | None = None,
     ) -> str:
         """Find relevant past learnings for a given context.
 
         Searches the project's knowledge store using text similarity
-        and tag matching. Returns scored results above the threshold.
+        and tag matching. Returns scored results above the threshold, plus a
+        ``backend`` field naming what produced the ranking. ``query`` is an
+        alias for ``context`` (either alone is fine; both with different
+        values is an error). A call with neither context/query nor tags is an
+        error — use ``trace_learn_list`` to browse the store unranked.
+
+        ``project`` is optional when the server is pinned (TRACE_PROJECT):
+        omit it to use the pin; a supplied label must resolve to the pinned
+        project. Unpinned, an explicit project is required.
 
         When threshold is None, uses the backend's default (BM25: 0.15, LLM: 0.2).
 
@@ -272,19 +296,44 @@ def register(mcp: FastMCP, storage: TraceStorage) -> None:
         keep recall fully local.
         """
         try:
-            guard = _reserved_project_error(project)
-            if guard:
-                return guard
+            project, _err = _resolve_project(project)
+            if _err:
+                return _err
+            # Normalize BEFORE alias-conflict detection: whitespace-only text is
+            # no query (it must not rank, and must not count as a conflicting
+            # alias value), and blank tag elements are no criteria.
+            if context is not None:
+                context = context.strip() or None
+            if query is not None:
+                query = query.strip() or None
+            if tags is not None:
+                tags = [t.strip() for t in tags if isinstance(t, str) and t.strip()] or None
+            if query is not None and context is not None and query != context:
+                return json.dumps(
+                    {
+                        "error": "query and context were both given and differ — pass a single query text",
+                        "project": project,
+                    }
+                )
+            if context is None:
+                context = query
+            if not context and not tags:
+                return json.dumps(
+                    {
+                        "error": "recall needs context text or tags to rank against",
+                        "hint": "To browse the store without a query, use trace_learn_list.",
+                        "project": project,
+                    }
+                )
             _eff, backend, provider = _effective(project)
             # Lock the full span (recall may backfill
             # embeddings and save — a read-modify-write).
             with store.project_lock(project), egress_project(pident.key_for_label(project) or None):
                 ks = store.load_store(project)
                 if not ks.learnings:
-                    return json.dumps({"project": project, "results": [], "total": 0})
-                if not context and not tags:
-                    results = store.list_learnings(ks)
-                    return json.dumps({"project": project, "results": results[:limit], "total": len(results)})
+                    return json.dumps(
+                        {"project": project, "results": [], "total": 0, "backend": matching.describe_backend(backend)}
+                    )
                 # Lazy-embed: generate (or regenerate) embeddings for learnings that need them
                 stale = _needs_embedding(ks, provider)
                 embedded = await _embed_learnings(stale, provider) if stale else False
@@ -299,7 +348,14 @@ def register(mcp: FastMCP, storage: TraceStorage) -> None:
                 )
                 if results or embedded:
                     store.save_store(ks)
-                return json.dumps({"project": project, "results": results, "total": len(results)})
+                return json.dumps(
+                    {
+                        "project": project,
+                        "results": results,
+                        "total": len(results),
+                        "backend": matching.describe_backend(backend),
+                    }
+                )
         except pident.RegistryUnavailableError as exc:
             return _registry_unavailable_error(project, exc)
         except Exception as exc:
@@ -319,8 +375,8 @@ def register(mcp: FastMCP, storage: TraceStorage) -> None:
 
     @mcp.tool()
     async def trace_learn_add(
-        project: str,
         content: str,
+        project: str | None = None,
         source_session: str | None = None,
         source_event: str | None = None,
         category: str = "learning",
@@ -331,13 +387,17 @@ def register(mcp: FastMCP, storage: TraceStorage) -> None:
         Use this to record insights, patterns, or corrections that should
         persist across sessions.
 
+        ``project`` is optional when the server is pinned (TRACE_PROJECT):
+        omit it to use the pin; a supplied label must resolve to the pinned
+        project. Unpinned, an explicit project is required.
+
         Data flow: with the OpenAI embedding backend configured, the learning
         content is embedded via OpenAI. Set ``TRACE_LOCAL_ONLY=1`` for local-only.
         """
         try:
-            guard = _reserved_project_error(project)
-            if guard:
-                return guard
+            project, _err = _resolve_project(project)
+            if _err:
+                return _err
             if category not in _VALID_CATEGORIES:
                 return json.dumps(
                     {
@@ -402,17 +462,21 @@ def register(mcp: FastMCP, storage: TraceStorage) -> None:
 
     @mcp.tool()
     async def trace_learn_list(
-        project: str,
+        project: str | None = None,
         category: str | None = None,
     ) -> str:
         """List all learnings in a project's knowledge store.
 
         Optionally filter by category (learning, correction, gotcha, decision).
+
+        ``project`` is optional when the server is pinned (TRACE_PROJECT):
+        omit it to use the pin; a supplied label must resolve to the pinned
+        project. Unpinned, an explicit project is required.
         """
         try:
-            guard = _reserved_project_error(project)
-            if guard:
-                return guard
+            project, _err = _resolve_project(project)
+            if _err:
+                return _err
             ks = store.load_store(project)
             results = store.list_learnings(ks, category=category)
             return json.dumps({"project": project, "learnings": results, "total": len(results)})
@@ -422,17 +486,21 @@ def register(mcp: FastMCP, storage: TraceStorage) -> None:
 
     @mcp.tool()
     async def trace_learn_forget(
-        project: str,
         learning_id: str,
+        project: str | None = None,
     ) -> str:
         """Remove a learning from the project's knowledge store.
 
         Use this when a learning is outdated, wrong, or no longer relevant.
+
+        ``project`` is optional when the server is pinned (TRACE_PROJECT):
+        omit it to use the pin; a supplied label must resolve to the pinned
+        project. Unpinned, an explicit project is required.
         """
         try:
-            guard = _reserved_project_error(project)
-            if guard:
-                return guard
+            project, _err = _resolve_project(project)
+            if _err:
+                return _err
             with store.project_lock(project):  # lock the full read-modify-write span
                 ks = store.load_store(project)
                 removed = store.remove_learning(ks, learning_id)
@@ -446,10 +514,14 @@ def register(mcp: FastMCP, storage: TraceStorage) -> None:
 
     @mcp.tool()
     async def trace_learn_extract(
-        project: str,
+        project: str | None = None,
         session_id: str | None = None,
     ) -> str:
         """Extract learnings from session annotations and decisions.
+
+        ``project`` is optional when the server is pinned (TRACE_PROJECT):
+        omit it to use the pin; a supplied label must resolve to the pinned
+        project. Unpinned, an explicit project is required.
 
         Processes learning/correction/gotcha annotations and rejected/revised
         decisions into persistent knowledge entries. Idempotent — running twice
@@ -467,9 +539,9 @@ def register(mcp: FastMCP, storage: TraceStorage) -> None:
         Otherwise, extracts from all sessions for the project.
         """
         try:
-            guard = _reserved_project_error(project)
-            if guard:
-                return guard
+            project, _err = _resolve_project(project)
+            if _err:
+                return _err
             # INV-6: when extracting a specific session, refuse if it belongs to a
             # different project — the cross-wired-extract bleed (would send this
             # project's whole store to the cloud alongside another's events).

--- a/src/trace_mcp/extensions/learn/matching.py
+++ b/src/trace_mcp/extensions/learn/matching.py
@@ -495,6 +495,24 @@ class EmbeddingBackend:
 # ── Backend auto-selection ────────────────────────────────────────────────
 
 
+def describe_backend(backend: MatchingBackend) -> str:
+    """Short name of the engine behind a ranking, for recall responses.
+
+    A caller must be able to tell WHICH backend produced a ranking — a
+    degraded or misconfigured backend has to be visible in the response, not
+    silent (the fail-loud posture of docs/INVARIANTS.md).
+    """
+    if isinstance(backend, EmbeddingBackend):
+        return f"embedding:{backend._provider.model_name}"
+    if isinstance(backend, LLMBackend):
+        return f"llm:{backend._model}"
+    if isinstance(backend, BM25Backend):
+        return "bm25"
+    if isinstance(backend, JaccardBackend):
+        return "jaccard"
+    return type(backend).__name__
+
+
 def get_default_backend(config: LearnConfig | None = None) -> MatchingBackend:
     """Return the best available matching backend based on *config*.
 

--- a/src/trace_mcp/project_identity.py
+++ b/src/trace_mcp/project_identity.py
@@ -605,3 +605,44 @@ def get_bound_project() -> BoundProject | None:
         return BoundProject(key=canon, display_label=raw, degraded=True)
     entry = registry.projects.get(hit)
     return BoundProject(key=hit, display_label=entry.display_label if entry else raw)
+
+
+def resolve_scoped_project(project: str | None, bound: BoundProject | None = None) -> str:
+    """Resolve a tool's free-form ``project`` argument against the process pin.
+
+    The single scope-resolution rule (ADR-006) for every tool that takes a
+    ``project`` parameter. Returns the display label the tool should operate
+    on. Raises ``ProjectKeyError`` on every violation so callers surface one
+    exception type:
+
+    - Pinned: ``None`` resolves to the pin's display label; a supplied label
+      must resolve to the pinned key or the error names both keys.
+    - Unpinned: a non-empty label is required.
+    - A label resolving to a reserved key (``auto``/``shared``) is rejected in
+      both modes, as is a pin set to a reserved key.
+
+    Side effects: reads ``TRACE_PROJECT`` and the registry via
+    ``get_bound_project`` when *bound* is omitted. Never enrolls a project.
+    """
+    if bound is None:
+        bound = get_bound_project()
+    if bound is not None:
+        if bound.key in RESERVED_KEYS:
+            raise ProjectKeyError(f"server is pinned to reserved key '{bound.key}' — fix TRACE_PROJECT.")
+        if project is None:
+            return bound.display_label
+        supplied = key_for_label(project)
+        if supplied != bound.key:
+            raise ProjectKeyError(
+                f"this server is pinned to project '{bound.key}', but the call named "
+                f"{project!r} (key '{supplied or '<invalid>'}'). Omit the project argument to use the pin."
+            )
+        return project
+    if not project or not project.strip():
+        raise ProjectKeyError(
+            "no project given and this server is not pinned (TRACE_PROJECT unset). "
+            'Pass project="<name>", or set TRACE_PROJECT in the server\'s .mcp.json env.'
+        )
+    if canonical_project_key(project) in RESERVED_KEYS:
+        raise ProjectKeyError(f"{project!r} resolves to a reserved project key and cannot be used.")
+    return project

--- a/src/trace_mcp/server.py
+++ b/src/trace_mcp/server.py
@@ -104,27 +104,10 @@ def _resolve_start_project(project: str | None, bound: pident.BoundProject | Non
     resolving to a reserved key (``auto``/``shared``) is rejected.
 
     Raises ``ProjectKeyError`` on any violation (the caller surfaces it).
+    Delegates to ``project_identity.resolve_scoped_project`` — the single
+    scope-resolution rule shared with the learn tools (INV-9).
     """
-    if bound is not None:
-        if bound.key in pident.RESERVED_KEYS:
-            raise pident.ProjectKeyError(f"server is pinned to reserved key '{bound.key}' — fix TRACE_PROJECT.")
-        if project is None:
-            return bound.display_label
-        supplied = pident.key_for_label(project)
-        if supplied != bound.key:
-            raise pident.ProjectKeyError(
-                f"this server is pinned to project '{bound.key}', but trace_start_session named "
-                f"{project!r} (key '{supplied or '<invalid>'}'). Omit the project argument to use the pin."
-            )
-        return project
-    if not project or not project.strip():
-        raise pident.ProjectKeyError(
-            "no project given and this server is not pinned (TRACE_PROJECT unset). "
-            'Pass project="<name>", or set TRACE_PROJECT in the server\'s .mcp.json env.'
-        )
-    if pident.canonical_project_key(project) in pident.RESERVED_KEYS:
-        raise pident.ProjectKeyError(f"{project!r} resolves to a reserved project key and cannot be used.")
-    return project
+    return pident.resolve_scoped_project(project, bound)
 
 
 def _pinned_project_key(bound: pident.BoundProject | None) -> str | None:

--- a/tests/test_invariants.py
+++ b/tests/test_invariants.py
@@ -303,9 +303,10 @@ def _learn_tool_functions_with_project() -> set[tuple[str, str]]:
 def test_inv9_learn_tools_guard_reserved_projects() -> None:
     tools = _learn_tool_functions_with_project()
     assert tools, "INV-9 positive control: no @mcp.tool with a project param found — pattern rot."
-    guards = _functions_calling("_reserved_project_error")
+    guards = _functions_calling("_resolve_project")
     missing = tools - guards
     assert not missing, (
         "INV-9 violation (docs/INVARIANTS.md): these learn tools take a free-form project but do not "
-        f"call _reserved_project_error at entry: {sorted(missing)}. A reserved-key label could reach a store."
+        f"call _resolve_project at entry: {sorted(missing)}. A foreign label could bypass the TRACE_PROJECT "
+        "pin, or a reserved-key label could reach a store."
     )

--- a/tests/test_learn_pin_scope.py
+++ b/tests/test_learn_pin_scope.py
@@ -1,0 +1,285 @@
+"""Learn tools resolve their ``project`` argument against the TRACE_PROJECT pin.
+
+ADR-006 mandates that ``project`` on all ``trace_learn_*`` tools is optional:
+under a pin, ``None`` resolves to the pin and any supplied label must resolve
+to the pinned key or the call errors naming both keys; unpinned, an explicit
+label is required. Before this suite, the learn surface accepted any foreign
+label on a pinned server — a cross-project read/write bypass of the documented
+fail-closed guarantee.
+
+Tools are exercised through ``FastMCP.call_tool`` so the registered schema
+(optional ``project``) and the real dispatch path are what is tested.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from mcp.server.fastmcp import FastMCP
+
+import trace_mcp.project_identity as pident
+from trace_mcp.extensions.learn import register
+from trace_mcp.storage.json_file import JsonFileStorage
+
+
+@pytest.fixture()
+def learn_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Isolated knowledge/session/registry dirs, offline BM25 backend, no pin."""
+    monkeypatch.setenv("TRACE_KNOWLEDGE_DIR", str(tmp_path / "knowledge"))
+    monkeypatch.setenv("TRACE_SESSIONS_DIR", str(tmp_path / "sessions"))
+    monkeypatch.setenv("TRACE_REGISTRY_PATH", str(tmp_path / "projects.json"))
+    monkeypatch.setenv("TRACE_EMBEDDING_BACKEND", "none")
+    monkeypatch.setenv("TRACE_LLM_ENABLED", "false")
+    monkeypatch.setenv("TRACE_STRICT_LLM", "false")
+    for var in ("TRACE_PROJECT", "OPENAI_API_KEY", "TRACE_LOCAL_ONLY"):
+        monkeypatch.delenv(var, raising=False)
+    pident._reset_registry_cache()
+    mcp = FastMCP("learn-pin-test")
+    register(mcp, JsonFileStorage(directory=str(tmp_path / "sessions")))
+    yield mcp, tmp_path
+    pident._reset_registry_cache()
+
+
+async def _call(mcp: FastMCP, tool: str, args: dict[str, Any]) -> dict:
+    """Call a registered tool and decode its JSON text payload."""
+    out = await mcp.call_tool(tool, args)
+    if isinstance(out, tuple):  # newer mcp: (content, structured)
+        out = out[0]
+    text = out[0].text  # type: ignore[union-attr]
+    return json.loads(text)
+
+
+# Minimal valid extra arguments per tool (beyond `project`).
+TOOL_MIN_ARGS: dict[str, dict[str, Any]] = {
+    "trace_learn_add": {"content": "a learning"},
+    "trace_learn_recall": {"context": "anything"},
+    "trace_learn_list": {},
+    "trace_learn_forget": {"learning_id": "lrn_001"},
+    "trace_learn_extract": {},
+}
+
+
+# ── pinned: foreign label fails closed ──────────────────────────────────────
+
+
+@pytest.mark.parametrize("tool", sorted(TOOL_MIN_ARGS))
+async def test_pinned_foreign_label_rejected(learn_env, monkeypatch: pytest.MonkeyPatch, tool: str) -> None:
+    mcp, tmp_path = learn_env
+    monkeypatch.setenv("TRACE_PROJECT", "proj-a")
+    result = await _call(mcp, tool, {"project": "proj-b", **TOOL_MIN_ARGS[tool]})
+    assert "error" in result, f"{tool} accepted a foreign label on a pinned server: {result}"
+    # The error names both the pinned key and the supplied label (ADR-006).
+    blob = json.dumps(result)
+    assert "proj-a" in blob and "proj-b" in blob
+    # Fail closed: no foreign store was created or touched.
+    assert not (tmp_path / "knowledge" / "proj-b.json").exists()
+
+
+@pytest.mark.parametrize("tool", sorted(TOOL_MIN_ARGS))
+async def test_pinned_case_variant_label_is_not_foreign(learn_env, monkeypatch: pytest.MonkeyPatch, tool: str) -> None:
+    """A label that canonicalizes to the pinned key is the SAME project, not foreign."""
+    mcp, _ = learn_env
+    monkeypatch.setenv("TRACE_PROJECT", "proj-a")
+    result = await _call(mcp, tool, {"project": "Proj_A", **TOOL_MIN_ARGS[tool]})
+    assert "error" not in result or "pinned" not in json.dumps(result), (
+        f"{tool} treated a case/separator variant of the pin as foreign: {result}"
+    )
+
+
+# ── pinned: omitted project resolves to the pin ─────────────────────────────
+
+
+async def test_pinned_omitted_project_resolves_to_pin_on_add(learn_env, monkeypatch: pytest.MonkeyPatch) -> None:
+    mcp, tmp_path = learn_env
+    monkeypatch.setenv("TRACE_PROJECT", "proj-a")
+    result = await _call(mcp, "trace_learn_add", {"content": "pinned default works"})
+    assert "added" in result, f"expected success, got: {result}"
+    assert (tmp_path / "knowledge" / "proj-a.json").exists()
+
+
+async def test_pinned_omitted_project_resolves_to_pin_on_list(learn_env, monkeypatch: pytest.MonkeyPatch) -> None:
+    mcp, _ = learn_env
+    monkeypatch.setenv("TRACE_PROJECT", "proj-a")
+    await _call(mcp, "trace_learn_add", {"content": "seed"})
+    result = await _call(mcp, "trace_learn_list", {})
+    assert result.get("total") == 1, f"expected the pinned store's learning, got: {result}"
+
+
+async def test_pinned_matching_label_still_works(learn_env, monkeypatch: pytest.MonkeyPatch) -> None:
+    mcp, tmp_path = learn_env
+    monkeypatch.setenv("TRACE_PROJECT", "proj-a")
+    result = await _call(mcp, "trace_learn_add", {"project": "proj-a", "content": "explicit pin label"})
+    assert "added" in result
+    assert (tmp_path / "knowledge" / "proj-a.json").exists()
+
+
+# ── unpinned ─────────────────────────────────────────────────────────────────
+
+
+async def test_unpinned_omitted_project_errors(learn_env) -> None:
+    mcp, _ = learn_env
+    result = await _call(mcp, "trace_learn_add", {"content": "no project anywhere"})
+    assert "error" in result
+    assert "pinned" in result["error"] or "project" in result["error"]
+
+
+async def test_unpinned_explicit_label_still_works(learn_env) -> None:
+    mcp, tmp_path = learn_env
+    result = await _call(mcp, "trace_learn_add", {"project": "proj-x", "content": "unpinned explicit"})
+    assert "added" in result
+    assert (tmp_path / "knowledge" / "proj-x.json").exists()
+
+
+async def test_reserved_key_still_rejected(learn_env) -> None:
+    mcp, _ = learn_env
+    result = await _call(mcp, "trace_learn_add", {"project": "auto", "content": "nope"})
+    assert "error" in result and "reserved" in result["error"]
+
+
+# ── recall honesty ───────────────────────────────────────────────────────────
+
+
+async def test_recall_without_context_or_tags_errors(learn_env) -> None:
+    """No query → an explicit error pointing at trace_learn_list, never an
+    insertion-order listing dressed up as results."""
+    mcp, _ = learn_env
+    await _call(mcp, "trace_learn_add", {"project": "proj-x", "content": "seed learning"})
+    result = await _call(mcp, "trace_learn_recall", {"project": "proj-x"})
+    assert "error" in result, f"recall with no query must error, got: {result}"
+    assert "trace_learn_list" in json.dumps(result)
+    assert "results" not in result
+
+
+async def test_recall_reports_backend(learn_env) -> None:
+    mcp, _ = learn_env
+    await _call(mcp, "trace_learn_add", {"project": "proj-x", "content": "the ZANZIBAR-9931 form gate"})
+    result = await _call(mcp, "trace_learn_recall", {"project": "proj-x", "context": "ZANZIBAR-9931"})
+    assert result.get("backend") == "bm25", f"expected backend name in response, got: {result}"
+
+
+async def test_recall_bm25_surfaces_verbatim_token(learn_env) -> None:
+    mcp, _ = learn_env
+    await _seed_corpus(mcp, "proj-x")
+    result = await _call(mcp, "trace_learn_recall", {"project": "proj-x", "context": "ZANZIBAR-9931", "limit": 1})
+    assert result["total"] == 1
+    assert "ZANZIBAR-9931" in result["results"][0]["learning"]["content"]
+
+
+# ── query alias ──────────────────────────────────────────────────────────────
+
+
+SEED_CORPUS = (
+    "prefer pathlib over os.path in the pipeline",
+    "the nightly job needs the warehouse VPN",
+    "form ZANZIBAR-9931 must be filed before export",
+)
+# BM25 note: a single-document store scores ~0 for every query (IDF collapses
+# when the term appears in the only document), so alias tests seed a small
+# corpus — the behavior under test is query=/context= parity, not tiny-store
+# ranking quality.
+
+
+async def _seed_corpus(mcp: FastMCP, project: str) -> None:
+    for text in SEED_CORPUS:
+        await _call(mcp, "trace_learn_add", {"project": project, "content": text})
+
+
+async def test_recall_query_alias_behaves_like_context(learn_env) -> None:
+    mcp, _ = learn_env
+    await _seed_corpus(mcp, "proj-x")
+    result = await _call(mcp, "trace_learn_recall", {"project": "proj-x", "query": "ZANZIBAR-9931"})
+    assert result.get("total") == 1, f"query= must rank like context=, got: {result}"
+    assert "ZANZIBAR-9931" in result["results"][0]["learning"]["content"]
+
+
+async def test_recall_query_context_conflict_errors(learn_env) -> None:
+    mcp, _ = learn_env
+    await _call(mcp, "trace_learn_add", {"project": "proj-x", "content": "seed"})
+    result = await _call(
+        mcp,
+        "trace_learn_recall",
+        {"project": "proj-x", "query": "one thing", "context": "another thing"},
+    )
+    assert "error" in result, f"conflicting query/context must error, got: {result}"
+
+
+async def test_recall_query_and_identical_context_allowed(learn_env) -> None:
+    mcp, _ = learn_env
+    await _seed_corpus(mcp, "proj-x")
+    result = await _call(
+        mcp,
+        "trace_learn_recall",
+        {"project": "proj-x", "query": "ZANZIBAR-9931", "context": "ZANZIBAR-9931"},
+    )
+    assert result.get("total") == 1
+
+
+# ── input normalization ──────────────────────────────────────────────────────
+
+
+async def test_recall_whitespace_only_context_errors(learn_env) -> None:
+    mcp, _ = learn_env
+    await _seed_corpus(mcp, "proj-x")
+    result = await _call(mcp, "trace_learn_recall", {"project": "proj-x", "context": "   \t"})
+    assert "error" in result, f"whitespace-only context must not rank, got: {result}"
+
+
+async def test_recall_blank_tags_are_no_criteria(learn_env) -> None:
+    mcp, _ = learn_env
+    await _seed_corpus(mcp, "proj-x")
+    result = await _call(mcp, "trace_learn_recall", {"project": "proj-x", "tags": ["", "   "]})
+    assert "error" in result, f"blank tag elements must not count as criteria, got: {result}"
+
+
+async def test_recall_empty_context_with_query_is_not_a_conflict(learn_env) -> None:
+    mcp, _ = learn_env
+    await _seed_corpus(mcp, "proj-x")
+    result = await _call(
+        mcp,
+        "trace_learn_recall",
+        {"project": "proj-x", "context": "", "query": "ZANZIBAR-9931"},
+    )
+    assert result.get("total") == 1, f"empty-string context is an absent alias, not a conflict: {result}"
+
+
+# ── registry-alias interactions ──────────────────────────────────────────────
+
+
+async def test_pinned_accepted_alias_uses_the_pinned_store(learn_env, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A registry alias whose canonical form differs from the pinned key must
+    still land in the PINNED project's store file — otherwise the accepted
+    alias silently opens a different store than the one it was authorized
+    against (store filenames key on canonical_project_key, which is
+    registry-independent)."""
+    mcp, tmp_path = learn_env
+    with pident.locked_registry() as reg:
+        reg.projects["payments-api"] = pident.ProjectEntry(
+            key="payments-api", display_label="Payments API", aliases=["Old Payments"]
+        )
+    pident._reset_registry_cache()
+    monkeypatch.setenv("TRACE_PROJECT", "payments-api")
+
+    result = await _call(mcp, "trace_learn_add", {"project": "Old Payments", "content": "alias-added learning"})
+    assert "added" in result, f"registry alias of the pin must be accepted: {result}"
+    assert (tmp_path / "knowledge" / "payments-api.json").exists()
+    assert not (tmp_path / "knowledge" / "old-payments.json").exists()
+
+    listing = await _call(mcp, "trace_learn_list", {})
+    assert listing.get("total") == 1, f"the pinned store must see the alias-added learning: {listing}"
+
+
+async def test_unpinned_alias_to_reserved_key_rejected(learn_env) -> None:
+    """A registry alias must not smuggle a benign-looking label into a
+    reserved quarantine store."""
+    mcp, tmp_path = learn_env
+    with pident.locked_registry() as reg:
+        reg.projects["auto"] = pident.ProjectEntry(key="auto", display_label="auto", aliases=["Automatic"])
+    pident._reset_registry_cache()
+
+    result = await _call(mcp, "trace_learn_add", {"project": "Automatic", "content": "nope"})
+    assert "error" in result and "reserved" in result["error"], f"alias to reserved key must be rejected: {result}"
+    assert not (tmp_path / "knowledge" / "automatic.json").exists()
+    assert not (tmp_path / "knowledge" / "auto.json").exists()


### PR DESCRIPTION
## Summary
- All five `trace_learn_*` tools resolve `project` through a shared scope rule (`project_identity.resolve_scoped_project`, also used by `trace_start_session`): pinned + omitted → the pin; pinned + foreign label → error naming both keys; unpinned + omitted → error; reserved keys rejected, including through a registry alias. `project` becomes optional on all five tools.
- The label a learn tool operates on is store-safe: a pinned call accepted through a registry alias whose canonical form differs from the pinned key is keyed to the pinned project's store, never to a divergent alias-derived filename.
- `trace_learn_recall` no longer returns unranked insertion-order listings when called with no query (explicit error pointing at `trace_learn_list`); whitespace-only text and blank tags are treated as absent; every ranked response names the ranking engine in a `backend` field; `query` is accepted as an alias for `context` with explicit conflict semantics.

## Why
A pinned server accepted any foreign label on the learn surface — one project's session could read or write another project's knowledge store, bypassing the documented cross-project fail-closed guarantee (ADR-006 mandated the missing behavior; the session half shipped in v0.5.0, the learn half never did). Separately, MCP argument models silently drop unknown fields, so a client sending `query=` instead of `context=` had its query ignored and received the store's first N learnings in insertion order presented as results — a silent no-search indistinguishable from a ranked match.

## Verification
- 27 tests in `tests/test_learn_pin_scope.py` exercise the registered schema and the real dispatch path via `FastMCP.call_tool`, including registry-alias store safety, the input-normalization matrix, and per-tool foreign-label rejection.
- INV-9 restated in `docs/INVARIANTS.md`; its structural guard now requires the shared resolver at every learn-tool entry.
- All 24 pinned consumer configurations on the deployment machine were swept: every declared label canonicalizes to its pin, so no working caller regresses.
- Full suite 1256 passed; ruff format/check clean; pyright clean on changed files.

## Risks / limitations
- Protocol-visible change: a caller relying on the no-query listing must switch to `trace_learn_list` (noted in CHANGELOG).
- `backend` names the engine selected for the ranking; per-item fallback attribution (mixed stores) is deliberately deferred.
- Deployed consumers pick the tool changes up on their next server start; their hook/settings fixes ship separately.