### PR TITLE
fix(adapter): derive the decision-audit hook matcher from the MCP server key

### DIFF
--- a/src/trace_mcp/adapters/base.py
+++ b/src/trace_mcp/adapters/base.py
@@ -9,6 +9,13 @@ from typing import Literal
 
 Disposition = Literal["installed", "updated", "skipped"]
 
+MCP_SERVER_KEY = "trace"
+"""The ``mcpServers`` key ``trace-mcp-init`` writes into a consumer's
+``.mcp.json``. Hosts namespace MCP tool names as ``mcp__<server-key>__<tool>``,
+so anything that must name a tool exactly — like a Claude Code hook matcher —
+derives from THIS constant. Init and the adapters must share it: if they
+drift, hook matchers silently stop firing."""
+
 
 @dataclass(frozen=True)
 class InstallResult:

--- a/src/trace_mcp/adapters/claude_code/__init__.py
+++ b/src/trace_mcp/adapters/claude_code/__init__.py
@@ -11,7 +11,7 @@ import json
 import shutil
 from pathlib import Path
 
-from trace_mcp.adapters.base import Adapter, Disposition, InstallResult
+from trace_mcp.adapters.base import MCP_SERVER_KEY, Adapter, Disposition, InstallResult
 
 _ASSETS = Path(__file__).parent / "assets"
 _HOOKS_SRC = _ASSETS / "hooks"
@@ -87,10 +87,69 @@ def _install_hooks(directory: Path, *, dry_run: bool) -> list[InstallResult]:
     return results
 
 
+def _hook_commands(entry: object) -> list[str] | None:
+    """The command strings a hook registration runs, or None for malformed shapes.
+
+    Settings files are user-edited JSON: a non-dict entry or a non-list/non-dict
+    ``hooks`` value must be skipped (left in place), never dereferenced.
+    """
+    if not isinstance(entry, dict) or not isinstance(entry.get("hooks"), list):
+        return None
+    if not all(isinstance(h, dict) for h in entry["hooks"]):
+        return None
+    return [h.get("command", "") for h in entry["hooks"]]
+
+
+def _is_superseded_trace_entry(entry: object, desired: dict) -> bool:
+    """True for a registration the INSTALLER itself wrote in a legacy form.
+
+    Same commands as the desired template entry AND exactly the matcher form
+    the installer is known to have shipped (the dead bare ``trace_end_session``
+    — the only form historical templates ever wrote). Entries running other
+    commands, or carrying any other matcher — including a namespaced one a
+    user authored for a renamed server key — are the user's: never touched.
+    """
+    cmds = _hook_commands(entry)
+    if cmds is None or cmds != _hook_commands(desired):
+        return False
+    assert isinstance(entry, dict)  # narrowed by _hook_commands
+    matcher = entry.get("matcher", "")
+    if matcher == desired.get("matcher"):
+        return False
+    return matcher == "trace_end_session"
+
+
+def _same_registration(entry: object, desired: dict) -> bool:
+    """Same commands and same matcher — the desired registration is present,
+    possibly with user-tuned fields (e.g. a raised timeout), which are respected."""
+    cmds = _hook_commands(entry)
+    if cmds is None or cmds != _hook_commands(desired):
+        return False
+    assert isinstance(entry, dict)
+    return entry.get("matcher") == desired.get("matcher")
+
+
+def _derive_tool_matchers(template_hooks: dict[str, list[dict]]) -> None:
+    """Rewrite matchers that name a TRACE tool to the full namespaced form.
+
+    Claude Code matchers match the FULL tool name exactly (a simple string is
+    not a substring pattern), and hosts namespace MCP tools as
+    ``mcp__<server-key>__<tool>`` — so the matcher must be derived from the
+    same ``.mcp.json`` server key init writes. A bare tool-name matcher never
+    fires: the decision-audit hook shipped dead this way.
+    """
+    for entries in template_hooks.values():
+        for entry in entries:
+            matcher = entry.get("matcher", "")
+            if matcher == "trace_end_session" or matcher.endswith("__trace_end_session"):
+                entry["matcher"] = f"mcp__{MCP_SERVER_KEY}__trace_end_session"
+
+
 def _merge_settings(directory: Path, *, dry_run: bool) -> InstallResult:
     dst = directory / ".claude" / "settings.json"
     template = json.loads(_SETTINGS_SRC.read_text())
     template_hooks: dict[str, list[dict]] = template.get("hooks", {})
+    _derive_tool_matchers(template_hooks)
 
     existing: dict = {}
     if dst.is_file():
@@ -103,10 +162,19 @@ def _merge_settings(directory: Path, *, dry_run: bool) -> InstallResult:
     changed = False
     for event, entries in template_hooks.items():
         event_hooks = hooks_section.setdefault(event, [])
+        if not isinstance(event_hooks, list):
+            continue  # malformed user shape — leave it untouched
         for entry in entries:
-            if entry not in event_hooks:
-                event_hooks.append(entry)
+            # Cleanup BEFORE the presence check, so a stale installer-written
+            # registration (the dead short-form decision-audit matcher) is
+            # removed even when the desired entry already exists beside it.
+            for stale in [e for e in event_hooks if _is_superseded_trace_entry(e, entry)]:
+                event_hooks.remove(stale)
                 changed = True
+            if any(_same_registration(e, entry) for e in event_hooks):
+                continue
+            event_hooks.append(entry)
+            changed = True
 
     if not changed:
         return InstallResult(path=dst, disposition="skipped")

--- a/src/trace_mcp/adapters/claude_code/assets/settings_template.json
+++ b/src/trace_mcp/adapters/claude_code/assets/settings_template.json
@@ -38,7 +38,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "trace_end_session",
+        "matcher": "mcp__trace__trace_end_session",
         "hooks": [
           {
             "type": "command",

--- a/src/trace_mcp/init_project.py
+++ b/src/trace_mcp/init_project.py
@@ -25,7 +25,7 @@ from pathlib import Path
 
 from trace_mcp import project_identity as pident
 from trace_mcp.adapters import detect_adapter, get_adapter, list_adapters
-from trace_mcp.adapters.base import Adapter
+from trace_mcp.adapters.base import MCP_SERVER_KEY, Adapter
 
 # Bold-tolerant, and byte-identical in intent to the hooks' shared block: the
 # absence check MUST accept the bolded form, or init appends a second pin line
@@ -119,7 +119,9 @@ def _mcp_server_config(project_key: str | None = None) -> dict:
     }
     if project_key:
         entry["env"] = {"TRACE_PROJECT": project_key}
-    return {"trace": entry}
+    # The server key is shared with the adapters (hook matchers derive
+    # mcp__<key>__<tool> from it) — see adapters.base.MCP_SERVER_KEY.
+    return {MCP_SERVER_KEY: entry}
 
 
 # ── Project identity ──────────────────────────────────────────────────────
@@ -371,9 +373,11 @@ def _write_mcp_json(project_dir: Path, project_key: str | None = None) -> str:
         config = {"mcpServers": {}}
         servers = config["mcpServers"]
 
-    was_present = "trace" in servers
-    fresh_entry = _mcp_server_config(project_key)["trace"]
-    servers["trace"] = _merge_trace_entry(servers.get("trace"), fresh_entry) if was_present else fresh_entry
+    was_present = MCP_SERVER_KEY in servers
+    fresh_entry = _mcp_server_config(project_key)[MCP_SERVER_KEY]
+    servers[MCP_SERVER_KEY] = (
+        _merge_trace_entry(servers.get(MCP_SERVER_KEY), fresh_entry) if was_present else fresh_entry
+    )
 
     mcp_path.write_text(json.dumps(config, indent=2) + "\n")
     return f"  {'updated' if was_present else 'wrote'}: {mcp_path}"
@@ -457,7 +461,7 @@ def init_project(
         if not dry_run:
             print(_write_mcp_json(project_dir, project_key))
         else:
-            entry = _mcp_server_config(project_key)["trace"]
+            entry = _mcp_server_config(project_key)[MCP_SERVER_KEY]
             print(f"  [dry-run] would write: {project_dir / '.mcp.json'} (uvx --from {entry['args'][1]})")
     except (TraceSourceUnresolvedError, TraceInitError) as exc:
         print(f"Error: {exc}")

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -13,6 +13,7 @@ from pathlib import Path
 import pytest
 
 from trace_mcp.adapters import detect_adapter, get_adapter, list_adapters
+from trace_mcp.adapters.base import MCP_SERVER_KEY
 from trace_mcp.adapters.claude_code import MARKER_END, MARKER_START, ClaudeCodeAdapter
 from trace_mcp.adapters.codex import CodexAdapter
 
@@ -146,7 +147,7 @@ class TestClaudeCodeInstall:
         assert len(post) == 2
         matchers = [entry["matcher"] for entry in post]
         assert "Edit|Write" in matchers
-        assert "trace_end_session" in matchers
+        assert f"mcp__{MCP_SERVER_KEY}__trace_end_session" in matchers
 
         # SessionStart added
         assert "SessionStart" in merged["hooks"]
@@ -327,3 +328,193 @@ class TestResolveTraceSource:
 
         # Three levels up from src/trace_mcp/init_project.py is the repo root
         assert ip._resolve_trace_source() == str(repo)
+
+
+# ── Decision-audit matcher (PostToolUse) ──────────────────────────────────
+
+
+class TestDecisionAuditMatcher:
+    """Claude Code hook matchers match the FULL tool name exactly (simple
+    strings are not substrings), and MCP tools are namespaced
+    ``mcp__<server-key>__<tool>``. A bare ``trace_end_session`` matcher
+    therefore never fires — the decision-audit hook was dead in every
+    project installed from the old template. The matcher must be derived
+    from the ``.mcp.json`` server key the installer itself writes."""
+
+    def _installed_settings(self, tmp_path: Path) -> dict:
+        a = ClaudeCodeAdapter()
+        (tmp_path / "CLAUDE.md").write_text("# Example\n")
+        a.install(tmp_path)
+        return json.loads((tmp_path / ".claude" / "settings.json").read_text())
+
+    def test_matcher_is_full_namespaced_tool_name(self, tmp_path: Path) -> None:
+        settings = self._installed_settings(tmp_path)
+        matchers = [e.get("matcher") for e in settings["hooks"]["PostToolUse"]]
+        assert f"mcp__{MCP_SERVER_KEY}__trace_end_session" in matchers
+        assert "trace_end_session" not in matchers
+
+    def test_reinstall_migrates_stale_short_matcher(self, tmp_path: Path) -> None:
+        """A consumer initialized from the old template carries the dead
+        short-matcher entry; re-running install must replace it, not stack a
+        second registration beside it."""
+        a = ClaudeCodeAdapter()
+        (tmp_path / "CLAUDE.md").write_text("# Example\n")
+        (tmp_path / ".claude").mkdir()
+        stale = {
+            "hooks": {
+                "PostToolUse": [
+                    {
+                        "matcher": "trace_end_session",
+                        "hooks": [
+                            {
+                                "type": "command",
+                                "command": '"$CLAUDE_PROJECT_DIR/.claude/hooks/decision-audit.sh"',
+                                "timeout": 10,
+                            }
+                        ],
+                    }
+                ]
+            }
+        }
+        settings_path = tmp_path / ".claude" / "settings.json"
+        settings_path.write_text(json.dumps(stale, indent=2))
+
+        a.install(tmp_path)
+        merged = json.loads(settings_path.read_text())
+        audit_entries = [
+            e
+            for e in merged["hooks"]["PostToolUse"]
+            if any("decision-audit" in h.get("command", "") for h in e.get("hooks", []))
+        ]
+        assert len(audit_entries) == 1, f"stale matcher entry not migrated: {audit_entries}"
+        assert audit_entries[0]["matcher"] == f"mcp__{MCP_SERVER_KEY}__trace_end_session"
+
+    def test_reinstall_preserves_unrelated_posttooluse_entries(self, tmp_path: Path) -> None:
+        a = ClaudeCodeAdapter()
+        (tmp_path / "CLAUDE.md").write_text("# Example\n")
+        (tmp_path / ".claude").mkdir()
+        settings_path = tmp_path / ".claude" / "settings.json"
+        settings_path.write_text(
+            json.dumps(
+                {
+                    "hooks": {
+                        "PostToolUse": [
+                            {"matcher": "Edit|Write", "hooks": [{"type": "command", "command": "my-linter.sh"}]}
+                        ]
+                    }
+                }
+            )
+        )
+        a.install(tmp_path)
+        merged = json.loads(settings_path.read_text())
+        commands = [h["command"] for e in merged["hooks"]["PostToolUse"] for h in e["hooks"]]
+        assert "my-linter.sh" in commands
+
+    def test_init_and_adapter_share_one_server_key(self) -> None:
+        """The matcher is only correct if the adapter derives it from the SAME
+        key init writes into .mcp.json — a drift here silently kills the hook."""
+        from trace_mcp import init_project as ip
+
+        entry = ip._mcp_server_config(None)
+        assert set(entry) == {MCP_SERVER_KEY}
+
+    def test_user_tuned_current_entry_is_respected(self, tmp_path: Path) -> None:
+        """A user who raised the timeout on the CURRENT registration keeps their
+        tuning — reinstall neither resets nor duplicates it."""
+        a = ClaudeCodeAdapter()
+        (tmp_path / "CLAUDE.md").write_text("# Example\n")
+        (tmp_path / ".claude").mkdir()
+        tuned = {
+            "matcher": f"mcp__{MCP_SERVER_KEY}__trace_end_session",
+            "hooks": [
+                {
+                    "type": "command",
+                    "command": '"$CLAUDE_PROJECT_DIR/.claude/hooks/decision-audit.sh"',
+                    "timeout": 60,
+                }
+            ],
+        }
+        settings_path = tmp_path / ".claude" / "settings.json"
+        settings_path.write_text(json.dumps({"hooks": {"PostToolUse": [tuned]}}))
+
+        a.install(tmp_path)
+        merged = json.loads(settings_path.read_text())
+        audit_entries = [
+            e
+            for e in merged["hooks"]["PostToolUse"]
+            if any("decision-audit" in h.get("command", "") for h in e.get("hooks", []))
+        ]
+        assert len(audit_entries) == 1, f"user-tuned entry duplicated or removed: {audit_entries}"
+        assert audit_entries[0]["hooks"][0]["timeout"] == 60
+
+    def test_stale_entry_removed_even_when_desired_already_present(self, tmp_path: Path) -> None:
+        a = ClaudeCodeAdapter()
+        (tmp_path / "CLAUDE.md").write_text("# Example\n")
+        (tmp_path / ".claude").mkdir()
+        cmd = '"$CLAUDE_PROJECT_DIR/.claude/hooks/decision-audit.sh"'
+        stale = {"matcher": "trace_end_session", "hooks": [{"type": "command", "command": cmd, "timeout": 10}]}
+        fixed = {
+            "matcher": f"mcp__{MCP_SERVER_KEY}__trace_end_session",
+            "hooks": [{"type": "command", "command": cmd, "timeout": 10}],
+        }
+        settings_path = tmp_path / ".claude" / "settings.json"
+        settings_path.write_text(json.dumps({"hooks": {"PostToolUse": [stale, fixed]}}))
+
+        a.install(tmp_path)
+        merged = json.loads(settings_path.read_text())
+        audit_entries = [
+            e
+            for e in merged["hooks"]["PostToolUse"]
+            if any("decision-audit" in h.get("command", "") for h in e.get("hooks", []))
+        ]
+        assert len(audit_entries) == 1, f"stale entry survived beside the fixed one: {audit_entries}"
+
+    def test_user_authored_namespaced_registration_preserved(self, tmp_path: Path) -> None:
+        """A user who wired the installer's script under their OWN server key's
+        namespace (e.g. a renamed server entry) keeps that registration — only
+        the exact matcher form historical templates shipped is migrated."""
+        a = ClaudeCodeAdapter()
+        (tmp_path / "CLAUDE.md").write_text("# Example\n")
+        (tmp_path / ".claude").mkdir()
+        user_entry = {
+            "matcher": "mcp__trace-prod__trace_end_session",
+            "hooks": [
+                {
+                    "type": "command",
+                    "command": '"$CLAUDE_PROJECT_DIR/.claude/hooks/decision-audit.sh"',
+                    "timeout": 10,
+                }
+            ],
+        }
+        settings_path = tmp_path / ".claude" / "settings.json"
+        settings_path.write_text(json.dumps({"hooks": {"PostToolUse": [user_entry]}}))
+
+        a.install(tmp_path)
+        merged = json.loads(settings_path.read_text())
+        matchers = [e.get("matcher") for e in merged["hooks"]["PostToolUse"] if isinstance(e, dict)]
+        assert "mcp__trace-prod__trace_end_session" in matchers, "user-authored registration was deleted"
+        assert f"mcp__{MCP_SERVER_KEY}__trace_end_session" in matchers
+
+    def test_malformed_settings_entries_do_not_crash_install(self, tmp_path: Path) -> None:
+        """Settings files are user-edited JSON: non-dict entries and malformed
+        hooks values must be skipped in place, never dereferenced."""
+        a = ClaudeCodeAdapter()
+        (tmp_path / "CLAUDE.md").write_text("# Example\n")
+        (tmp_path / ".claude").mkdir()
+        settings_path = tmp_path / ".claude" / "settings.json"
+        settings_path.write_text(
+            json.dumps(
+                {
+                    "hooks": {
+                        "PostToolUse": ["not-a-dict", 7, {"matcher": "X", "hooks": "nope"}],
+                        "SessionStart": "also-not-a-list",
+                    }
+                }
+            )
+        )
+        a.install(tmp_path)  # must not raise
+        merged = json.loads(settings_path.read_text())
+        assert "not-a-dict" in merged["hooks"]["PostToolUse"]  # left in place
+        matchers = [e.get("matcher") for e in merged["hooks"]["PostToolUse"] if isinstance(e, dict)]
+        assert f"mcp__{MCP_SERVER_KEY}__trace_end_session" in matchers
+        assert merged["hooks"]["SessionStart"] == "also-not-a-list"  # malformed event untouched


### PR DESCRIPTION
## Summary
- The settings template's decision-audit PostToolUse matcher becomes the full namespaced tool name, derived at install time from a single shared constant (`adapters.base.MCP_SERVER_KEY`) that `trace-mcp-init` now also uses for the `.mcp.json` server entry.
- Re-running install migrates the dead legacy registration in place — removed only when it runs the installer's own hook commands AND carries exactly the matcher form historical templates shipped, and removed even when the corrected entry already exists beside it. User-tuned current entries are respected; user-authored registrations (other commands, other matchers, including namespaced forms for a renamed server key) are never touched. Malformed settings shapes are skipped in place, never dereferenced.

## Why
Claude Code hook matchers match the full tool name exactly, and hosts namespace MCP tools as `mcp__<server-key>__<tool>`. The template registered the bare matcher `trace_end_session`, which matches no real tool name — the decision-audit hook (unresolved decisions, AI self-resolutions, orphaned corrections at session end) has never fired in any project installed from the template. Hook-event history confirms the only projects with real emissions are the two whose matcher was hand-corrected to the full form.

## Verification
- Adapter suite covers the derived matcher, stale-entry migration (including beside an existing corrected entry), user-tuned entry preservation, user-authored namespaced-registration preservation, malformed-shape tolerance, unrelated-entry preservation, and init/adapter key coherence.
- Full suite green; ruff and pyright clean.

## Risks / limitations
- Existing consumers pick this up when `trace-mcp-init` runs again against their project — a server rebuild alone does not rewrite `.claude/settings.json`. The fleet re-init is a separate, deliberate operator step.
- The matcher derives from the key init writes (`trace`); reading a consumer's actual `.mcp.json` key at install time is a possible future refinement.