### PR TITLE
feat(conformance): add `trace-mcp doctor` for deployed-state checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`trace-mcp doctor [DIR] [--live] [--json]` — deployed-state conformance
+  (INV-11).** The unit suite proves the source tree is correct; it cannot prove
+  a *deployment* is. The doctor checks one project directory against this
+  build's own shipped artifacts: the `.mcp.json` launch entry (uvx command, a
+  resolvable `--from` source that is not the unrelated PyPI distribution, the
+  three trace-learn `--with` extras, a refresh flag), the host hook deployment
+  (all shipped scripts present, executable, carrying this build's
+  `[trace-hooks vX.Y]` stamp, registered in `settings.json`, and — the defect
+  that left the decision-audit hook dead in most deployed projects — attached
+  to the namespaced `mcp__<server-key>__trace_end_session` matcher), and the
+  three project-pin sites, which must all canonicalize to one key. `--live`
+  additionally spawns the project's own configured command and verifies the
+  build it actually serves (version and the 22-tool surface), which is the only
+  way to catch a warm package cache serving a stale wheel despite
+  `--refresh-package`; the finding carries the remedy. Exits non-zero on any
+  failing check, mirroring `trace-mcp identity check`; `--json` emits a
+  `DoctorReport` with stable check ids (`0` clean, `1` findings, `2` usage error; diagnostics on stderr).
+  A hook is checked under **its own host event** — one registered under the
+  wrong event is installed, current, executable, and still never fires — and
+  TRACE-stamped scripts this build no longer ships are reported as leftovers.
+- **INV-11 — a freshly initialized project is conformance-clean.** A new
+  registry row binds the installer's output to the checker's expectations, so
+  template rot (a hook matcher that never fires, a stale asset, a launch config
+  missing the extras that make a 22-tool server) fails at PR time instead of
+  months later on a consumer's machine. The guard is parametrized over the
+  adapter registry: a new host adapter is checked the moment it ships.
+
 ### Fixed
 
 - **Learn tools now enforce the `TRACE_PROJECT` pin (INV-9, ADR-006).** All

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,7 @@ uv run pyright src/                 # Type check
 python scripts/generate_schema.py   # Regenerate JSON Schema from Pydantic models
 uv build && uv run pytest tests/test_packaging_artifacts.py   # Verify the shipped wheel/sdist before tagging
 trace-mcp identity check            # Report project-identity drift (non-zero exit on findings)
+trace-mcp doctor [DIR] [--live]     # Report deployed-state drift for one project (non-zero exit on findings)
 ```
 
 Two console scripts ship with the package: `trace-mcp` (the MCP server) and
@@ -54,6 +55,7 @@ src/trace_mcp/
     project_identity.py    # Canonical project keys + alias registry (~/.trace/projects.json)
     identity_cli.py        # `trace-mcp identity` migration subcommands
     identity_report.py     # Read-only drift/stray-store reporting for the CLI
+    conformance/           # `trace-mcp doctor` — deployed-state checks (INV-11)
     init_project.py        # `trace-mcp-init`: .mcp.json, TRACE_PROJECT pin, adapter dispatch
     scratchpad.py           # Session-end scratchpad generator
     extension_hooks.py     # Hook registry for extension ↔ core integration
@@ -71,11 +73,11 @@ provides a `register(mcp, storage)` function.
 
 Correctness invariants are registered in [`docs/INVARIANTS.md`](docs/INVARIANTS.md)
 — one entry per invariant with its exhaustive site-set and enforcing test.
-Ten are registered and enforced (INV-1 … INV-10), covering session writes,
+Eleven are registered and enforced (INV-1 … INV-11), covering session writes,
 completed-session immutability, decision validation, canonical-key project
 scoping, cloud-egress attestation, project/session coherence, registry writes,
-the knowledge-store lock, learn-tool label guarding, and version-declaration
-consistency.
+the knowledge-store lock, learn-tool label guarding, version-declaration
+consistency, and conformance of a freshly initialized project.
 `tests/test_invariants.py` runs as a dedicated CI step and **fails when a new
 site appears that is not registered** — a new `storage.update_session` caller
 outside `locked_disk_session`, a new OpenAI call site that does not

--- a/README.md
+++ b/README.md
@@ -155,12 +155,12 @@ The Claude Code adapter installs four hooks:
 
 | Hook | Event | Purpose |
 |------|-------|---------|
-| `session-reminder.sh` | `SessionStart` | Reminds you to start a TRACE session if one isn't active for the current project. Project detection: `CLAUDE.md` → git repo basename → cwd basename. |
+| `session-reminder.sh` | `SessionStart` | Reminds you to start a TRACE session if one isn't active for the current project. Project detection: `.claude/trace.project` → `CLAUDE.md` → git repo basename → cwd basename. |
 | `prompt-reminder.sh` | `UserPromptSubmit` | Periodic nudge after several prompts without a session. Per-project rate-limited. |
 | `pretool-guard.sh` | `PreToolUse` (`Edit\|Write`) | Warns (or blocks) edits when no TRACE session is active. |
-| `decision-audit.sh` | `PostToolUse` (`trace_end_session`) | Echoes the session-end attribution audit into the conversation. |
+| `decision-audit.sh` | `PostToolUse` (`mcp__trace__trace_end_session`) | Echoes the session-end attribution audit into the conversation. The matcher is the FULL namespaced tool name — a host matches tool names exactly, so a bare `trace_end_session` never fires. |
 
-Project detection uses, in order: a `TRACE project name: "..."` line in `CLAUDE.md`, the git repository basename, then the current working directory basename. Add the explicit marker if your repo name differs from the project name you want logged.
+Project detection uses, in order: the `.claude/trace.project` pin file written by `trace-mcp-init`, a `TRACE project name: "..."` line in `CLAUDE.md` (bold form accepted), the git repository basename, then the current working directory basename. Add the explicit marker if your repo name differs from the project name you want logged.
 
 **Codex** support is scaffolded as a placeholder; see [`src/trace_mcp/adapters/codex/README.md`](https://github.com/Thru-Echoes/TRACE/blob/main/src/trace_mcp/adapters/codex/README.md) for the hook primitives a Codex adapter would need.
 
@@ -175,6 +175,32 @@ Worked examples for logging decisions, corrections, contributions, and decision 
 | `TRACE_PROMPT_COOLDOWN_SEC` | `300` | Wall-clock cooldown between nudges from `prompt-reminder.sh`. |
 | `TRACE_RUNTIME_DIR` | `~/.trace/runtime` | Per-project nudge state (`<project>.state.json`). Safe to delete to reset. |
 | `TRACE_SOURCE_PATH` | _unset_ | Override what `trace-mcp-init` writes into `.mcp.json` as `uvx --from <X>`. Set to a local TRACE clone path. **Required when running init from an installed wheel** — with no override, init fails closed rather than writing the PyPI name `trace-mcp`, which belongs to an unrelated package (dependency confusion). |
+
+### Verify the deployment
+
+A green test suite proves the *source tree* is correct. It cannot prove that a *deployed* project is: hook copies drift a release behind, a matcher stops firing, a pin goes missing, a package cache serves a stale build. `trace-mcp doctor` checks one project directory against the artifacts the installed build actually ships.
+
+```bash
+trace-mcp doctor                 # check the current directory
+trace-mcp doctor /path/to/proj   # check another project
+trace-mcp doctor --live          # also start the configured server and verify what it serves
+trace-mcp doctor --json          # machine-readable report (stable check ids)
+```
+
+Exit codes: `0` clean, `1` findings, `2` usage error — a bad path is not an unhealthy project, and diagnostics go to stderr so `--json` stdout is always a report or empty. What it checks:
+
+| Group | Checks |
+|---|---|
+| `config.*` | `.mcp.json` parses and declares a `trace` server; launched with `uvx`; the `--from` source is something uvx can build (and is not the unrelated PyPI distribution name); the args actually name `trace-mcp` as the command to run; the three trace-learn `--with` extras are present; `--refresh-package trace-mcp` is set. |
+| `hooks.*` | Every shipped hook script is installed, executable, and carries this build's `[trace-hooks vX.Y]` stamp; no TRACE-stamped leftovers from an older release remain; `settings.json` parses; every hook is registered **under its own host event**; the decision-audit hook uses the namespaced matcher that actually fires. |
+| `pin.*` | The pin file, the `.mcp.json` `TRACE_PROJECT` env pin, and the CLAUDE.md pin line all exist and canonicalize to one project key. |
+| `live.*` | With `--live` only: the project's own configured command starts, completes an MCP handshake, reports this build's version, and serves all 22 tools. |
+
+`--live` is opt-in because it **runs the command the project's `.mcp.json` declares** — an action, not an inspection. It is the only check that catches a project whose config, hooks, and pins are all correct while the running server is a stale build; a warm `uv` cache can serve an old wheel for minutes even with `--refresh-package`, and the finding names the remedy (`uv cache clean trace-mcp`, then restart the server).
+
+A finding is `pass`, `fail`, or `skip` — where `skip` means *not evaluated* and always names the upstream check that made evaluation impossible. Exactly one check fails per root cause.
+
+The hook checks describe the Claude Code deployment, which is the only host adapter that installs today. A project set up with `--client none` has no hooks by construction and reports the `hooks.*` checks as failures — deliberately: an MCP server without host-side enforcement is a real gap in the audit trail, not a supported configuration to be waved through.
 
 ### Run a first session
 
@@ -317,6 +343,7 @@ src/trace_mcp/
     project_identity.py    # Canonical project keys + alias registry
     identity_cli.py        # `trace-mcp identity` migration subcommands
     identity_report.py     # Read-only drift and stray-store reporting
+    conformance/           # `trace-mcp doctor`: deployed-state checks (INV-11)
     init_project.py        # `trace-mcp-init`: .mcp.json, pin, adapter dispatch
     validate.py            # `trace-mcp validate` schema conformance CLI
     scratchpad.py          # Session-end scratchpad generator

--- a/docs/INVARIANTS.md
+++ b/docs/INVARIANTS.md
@@ -281,6 +281,55 @@ wire bump that forgets to rename or regenerate the schema fails.
 
 ---
 
+## INV-11 — A freshly initialized project is conformance-clean  · ENFORCED
+
+**Statement.** For every host adapter TRACE actually installs, running
+`trace-mcp-init` on an empty directory must produce a deployment that
+`trace_mcp.conformance.run_doctor` reports as `ok` — no failing check — using
+only this build's own shipped artifacts as the reference. Equivalently: the
+installer's OUTPUT and the checker's EXPECTATIONS are never allowed to
+disagree.
+
+**Why this is an integrity invariant, not a convenience.** The defects this
+closes were all *deployment* defects invisible to the unit suite: a
+`settings_template.json` that shipped a PostToolUse matcher naming the bare
+tool name `trace_end_session` (which a host never matches, because MCP tools
+are namespaced `mcp__<server-key>__<tool>`), so the decision-audit hook was
+dead in 15 of 17 deployed projects for several releases; hook copies frozen at
+an older release across the whole fleet; launch configs missing the
+`--with` extras, which yields a silent 17-tool server instead of the
+documented 22. Each one was found by hand, months late. Binding installer to
+checker means the next one fails at PR time.
+
+**Exhaustive site-set (what the invariant binds together):**
+- Installer output — `src/trace_mcp/init_project.py` (`.mcp.json` entry:
+  command, `--from` source, `LEARN_EXTRAS`, refresh flag, `TRACE_PROJECT` pin;
+  plus the pin file and the CLAUDE.md pin line) and
+  `src/trace_mcp/adapters/claude_code/` with its `assets/` (hook scripts,
+  `settings_template.json`, `CLAUDE_BLOCK.md`).
+- Checker expectations — `src/trace_mcp/conformance/expectations.py` and the
+  probes in `src/trace_mcp/conformance/probes.py`.
+
+**Enforcement.** The expectations are *derived from the shipped artifacts*
+rather than restated: required hook filenames and the `[trace-hooks vX.Y]`
+stamp are read from `adapters.claude_code.HOOK_ASSETS_DIR`, the decision-audit
+matcher is built from `adapters.base.MCP_SERVER_KEY`, the expected served
+version from `trace_mcp.__version__`, and the expected tool total is computed
+from the declared tool names (themselves pinned against the README table and
+against the tools the server registers).
+
+**Guard:** `tests/test_conformance_doctor.py :: test_fresh_init_is_doctor_clean`
+— parametrized over the adapter registry, skipping only adapters whose
+`install()` is not implemented. A new host adapter therefore starts being
+checked the moment it ships, and the doctor must learn that host's layout or
+the guard fails. Supporting guards in the same file pin the derivation itself
+(a hand-copied hook list, stamp, matcher, or tool count fails) and assert that
+breaking exactly one aspect of a fresh install fails exactly one check.
+
+**Status.** ENFORCED.
+
+---
+
 *To add an invariant: give it the next `INV-N`, state it, enumerate the
 exhaustive site-set, name the guard + test, and add a check that fails when a
 new site violates it — in `tests/test_invariants.py` for the AST/enumeration

--- a/src/trace_mcp/adapters/claude_code/__init__.py
+++ b/src/trace_mcp/adapters/claude_code/__init__.py
@@ -21,6 +21,19 @@ _CLAUDE_BLOCK_SRC = _ASSETS / "CLAUDE_BLOCK.md"
 MARKER_START = "<!-- trace-mcp:claude-code -->"
 MARKER_END = "<!-- /trace-mcp:claude-code -->"
 
+HOOK_ASSETS_DIR = _HOOKS_SRC
+"""The shipped hook scripts — the single source for which hooks a correct
+deployment carries and which version stamp they emit. Read by
+``trace_mcp.conformance`` so the deployed-state checker derives its
+expectations from the same files the installer copies, instead of restating
+them in a second place that can drift."""
+
+SETTINGS_TEMPLATE_PATH = _SETTINGS_SRC
+"""The shipped hook registrations — the single source for which host EVENT each
+hook must be registered under. A hook registered under the wrong event never
+fires for its trigger while still looking installed, so the checker derives the
+event map from this file rather than restating it."""
+
 
 class ClaudeCodeAdapter(Adapter):
     """Claude Code host integration."""
@@ -204,4 +217,4 @@ def _append_claude_block(directory: Path, *, dry_run: bool) -> InstallResult:
     return InstallResult(path=dst, disposition="installed")
 
 
-__all__ = ["ClaudeCodeAdapter", "MARKER_END", "MARKER_START"]
+__all__ = ["HOOK_ASSETS_DIR", "SETTINGS_TEMPLATE_PATH", "ClaudeCodeAdapter", "MARKER_END", "MARKER_START"]

--- a/src/trace_mcp/conformance/__init__.py
+++ b/src/trace_mcp/conformance/__init__.py
@@ -1,0 +1,119 @@
+"""Deployed-state conformance for TRACE — the `trace-mcp doctor` layer.
+
+The unit suite proves the source tree is correct. It cannot prove that the
+*deployed* system is: hook copies that predate the release, a PostToolUse
+matcher that never fires, a project with no `TRACE_PROJECT` pin, a server
+process built from a stale cached wheel. Every one of those has happened, and
+every one was found by hand. This package turns that hand-checking into a
+machine-readable check of one project directory against this build's own
+expectations.
+
+Public API:
+
+    run_doctor(project_dir, *, live=False) -> DoctorReport
+
+``DoctorReport.ok`` is False when any check failed; ``skip`` findings name the
+upstream check that made evaluation impossible and never make a report
+unhealthy on their own. ``expectations`` holds the models and the derived
+constants; ``probes`` holds the individual checks; ``cli`` is the
+``trace-mcp doctor`` entry point.
+
+Nothing here writes to the checked project or to ``~/.trace``. The single
+action — spawning the project's own configured server command — happens only
+under ``live=True`` (the CLI's ``--live`` flag).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+
+from trace_mcp.conformance.expectations import (
+    CORE_TOOLS,
+    LEARN_TOOLS,
+    ConformanceAssetError,
+    DoctorReport,
+    ExpectedHookDeployment,
+    ExpectedServedBuild,
+    ExpectedToolSurface,
+    Finding,
+)
+from trace_mcp.conformance.probes import (
+    CONFIG_CHECKS,
+    HOOK_CHECKS,
+    LIVE_CHECKS,
+    PIN_CHECKS,
+    check_config,
+    check_hooks,
+    check_pin_coherence,
+    check_served_build,
+)
+
+_OFFLINE_PROBES: tuple[tuple[str, Callable[[Path], list[Finding]], tuple[str, ...]], ...] = (
+    ("config", check_config, CONFIG_CHECKS),
+    ("hooks", check_hooks, HOOK_CHECKS),
+    ("pin", check_pin_coherence, PIN_CHECKS),
+)
+
+
+def run_doctor(project_dir: Path, *, live: bool = False) -> DoctorReport:
+    """Check one project directory's deployed state against this build.
+
+    *live* additionally spawns the project's own configured server command and
+    handshakes with it (see ``probes.check_served_build``); without it the
+    three ``live.*`` checks report as not evaluated.
+
+    Side effects: reads files under *project_dir*; with *live*, starts and
+    terminates one subprocess. Never writes.
+
+    A probe that raises is itself reported as a failed check rather than
+    propagating: a checker that dies on one malformed project would take a
+    whole fleet sweep down with it, and an unexplained crash is exactly the
+    silence this layer exists to remove.
+    """
+    findings: list[Finding] = []
+    for name, probe, owned in _OFFLINE_PROBES:
+        findings += _guarded(name, owned, lambda p=probe: p(project_dir))
+    findings += _guarded("live", LIVE_CHECKS, lambda: check_served_build(project_dir, live=live))
+    return DoctorReport(project_dir=project_dir, findings=findings)
+
+
+def _guarded(name: str, owned: tuple[str, ...], probe: Callable[[], list[Finding]]) -> list[Finding]:
+    """Run one probe, converting a crash into findings that keep its check ids present.
+
+    Check ids are consumed by tooling, so a crashing probe must not make its
+    whole group vanish: the crash itself is one failed check, and every id the
+    probe owns is reported as not evaluated.
+    """
+    try:
+        return probe()
+    except Exception as exc:  # noqa: BLE001 - a probe crash must surface as findings, never propagate
+        reason = f"the {name} probe raised {type(exc).__name__}: {exc}"
+        return [
+            Finding(check=f"{name}.probe_error", status="fail", detail=reason),
+            *[
+                Finding(check=check, status="skip", detail=f"not evaluated: {reason} (see {name}.probe_error)")
+                for check in owned
+            ],
+        ]
+
+
+__all__ = [
+    "CONFIG_CHECKS",
+    "CORE_TOOLS",
+    "HOOK_CHECKS",
+    "LIVE_CHECKS",
+    "LEARN_TOOLS",
+    "PIN_CHECKS",
+    "ConformanceAssetError",
+    "DoctorReport",
+    "ExpectedHookDeployment",
+    "ExpectedServedBuild",
+    "ExpectedToolSurface",
+    "Finding",
+    "check_config",
+    "check_hooks",
+    "check_pin_coherence",
+    "check_served_build",
+    "run_doctor",
+]

--- a/src/trace_mcp/conformance/cli.py
+++ b/src/trace_mcp/conformance/cli.py
@@ -1,0 +1,71 @@
+"""``trace-mcp doctor`` — check one project's deployed TRACE state.
+
+    trace-mcp doctor [DIR] [--live] [--json]
+
+Exit codes: 0 clean, 1 findings, 2 usage error (a bad path is not an unhealthy
+project, and a caller must be able to tell them apart). Diagnostics go to
+stderr so ``--json`` stdout is always a report or empty. ``--json`` prints the
+``DoctorReport`` for machine consumption (stable check ids; ``ok`` is a
+serialized field).
+
+``--live`` additionally **runs the command the project's own `.mcp.json`
+declares** and handshakes with it — the only way to catch a correct-looking
+project whose running server is a stale build. It is opt-in for that reason:
+executing a command out of a config file is an action, not an inspection.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import TextIO
+
+from trace_mcp.conformance import run_doctor
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="trace-mcp doctor",
+        description="Check a project directory's deployed TRACE state (config, hooks, pins, served build).",
+    )
+    parser.add_argument("directory", nargs="?", default=None, help="project directory (default: cwd)")
+    parser.add_argument(
+        "--live",
+        action="store_true",
+        help="also spawn the project's configured server command and verify the build it serves",
+    )
+    parser.add_argument("--json", action="store_true", help="print the report as JSON instead of text")
+    return parser
+
+
+EXIT_OK = 0
+EXIT_FINDINGS = 1
+EXIT_USAGE = 2
+"""Exit codes. A usage error is distinct from an unhealthy project: a sweep
+shelling out to this command must be able to tell "you gave me a bad path" from
+"this project is broken", and must not have to parse a diagnostic that is not
+the report it asked for."""
+
+
+def main(argv: list[str] | None = None, out: TextIO | None = None, err: TextIO | None = None) -> int:
+    """Entry point for ``trace-mcp doctor``. Returns a process exit code.
+
+    The report goes to *out* (stdout); usage diagnostics go to *err* (stderr),
+    so ``--json`` stdout is always either a report or empty — never a
+    human-readable error a caller would try to parse as JSON.
+    """
+    stream = out if out is not None else sys.stdout
+    errors = err if err is not None else sys.stderr
+    ns = build_parser().parse_args(argv)
+    project_dir = Path(ns.directory).expanduser() if ns.directory else Path.cwd()
+    if not project_dir.is_dir():
+        print(f"Error: {project_dir} is not a directory", file=errors)
+        return EXIT_USAGE
+
+    report = run_doctor(project_dir, live=ns.live)
+    print(report.model_dump_json(indent=2) if ns.json else report.render(), file=stream)
+    return EXIT_OK if report.ok else EXIT_FINDINGS
+
+
+__all__ = ["EXIT_FINDINGS", "EXIT_OK", "EXIT_USAGE", "build_parser", "main"]

--- a/src/trace_mcp/conformance/expectations.py
+++ b/src/trace_mcp/conformance/expectations.py
@@ -1,0 +1,322 @@
+"""Machine-readable expectations for a correctly *deployed* TRACE project.
+
+The unit suite proves the source tree is correct. This module states what a
+correct **deployment** looks like — the tool surface a server must serve, the
+hook copies a project must carry, the identity pins that must agree — so
+`trace_mcp.conformance.probes` can compare a real directory against it.
+
+Everything here is derived from a shipped artifact rather than restated:
+the required hook filenames and their version stamp are read out of the
+adapter's asset directory, the decision-audit matcher is built from
+``adapters.base.MCP_SERVER_KEY``, the expected served version comes from
+``trace_mcp.__version__``, and the expected tool total is computed from the
+declared names. A restated expectation is one more copy to rot, and rot in
+exactly this layer — a matcher naming a bare tool name, a hook fleet frozen at
+an old release — is what the doctor exists to catch.
+
+Exports: ``CORE_TOOLS``, ``LEARN_TOOLS``, ``ConformanceAssetError``,
+``DoctorReport``, ``ExpectedHookDeployment``, ``ExpectedServedBuild``,
+``ExpectedToolSurface``, ``Finding``, ``shipped_hook_files``,
+``shipped_hook_stamp``.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, computed_field
+
+import trace_mcp
+from trace_mcp.adapters.base import MCP_SERVER_KEY
+from trace_mcp.adapters.claude_code import HOOK_ASSETS_DIR, SETTINGS_TEMPLATE_PATH
+
+# ── Tool surface ────────────────────────────────────────────────────────────
+
+CORE_TOOLS: tuple[str, ...] = (
+    "trace_start_session",
+    "trace_end_session",
+    "trace_log_tool_call",
+    "trace_log_annotation",
+    "trace_log_contribution",
+    "trace_log_state_change",
+    "trace_propose_decision",
+    "trace_resolve_decision",
+    "trace_get_session",
+    "trace_get_events",
+    "trace_get_decisions",
+    "trace_get_decision_chain",
+    "trace_search",
+    "trace_export",
+    "trace_list_sessions",
+    "trace_project_summary",
+    "trace_health_check",
+)
+"""The core tools every TRACE server registers, in the documented order.
+
+This tuple is the ONE place the names live for conformance purposes; tests pin
+it against both the README table and the tools the server actually registers,
+so a tool added, renamed, or lost cannot pass silently. The names cannot be
+introspected from the server here: importing ``trace_mcp.server`` constructs a
+``JsonFileStorage`` and would make a read-only checker touch the data
+directory."""
+
+LEARN_TOOLS: tuple[str, ...] = (
+    "trace_learn_recall",
+    "trace_learn_add",
+    "trace_learn_list",
+    "trace_learn_forget",
+    "trace_learn_extract",
+)
+"""The trace-learn extension's tools.
+
+Kept separate from the core names because the extension is optional by
+governance (ADR-003): core must work with it absent. A server missing exactly
+these five is the documented symptom of a launch config without the
+``--with openai/numpy/model2vec`` extras."""
+
+
+# ── Shipped hook assets ─────────────────────────────────────────────────────
+
+
+class ConformanceAssetError(RuntimeError):
+    """The installed trace-mcp's own hook assets are missing or inconsistent.
+
+    Raised rather than defaulted: a checker that cannot read its own reference
+    copy cannot judge a deployment, and guessing would report a stale fleet as
+    healthy."""
+
+
+_STAMP_RE = re.compile(r"\[trace-hooks v[\d.]+\]")
+
+
+def shipped_hook_files() -> tuple[str, ...]:
+    """Names of the hook scripts this build ships, sorted.
+
+    Side effects: reads the adapter's asset directory.
+
+    Raises:
+        ConformanceAssetError: the asset directory holds no hook scripts.
+    """
+    names = tuple(sorted(p.name for p in HOOK_ASSETS_DIR.glob("*.sh")))
+    if not names:
+        raise ConformanceAssetError(
+            f"no hook scripts found in {HOOK_ASSETS_DIR} — this trace-mcp build is missing its adapter assets, "
+            "so a deployment cannot be checked against them. Reinstall the package."
+        )
+    return names
+
+
+def shipped_hook_stamp() -> str:
+    """The single version stamp (``[trace-hooks vX.Y]``) every shipped hook emits.
+
+    Deriving it — rather than restating it — is what makes a stamp bump
+    automatically flag every deployed copy that predates it.
+
+    Side effects: reads the adapter's hook assets.
+
+    Raises:
+        ConformanceAssetError: a hook carries no stamp, or the copies disagree.
+    """
+    stamps: set[str] = set()
+    for name in shipped_hook_files():
+        found = set(_STAMP_RE.findall((HOOK_ASSETS_DIR / name).read_text(encoding="utf-8", errors="replace")))
+        if not found:
+            raise ConformanceAssetError(f"shipped hook {name} carries no [trace-hooks vX.Y] version stamp")
+        stamps |= found
+    if len(stamps) != 1:
+        raise ConformanceAssetError(f"shipped hooks disagree about their version stamp: {sorted(stamps)}")
+    return stamps.pop()
+
+
+def extract_hook_stamp(text: str) -> str | None:
+    """The ``[trace-hooks vX.Y]`` stamp *text* carries, or None.
+
+    Used to report what a deployed copy actually says, so a mismatch can name
+    both sides instead of asserting a direction.
+    """
+    found = _STAMP_RE.findall(text)
+    return found[0] if found else None
+
+
+def shipped_hook_events() -> dict[str, str]:
+    """Map each shipped hook script to the host event it must be registered under.
+
+    Derived from the installer's own ``settings_template.json``: a hook
+    registered under the wrong event is installed, executable, current, and
+    completely inert — it never fires for the trigger it exists to answer. That
+    is the same shape as the dead matcher, one level up, so the event belongs in
+    the expectations rather than in a reviewer's memory.
+
+    Side effects: reads the adapter's settings template.
+
+    Raises:
+        ConformanceAssetError: the template is unreadable, a shipped hook has no
+            registration in it, or one hook is registered under two events.
+    """
+    try:
+        template = json.loads(SETTINGS_TEMPLATE_PATH.read_text(encoding="utf-8", errors="replace"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ConformanceAssetError(
+            f"cannot read the shipped settings template {SETTINGS_TEMPLATE_PATH}: {exc}"
+        ) from exc
+    hooks = template.get("hooks") if isinstance(template, dict) else None
+    if not isinstance(hooks, dict):
+        raise ConformanceAssetError(f"{SETTINGS_TEMPLATE_PATH} declares no 'hooks' object")
+
+    events: dict[str, set[str]] = {name: set() for name in shipped_hook_files()}
+    for event, entries in hooks.items():
+        if not isinstance(entries, list):
+            continue
+        for entry in entries:
+            commands = entry.get("hooks") if isinstance(entry, dict) else None
+            if not isinstance(commands, list):
+                continue
+            for command in commands:
+                text = command.get("command", "") if isinstance(command, dict) else ""
+                for name in events:
+                    if isinstance(text, str) and name in text:
+                        events[name].add(str(event))
+
+    unmapped = sorted(name for name, evs in events.items() if not evs)
+    if unmapped:
+        raise ConformanceAssetError(
+            f"shipped hook(s) {unmapped} have no registration in {SETTINGS_TEMPLATE_PATH} — "
+            "the installer would copy a script nothing ever runs"
+        )
+    ambiguous = sorted(name for name, evs in events.items() if len(evs) > 1)
+    if ambiguous:
+        raise ConformanceAssetError(f"shipped hook(s) {ambiguous} are registered under more than one event")
+    return {name: next(iter(evs)) for name, evs in sorted(events.items())}
+
+
+# ── Expectation models ──────────────────────────────────────────────────────
+
+
+class ExpectedToolSurface(BaseModel):
+    """The tools a correctly launched TRACE server serves."""
+
+    model_config = ConfigDict(frozen=True)
+
+    core_tools: tuple[str, ...] = Field(default=CORE_TOOLS, description="Core tool names, in documented order.")
+    learn_tools: tuple[str, ...] = Field(
+        default=LEARN_TOOLS, description="trace-learn extension tool names, in documented order."
+    )
+
+    @computed_field(description="Total tools a fully-equipped server serves (core + learn).")
+    @property
+    def total(self) -> int:
+        return len(self.core_tools) + len(self.learn_tools)
+
+
+class ExpectedHookDeployment(BaseModel):
+    """The host-integration artifacts a correctly initialized project carries."""
+
+    model_config = ConfigDict(frozen=True)
+
+    hook_files: tuple[str, ...] = Field(
+        default_factory=shipped_hook_files, description="Hook scripts that must exist under .claude/hooks/."
+    )
+    version_stamp: str = Field(
+        default_factory=shipped_hook_stamp,
+        description="Stamp every deployed hook must carry; an older stamp identifies a stale copy.",
+    )
+    decision_audit_matcher: str = Field(
+        default=f"mcp__{MCP_SERVER_KEY}__trace_end_session",
+        description=(
+            "PostToolUse matcher for the decision-audit hook. Claude Code matches the FULL tool name, "
+            "and hosts namespace MCP tools as mcp__<server-key>__<tool>, so a bare tool name never fires."
+        ),
+    )
+    hooks_dir: str = Field(default=".claude/hooks", description="Project-relative hook script directory.")
+    settings_file: str = Field(default=".claude/settings.json", description="Project-relative host settings file.")
+    pin_file: str = Field(
+        default=".claude/trace.project", description="Project-relative canonical-key pin file (hooks read this first)."
+    )
+    decision_audit_script: str = Field(
+        default="decision-audit.sh", description="Hook script the decision-audit matcher must be attached to."
+    )
+    hook_events: dict[str, str] = Field(
+        default_factory=shipped_hook_events,
+        description="Host event each hook script must be registered under; a hook under the wrong event never fires.",
+    )
+
+
+class ExpectedServedBuild(BaseModel):
+    """What the project's own configured server command must report when spawned."""
+
+    model_config = ConfigDict(frozen=True)
+
+    version: str = Field(
+        default=trace_mcp.__version__,
+        description="Version the MCP initialize handshake must report in serverInfo.",
+    )
+    tool_total: int = Field(
+        default_factory=lambda: ExpectedToolSurface().total, description="Tool count tools/list must return."
+    )
+
+
+# ── Report ──────────────────────────────────────────────────────────────────
+
+FindingStatus = Literal["pass", "fail", "skip"]
+
+
+class Finding(BaseModel):
+    """One check's outcome.
+
+    ``skip`` means *not evaluated* and always names the upstream check that
+    made evaluation impossible — the doctor never stays silent about a check
+    it could not run.
+    """
+
+    check: str = Field(..., description="Stable dotted check id, e.g. 'hooks.decision_audit_matcher'.")
+    status: FindingStatus = Field(..., description="pass, fail, or skip (not evaluated).")
+    detail: str = Field(..., description="Human-readable evidence, including the remedy on a failure.")
+
+
+class DoctorReport(BaseModel):
+    """Result of checking one project directory's deployed state."""
+
+    project_dir: Path = Field(..., description="Directory that was checked.")
+    findings: list[Finding] = Field(default_factory=list, description="Findings in check order.")
+
+    @computed_field(description="True when no check failed. Skipped checks do not make a report unhealthy.")
+    @property
+    def ok(self) -> bool:
+        return not any(f.status == "fail" for f in self.findings)
+
+    def failures(self) -> list[Finding]:
+        """The failing findings, in check order."""
+        return [f for f in self.findings if f.status == "fail"]
+
+    def render(self) -> str:
+        """Human-readable report body (no trailing newline)."""
+        width = max((len(f.check) for f in self.findings), default=0)
+        lines = [f"doctor: {self.project_dir}"]
+        lines += [f"  {f.status.upper():<4} {f.check:<{width}}  {f.detail}" for f in self.findings]
+        failed = self.failures()
+        lines.append(
+            "doctor: clean — deployed state matches this build's expectations."
+            if not failed
+            else f"doctor: {len(failed)} check(s) failed"
+        )
+        return "\n".join(lines)
+
+
+__all__ = [
+    "CORE_TOOLS",
+    "LEARN_TOOLS",
+    "ConformanceAssetError",
+    "DoctorReport",
+    "ExpectedHookDeployment",
+    "ExpectedServedBuild",
+    "ExpectedToolSurface",
+    "Finding",
+    "FindingStatus",
+    "extract_hook_stamp",
+    "shipped_hook_events",
+    "shipped_hook_files",
+    "shipped_hook_stamp",
+]

--- a/src/trace_mcp/conformance/probes.py
+++ b/src/trace_mcp/conformance/probes.py
@@ -1,0 +1,983 @@
+"""Checks that compare one project directory's DEPLOYED state to expectations.
+
+Each ``check_*`` function takes a project directory and returns a list of
+``Finding``s; none of them raise for a defect in the target, and none of them
+write anything to the project or to ``~/.trace``. The one exception to
+"reads only" is ``check_served_build`` with ``live=True``, which **spawns the
+project's own configured server command** — noted in its docstring and gated
+behind the CLI's ``--live`` flag, because running a command out of a config
+file is a real action, not an inspection.
+
+Two contracts hold across every probe, both of them the fail-loud rule from
+the handoff:
+
+* **One fail per root cause.** When an input cannot be read, exactly one check
+  fails for it and every dependent check reports ``skip`` naming that upstream
+  check. A skip is never silence — it says what was not evaluated and why.
+* **A probe that cannot determine health fails.** There is no
+  warn-and-proceed: an unreadable settings file, a vanished ``--from`` source,
+  or a server that will not start are failures, not notes.
+
+Check ids are stable API: ``trace-mcp fleet-check`` and downstream tooling key
+off them, so rename with the same care as a wire field.
+
+The hook checks describe the Claude Code deployment — the only adapter that
+installs today. A directory set up with ``--client none`` therefore fails
+them, which is intended: an MCP server with no host-side enforcement is a gap
+in the audit trail, not a supported configuration.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import queue
+import re
+import subprocess
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from trace_mcp import project_identity as pident
+from trace_mcp.adapters.base import MCP_SERVER_KEY
+from trace_mcp.conformance.expectations import (
+    ExpectedHookDeployment,
+    ExpectedServedBuild,
+    ExpectedToolSurface,
+    Finding,
+    extract_hook_stamp,
+)
+
+# Reused, not restated: the same `--with` extras init writes, the same
+# bold-tolerant pin-line regex the hooks and init share, and the same argument
+# scanner init uses to merge configs. A second copy of any of these is a second
+# thing to drift.
+from trace_mcp.init_project import _PIN_LINE_RE, LEARN_EXTRAS, _extract_with_packages
+
+_LIVE_TIMEOUT = "TRACE_DOCTOR_LIVE_TIMEOUT"
+_DEFAULT_LIVE_TIMEOUT = 180.0
+
+CONFIG_CHECKS = (
+    "config.file",
+    "config.server_entry",
+    "config.command",
+    "config.source",
+    "config.entrypoint",
+    "config.learn_extras",
+    "config.refresh",
+)
+HOOK_CHECKS = (
+    "hooks.present",
+    "hooks.executable",
+    "hooks.stamp",
+    "hooks.unknown",
+    "hooks.settings",
+    "hooks.registered",
+    "hooks.decision_audit_matcher",
+)
+PIN_CHECKS = ("pin.trace_project_file", "pin.mcp_env", "pin.claude_md_line", "pin.coherence")
+LIVE_CHECKS = ("live.spawn", "live.version", "live.tool_surface")
+"""Every check id each probe owns, in emission order.
+
+These are stable API — `trace-mcp fleet-check` and downstream tooling key off
+them — so a probe must emit its whole set on every run, including when it
+cannot evaluate a check and when it crashes outright. A consumer that keys on
+an id must never have that id silently disappear.
+"""
+
+
+# ── Finding constructors ────────────────────────────────────────────────────
+
+
+def _ok(check: str, detail: str) -> Finding:
+    return Finding(check=check, status="pass", detail=detail)
+
+
+def _bad(check: str, detail: str) -> Finding:
+    return Finding(check=check, status="fail", detail=detail)
+
+
+def _unevaluated(check: str, reason: str, upstream: str | None = None) -> Finding:
+    suffix = f" (see {upstream})" if upstream else ""
+    return Finding(check=check, status="skip", detail=f"not evaluated: {reason}{suffix}")
+
+
+# ── Shared readers ──────────────────────────────────────────────────────────
+
+
+def _load_config(project_dir: Path) -> tuple[dict[str, Any] | None, str | None]:
+    """Parse ``.mcp.json``. Returns (config, error) — never both.
+
+    Side effects: reads ``<project_dir>/.mcp.json``.
+    """
+    path = project_dir / ".mcp.json"
+    if not path.is_file():
+        return None, f"{path} does not exist — this directory has no MCP server configuration"
+    try:
+        data = json.loads(path.read_text(encoding="utf-8", errors="replace"))
+    except json.JSONDecodeError as exc:
+        return None, f"{path} is not valid JSON ({exc})"
+    if not isinstance(data, dict):
+        return None, f"{path} does not contain a JSON object"
+    return data, None
+
+
+def _trace_entry(config: dict[str, Any]) -> dict[str, Any] | None:
+    """The ``mcpServers.<key>`` entry TRACE is configured under, if well-formed."""
+    servers = config.get("mcpServers")
+    if not isinstance(servers, dict):
+        return None
+    entry = servers.get(MCP_SERVER_KEY)
+    return entry if isinstance(entry, dict) else None
+
+
+def _entry_or_reason(project_dir: Path) -> tuple[dict[str, Any] | None, str, str]:
+    """Return (entry, reason, upstream_check) for probes that need the trace entry."""
+    config, _error = _load_config(project_dir)
+    if config is None:
+        return None, ".mcp.json is unreadable", "config.file"
+    entry = _trace_entry(config)
+    if entry is None:
+        return None, f"no '{MCP_SERVER_KEY}' server entry in .mcp.json", "config.server_entry"
+    return entry, "", ""
+
+
+def _args(entry: dict[str, Any]) -> list[str]:
+    raw = entry.get("args")
+    return [a for a in raw if isinstance(a, str)] if isinstance(raw, list) else []
+
+
+def _env_pin(entry: dict[str, Any]) -> str | None:
+    env = entry.get("env")
+    if not isinstance(env, dict):
+        return None
+    pin = env.get("TRACE_PROJECT")
+    return pin.strip() if isinstance(pin, str) and pin.strip() else None
+
+
+# ── check_config ────────────────────────────────────────────────────────────
+
+_CONFIG_ENTRY_DEPENDENTS = ("config.command", "config.source", "config.learn_extras", "config.refresh")
+
+
+def check_config(project_dir: Path) -> list[Finding]:
+    """Check ``.mcp.json``: a launchable, pinned, fully-equipped trace server.
+
+    Side effects: reads ``<project_dir>/.mcp.json`` and, for a filesystem
+    ``--from`` source, stats that path.
+    """
+    findings: list[Finding] = []
+    config, error = _load_config(project_dir)
+    if config is None:
+        findings.append(_bad("config.file", error or "unreadable"))
+        findings.append(_unevaluated("config.server_entry", ".mcp.json is unreadable", "config.file"))
+        findings += [_unevaluated(c, ".mcp.json is unreadable", "config.file") for c in _CONFIG_ENTRY_DEPENDENTS]
+        return findings
+
+    findings.append(_ok("config.file", f"{project_dir / '.mcp.json'} parses"))
+    entry = _trace_entry(config)
+    if entry is None:
+        findings.append(
+            _bad(
+                "config.server_entry",
+                f"no well-formed '{MCP_SERVER_KEY}' entry under mcpServers — the TRACE tools are not "
+                f"configured here. Run `trace-mcp-init` in this directory.",
+            )
+        )
+        findings += [
+            _unevaluated(c, f"no '{MCP_SERVER_KEY}' server entry", "config.server_entry")
+            for c in _CONFIG_ENTRY_DEPENDENTS
+        ]
+        return findings
+    findings.append(_ok("config.server_entry", f"mcpServers.{MCP_SERVER_KEY} is present"))
+
+    command = entry.get("command")
+    findings.append(
+        _ok("config.command", "launched with uvx")
+        if command == "uvx"
+        else _bad(
+            "config.command",
+            f"command is {command!r}, not 'uvx' — the supported launch path builds an isolated environment "
+            "from the source checkout. A different launcher is not covered by this build's expectations.",
+        )
+    )
+
+    args = _args(entry)
+    findings.append(_check_source(project_dir, args))
+    findings.append(_check_entrypoint(args))
+    findings.append(_check_learn_extras(args))
+    findings.append(_check_refresh(args))
+    return findings
+
+
+_DISTRIBUTION_NAME = "trace-mcp"
+
+_ARCHIVE_SUFFIXES = (".whl", ".tar.gz", ".zip")
+
+# uvx options that consume the following argument. Needed to tell the command
+# uvx runs (the first true positional) from a flag's value — the difference
+# between `... --refresh-package trace-mcp trace-mcp` (correct) and
+# `... --refresh-package trace-mcp` (no command at all, but the same last word).
+_UVX_VALUE_FLAGS = frozenset(
+    {
+        "--from",
+        "--with",
+        "--with-editable",
+        "--with-requirements",
+        "--refresh-package",
+        "--python",
+        "-p",
+        "--index",
+        "--index-url",
+        "--extra-index-url",
+        "--constraint",
+        "--override",
+        "--exclude-newer",
+        "--cache-dir",
+        "--directory",
+        "--project",
+    }
+)
+
+
+def _normalized_requirement(source: str) -> str | None:
+    """The PEP 503 normalized name if *source* is a bare requirement, else None.
+
+    ``trace_mcp``, ``Trace-MCP`` and ``trace-mcp==0.5.0`` all install the same
+    distribution, so an exact-string check on one spelling would wave the other
+    two through.
+    """
+    if "://" in source or source.startswith(("git+", "~", ".", "/")) or "/" in source or os.sep in source:
+        return None
+    name = re.split(r"[<>=!~;\[@ ]", source, maxsplit=1)[0].strip()
+    return re.sub(r"[-_.]+", "-", name).lower() if name else None
+
+
+def _check_source(project_dir: Path, args: list[str]) -> Finding:
+    """The ``--from`` source must be something uvx can actually build.
+
+    A relative source (this repository's own config uses ``--from .``) is
+    resolved against the PROJECT directory, because that is uvx's working
+    directory when the host starts the server — resolving it against the
+    checker's cwd would report one project as healthy or broken depending on
+    where the check was run from.
+    """
+    if "--from" not in args:
+        return _bad("config.source", "no `--from <source>` in the launch args — uvx has nothing to build")
+    idx = args.index("--from")
+    if idx + 1 >= len(args):
+        return _bad("config.source", "`--from` is the last argument — no source follows it")
+    source = args[idx + 1]
+
+    if "://" in source or source.startswith("git+"):
+        return _ok("config.source", f"builds from the remote ref {source}")
+
+    requirement = _normalized_requirement(source)
+    if requirement == _DISTRIBUTION_NAME:
+        return _bad(
+            "config.source",
+            f"`--from {source}` names the PyPI distribution `{_DISTRIBUTION_NAME}`, which belongs to an "
+            "UNRELATED project — every server start would download and execute a third party's code "
+            "(dependency confusion). Point `--from` at a TRACE checkout or a git ref instead.",
+        )
+    if requirement is not None:
+        return _bad(
+            "config.source",
+            f"`--from {source}` names a package on an index rather than a checkout, and TRACE is not published "
+            "under that name — this cannot resolve to this project. Use a local checkout path or a git ref.",
+        )
+
+    if source.startswith("~"):
+        return _bad(
+            "config.source",
+            f"`--from {source}` starts with `~`, which only a shell expands. The host executes uvx directly, so "
+            "the tilde is taken literally and resolved against the working directory. Write the path in full.",
+        )
+
+    candidate = Path(source)
+    if not candidate.is_absolute():
+        candidate = project_dir / candidate
+    if not candidate.exists():
+        return _bad(
+            "config.source",
+            f"`--from {source}` does not exist (resolved to {candidate}) — every server start from this config "
+            "fails. Repoint it at the TRACE checkout (or re-run `trace-mcp-init` with TRACE_SOURCE_PATH set).",
+        )
+    if not candidate.is_dir() and candidate.suffix not in _ARCHIVE_SUFFIXES:
+        return _bad(
+            "config.source",
+            f"`--from {source}` is neither a project directory nor a distribution archive "
+            f"({', '.join(_ARCHIVE_SUFFIXES)}) — uvx has nothing to build from it.",
+        )
+    return _ok("config.source", f"builds from {source}")
+
+
+def _uvx_command(args: list[str]) -> str | None:
+    """The command uvx would run: the first argument that is not a flag or a flag's value."""
+    i = 0
+    while i < len(args):
+        token = args[i]
+        if token in _UVX_VALUE_FLAGS:
+            i += 2
+            continue
+        if token.startswith("-"):
+            i += 1
+            continue
+        return token
+    return None
+
+
+def _check_entrypoint(args: list[str]) -> Finding:
+    """uvx must be told which command to run, and it must be the TRACE server."""
+    command = _uvx_command(args)
+    if command is None:
+        return _bad(
+            "config.entrypoint",
+            f"the launch args name no command for uvx to run — every argument is a flag or a flag's value, so "
+            f"nothing starts. Append `{_DISTRIBUTION_NAME}` after the flags.",
+        )
+    if command != _DISTRIBUTION_NAME:
+        return _bad(
+            "config.entrypoint",
+            f"uvx would run {command!r}, not `{_DISTRIBUTION_NAME}` — this entry does not start the TRACE server.",
+        )
+    return _ok("config.entrypoint", f"runs `{_DISTRIBUTION_NAME}`")
+
+
+def _check_learn_extras(args: list[str]) -> Finding:
+    """Missing extras is the silent 17-tool server — the symptom with no error."""
+    present = _extract_with_packages(args)
+    missing = [pkg for pkg in LEARN_EXTRAS if pkg not in present]
+    if missing:
+        return _bad(
+            "config.learn_extras",
+            f"missing `--with` extras {missing} — without them the trace-learn extension does not register and "
+            f"the server comes up with 17 tools instead of the documented 22, with no error to explain the gap. "
+            f"Add: " + " ".join(f"--with {pkg}" for pkg in missing),
+        )
+    return _ok("config.learn_extras", f"carries the trace-learn extras {list(LEARN_EXTRAS)} (22-tool server)")
+
+
+def _check_refresh(args: list[str]) -> Finding:
+    """Without a refresh flag the launcher can serve an arbitrarily old build."""
+    if "--refresh-package" in args:
+        idx = args.index("--refresh-package")
+        target = args[idx + 1] if idx + 1 < len(args) else None
+        if target != "trace-mcp":
+            return _bad(
+                "config.refresh",
+                f"`--refresh-package {target!r}` does not name trace-mcp, so source changes are not picked up "
+                "on server start. Use `--refresh-package trace-mcp`.",
+            )
+        return _ok("config.refresh", "refreshes trace-mcp on every server start")
+    if "--refresh" in args:
+        return _ok("config.refresh", "uses the blanket `--refresh` (canonical form is `--refresh-package trace-mcp`)")
+    return _bad(
+        "config.refresh",
+        "no `--refresh-package trace-mcp` flag — uvx may serve a cached build indefinitely, so merged fixes "
+        "never reach this project.",
+    )
+
+
+# ── check_hooks ─────────────────────────────────────────────────────────────
+
+
+def check_hooks(project_dir: Path) -> list[Finding]:
+    """Check the host hook deployment: files, executability, version, wiring.
+
+    Side effects: reads ``.claude/hooks/*`` and ``.claude/settings.json`` under
+    *project_dir*.
+    """
+    expected = ExpectedHookDeployment()
+    hooks_dir = project_dir / expected.hooks_dir
+    findings: list[Finding] = []
+
+    present = [name for name in expected.hook_files if (hooks_dir / name).is_file()]
+    missing = [name for name in expected.hook_files if name not in present]
+    findings.append(
+        _bad(
+            "hooks.present",
+            f"missing hook script(s) {missing} under {hooks_dir} — re-run `trace-mcp-init` in this directory.",
+        )
+        if missing
+        else _ok("hooks.present", f"all {len(present)} shipped hook scripts are installed")
+    )
+
+    if not present:
+        findings.append(_unevaluated("hooks.executable", "no hook scripts are installed", "hooks.present"))
+        findings.append(_unevaluated("hooks.stamp", "no hook scripts are installed", "hooks.present"))
+    else:
+        findings.append(_check_hook_executable(hooks_dir, present))
+        findings.append(_check_hook_stamp(hooks_dir, present, expected.version_stamp))
+
+    findings.append(_check_unknown_hooks(hooks_dir, expected))
+    findings += _check_settings(project_dir, expected)
+    return findings
+
+
+def _check_unknown_hooks(hooks_dir: Path, expected: ExpectedHookDeployment) -> Finding:
+    """TRACE-stamped scripts this build no longer ships are left running forever.
+
+    Only scripts carrying a `[trace-hooks vX.Y]` stamp are reported: that stamp
+    identifies a copy TRACE installed, so a project's own unrelated hook scripts
+    are none of this checker's business. When a release renames or drops a hook,
+    the old copy stays on disk and stays registered — checking only the shipped
+    names would call that deployment current.
+    """
+    if not hooks_dir.is_dir():
+        return _unevaluated("hooks.unknown", f"{hooks_dir} does not exist", "hooks.present")
+    orphans = [
+        path.name
+        for path in sorted(hooks_dir.glob("*.sh"))
+        if path.name not in expected.hook_files
+        and extract_hook_stamp(path.read_text(encoding="utf-8", errors="replace")) is not None
+    ]
+    if orphans:
+        return _bad(
+            "hooks.unknown",
+            f"hook script(s) {orphans} carry a TRACE version stamp but are not shipped by this build — they are "
+            "leftovers from an older release still running old semantics. Remove them.",
+        )
+    return _ok("hooks.unknown", "no leftover TRACE hook scripts from an older release")
+
+
+def _check_hook_executable(hooks_dir: Path, present: list[str]) -> Finding:
+    not_exec = [name for name in present if not os.access(hooks_dir / name, os.X_OK)]
+    if not_exec:
+        return _bad(
+            "hooks.executable",
+            f"hook script(s) {not_exec} are not executable — the host cannot run them, so the protocol "
+            f"is silently unenforced here. Fix with `chmod +x {hooks_dir}/*.sh`.",
+        )
+    return _ok("hooks.executable", "every installed hook script is executable")
+
+
+def _version_tuple(text: str) -> tuple[int, ...] | None:
+    """Leading dotted integers in *text*, or None when it carries no version."""
+    match = re.search(r"(\d+(?:\.\d+)*)", text)
+    return tuple(int(part) for part in match.group(1).split(".")) if match else None
+
+
+def _which_side_is_behind(deployed: str | None, shipped: str) -> str:
+    """Say which artifact is older, or decline to guess.
+
+    Asserting "stale deployment" in both directions is wrong half the time: a
+    sweep run with an older `trace-mcp` on PATH meets projects initialized from
+    a newer checkout, and telling their owner to re-run init would downgrade a
+    correct deployment.
+    """
+    left, right = _version_tuple(deployed or ""), _version_tuple(shipped)
+    if left is None or right is None or left == right:
+        return "differs from"
+    return "is OLDER than" if left < right else "is NEWER than"
+
+
+def _check_hook_stamp(hooks_dir: Path, present: list[str], stamp: str) -> Finding:
+    mismatched: list[tuple[str, str]] = []
+    for name in present:
+        text = (hooks_dir / name).read_text(encoding="utf-8", errors="replace")
+        if stamp not in text:
+            mismatched.append((name, extract_hook_stamp(text) or "no stamp"))
+    if not mismatched:
+        return _ok("hooks.stamp", f"every installed hook carries {stamp}")
+    found = sorted({found for _name, found in mismatched})
+    direction = _which_side_is_behind(found[0] if len(found) == 1 else None, stamp)
+    remedy = (
+        "Re-run `trace-mcp-init` to refresh them."
+        if direction != "is NEWER than"
+        else "The CHECKER is the older side: upgrade the trace-mcp you are running rather than touching the project."
+    )
+    listed = ", ".join(f"{name} ({found})" for name, found in mismatched)
+    return _bad(
+        "hooks.stamp",
+        f"installed hook version {direction} this build's {stamp}: {listed}. A copy from a different release may "
+        f"detect the project differently or emit warnings that no longer apply. {remedy}",
+    )
+
+
+def _hook_registrations(settings: dict[str, Any]) -> list[tuple[str, dict[str, Any]]]:
+    """Every (event, registration) pair in a settings file, malformed shapes skipped."""
+    hooks = settings.get("hooks")
+    if not isinstance(hooks, dict):
+        return []
+    pairs: list[tuple[str, dict[str, Any]]] = []
+    for event, entries in hooks.items():
+        if not isinstance(entries, list):
+            continue
+        pairs += [(str(event), e) for e in entries if isinstance(e, dict)]
+    return pairs
+
+
+def _registration_commands(entry: dict[str, Any]) -> list[str]:
+    hooks = entry.get("hooks")
+    if not isinstance(hooks, list):
+        return []
+    return [h.get("command", "") for h in hooks if isinstance(h, dict) and isinstance(h.get("command"), str)]
+
+
+def _check_settings(project_dir: Path, expected: ExpectedHookDeployment) -> list[Finding]:
+    """Settings parse, every hook is wired to its own event, and the audit matcher can fire."""
+    path = project_dir / expected.settings_file
+    dependents = ("hooks.registered", "hooks.decision_audit_matcher")
+    if not path.is_file():
+        return [
+            _bad("hooks.settings", f"{path} does not exist — no hook is registered, so none of them ever run."),
+            *[_unevaluated(c, "settings.json is missing", "hooks.settings") for c in dependents],
+        ]
+    try:
+        settings = json.loads(path.read_text(encoding="utf-8", errors="replace"))
+    except json.JSONDecodeError as exc:
+        return [
+            _bad("hooks.settings", f"{path} is not valid JSON ({exc}) — the host ignores it and no hook runs."),
+            *[_unevaluated(c, "settings.json is unparseable", "hooks.settings") for c in dependents],
+        ]
+    if not isinstance(settings, dict) or not isinstance(settings.get("hooks"), dict):
+        return [
+            _bad("hooks.settings", f"{path} has no 'hooks' object — nothing is registered."),
+            *[_unevaluated(c, "settings.json declares no hooks", "hooks.settings") for c in dependents],
+        ]
+
+    findings = [_ok("hooks.settings", f"{path} parses and declares hooks")]
+    registrations = _hook_registrations(settings)
+    findings.append(_check_registrations(path, registrations, expected))
+    findings.append(_check_audit_matcher(registrations, expected))
+    return findings
+
+
+def _events_running(registrations: list[tuple[str, dict[str, Any]]], script: str) -> set[str]:
+    """Every host event under which some registration runs *script*."""
+    return {
+        event for event, entry in registrations if any(script in command for command in _registration_commands(entry))
+    }
+
+
+def _check_registrations(path: Path, registrations: list[tuple[str, dict[str, Any]]], expected) -> Finding:
+    """Each shipped hook must be registered, and under ITS OWN event.
+
+    Checking only that a script is mentioned somewhere in settings.json is the
+    same defect as matching a bare tool name: a decision-audit hook registered
+    under `PreToolUse` is installed, current, executable — and never fires on
+    session end. The event is part of the deployment, so it is part of the check.
+    """
+    unregistered: list[str] = []
+    misregistered: list[str] = []
+    for script, event in sorted(expected.hook_events.items()):
+        found = _events_running(registrations, script)
+        if not found:
+            unregistered.append(script)
+        elif event not in found:
+            misregistered.append(f"{script} (registered under {sorted(found)}, expected {event})")
+    if not unregistered and not misregistered:
+        return _ok("hooks.registered", "every shipped hook script is registered under its own host event")
+    parts: list[str] = []
+    if unregistered:
+        parts.append(
+            f"hook script(s) {unregistered} exist on disk but no registration in {path} runs them — an installed "
+            "hook that nothing invokes is not a deployment"
+        )
+    if misregistered:
+        parts.append(
+            f"hook script(s) registered under the wrong host event: {misregistered} — a hook on the wrong event "
+            "looks installed and never fires for its trigger"
+        )
+    return _bad("hooks.registered", ". ".join(parts) + ". Re-run `trace-mcp-init`.")
+
+
+def _check_audit_matcher(registrations: list[tuple[str, dict[str, Any]]], expected) -> Finding:
+    """The decision-audit hook must match the full namespaced tool name, on its own event."""
+    event = expected.hook_events.get(expected.decision_audit_script)
+    audit = [
+        entry
+        for ev, entry in registrations
+        if ev == event and any(expected.decision_audit_script in cmd for cmd in _registration_commands(entry))
+    ]
+    if not audit:
+        return _unevaluated(
+            "hooks.decision_audit_matcher",
+            f"the decision-audit hook is not registered under {event}",
+            "hooks.registered",
+        )
+    wrong = [entry.get("matcher", "") for entry in audit if entry.get("matcher") != expected.decision_audit_matcher]
+    if not wrong:
+        return _ok("hooks.decision_audit_matcher", f"matches {expected.decision_audit_matcher} on {event}")
+    return _bad(
+        "hooks.decision_audit_matcher",
+        f"decision-audit is registered with matcher(s) {wrong!r}, not {expected.decision_audit_matcher!r}. "
+        "Claude Code matches the FULL tool name, and hosts namespace MCP tools as mcp__<server-key>__<tool>, "
+        "so this matcher never fires and the attribution audit is never surfaced. Re-run `trace-mcp-init` "
+        "(it rewrites the legacy short matcher in place).",
+    )
+
+
+# ── check_pin_coherence ─────────────────────────────────────────────────────
+
+
+def _canonical(label: str) -> str | None:
+    try:
+        return pident.canonical_project_key(label)
+    except pident.ProjectKeyError:
+        return None
+
+
+def check_pin_coherence(project_dir: Path) -> list[Finding]:
+    """The three pin sites must exist and canonicalize to ONE project key.
+
+    The pin file (hooks), the ``.mcp.json`` env pin (server), and the CLAUDE.md
+    pin line (a model reading the repository) are three readers of one
+    identity. A disagreement mints two projects out of one directory — two
+    knowledge stores, two session pools — which is precisely the drift ADR-006
+    closed at the schema level and this check closes at the deployment level.
+
+    Side effects: reads the pin file, ``.mcp.json``, and ``CLAUDE.md``.
+    """
+    expected = ExpectedHookDeployment()
+    findings: list[Finding] = []
+    keys: dict[str, str] = {}
+
+    pin_path = project_dir / expected.pin_file
+    raw_pin = pin_path.read_text(encoding="utf-8", errors="replace").strip() if pin_path.is_file() else ""
+    if not raw_pin:
+        findings.append(
+            _bad(
+                "pin.trace_project_file",
+                f"{pin_path} is missing or empty — the hooks fall back to guessing this project's identity "
+                "from CLAUDE.md or the directory name. Re-run `trace-mcp-init`.",
+            )
+        )
+    elif (key := _canonical(raw_pin)) is None:
+        findings.append(_bad("pin.trace_project_file", f"{pin_path} holds {raw_pin!r}, which yields no usable key"))
+    else:
+        keys[expected.pin_file] = key
+        findings.append(_ok("pin.trace_project_file", f"pins '{key}'"))
+
+    entry, reason, upstream = _entry_or_reason(project_dir)
+    if entry is None:
+        findings.append(_unevaluated("pin.mcp_env", reason, upstream))
+    elif (pin := _env_pin(entry)) is None:
+        findings.append(
+            _bad(
+                "pin.mcp_env",
+                "the trace server entry has no env.TRACE_PROJECT pin — an unpinned server rejects "
+                "trace_start_session outright (which clients report as 'TRACE tools unavailable') and cannot "
+                "fail closed on cross-project reads. Re-run `trace-mcp-init`.",
+            )
+        )
+    elif (key := _canonical(pin)) is None:
+        findings.append(_bad("pin.mcp_env", f"env.TRACE_PROJECT is {pin!r}, which yields no usable key"))
+    else:
+        keys[".mcp.json env.TRACE_PROJECT"] = key
+        findings.append(_ok("pin.mcp_env", f"pins '{key}'"))
+
+    claude_md = project_dir / "CLAUDE.md"
+    match = (
+        _PIN_LINE_RE.search(claude_md.read_text(encoding="utf-8", errors="replace")) if claude_md.is_file() else None
+    )
+    if match is None:
+        findings.append(
+            _bad(
+                "pin.claude_md_line",
+                f'{claude_md} declares no machine-parseable `TRACE project name: "..."` line — a model reading '
+                "this repository has to guess the project. Re-run `trace-mcp-init`.",
+            )
+        )
+    elif (key := _canonical(match.group(1))) is None:
+        findings.append(
+            _bad("pin.claude_md_line", f"CLAUDE.md declares {match.group(1)!r}, which yields no usable key")
+        )
+    else:
+        keys["CLAUDE.md"] = key
+        findings.append(_ok("pin.claude_md_line", f"declares '{key}'"))
+
+    if len(keys) < 3:
+        missing = [site for site in (expected.pin_file, ".mcp.json env.TRACE_PROJECT", "CLAUDE.md") if site not in keys]
+        findings.append(_unevaluated("pin.coherence", f"pin site(s) {missing} unusable", "the pin.* checks above"))
+        return findings
+
+    distinct = sorted(set(keys.values()))
+    findings.append(
+        _bad(
+            "pin.coherence",
+            "the three pin sites disagree about this project's canonical key: "
+            + "; ".join(f"{site} → '{key}'" for site, key in sorted(keys.items()))
+            + ". One directory with two keys means two knowledge stores and two session pools. Repair with an "
+            "alias in the registry (`trace-mcp identity`) — never by rewriting captured sessions.",
+        )
+        if len(distinct) != 1
+        else _ok("pin.coherence", f"all three pin sites resolve to '{distinct[0]}'")
+    )
+    return findings
+
+
+# ── check_served_build (--live) ─────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class _LiveResult:
+    """Outcome of one handshake against a project's configured server command."""
+
+    version: str | None = None
+    tool_names: tuple[str, ...] = ()
+    error: str | None = None
+    stderr_tail: str = ""
+
+
+def check_served_build(project_dir: Path, *, live: bool = False, timeout: float | None = None) -> list[Finding]:
+    """Check what the project's own configured command actually serves.
+
+    Every other check reads files; this one is the only way to catch a
+    deployment whose config, hooks, and pins are all correct while the RUNNING
+    build is something else — a warm uv cache can serve a stale wheel for
+    minutes after a merge, even with ``--refresh-package``.
+
+    Side effects: with ``live=True``, **spawns the command from the project's
+    ``.mcp.json``** (with that entry's ``env`` layered over the current
+    environment, cwd set to *project_dir*), performs an MCP initialize +
+    tools/list handshake, and terminates it. Nothing is written. With
+    ``live=False`` (the default) nothing is spawned and all three checks are
+    reported as not evaluated.
+    """
+    if not live:
+        return [_unevaluated(c, "the served build is only probed when --live is given", None) for c in LIVE_CHECKS]
+
+    entry, reason, upstream = _entry_or_reason(project_dir)
+    if entry is None:
+        return [_unevaluated(c, reason, upstream) for c in LIVE_CHECKS]
+
+    expected = ExpectedServedBuild()
+    result = _handshake(entry, project_dir, timeout)
+    if result.error is not None:
+        detail = f"could not complete an MCP handshake with the configured command: {result.error}"
+        if result.stderr_tail:
+            detail += f"\n        server stderr: {result.stderr_tail}"
+        return [
+            _bad("live.spawn", detail),
+            *[_unevaluated(c, "the server did not answer", "live.spawn") for c in LIVE_CHECKS[1:]],
+        ]
+
+    findings = [_ok("live.spawn", "the configured command starts and completes an MCP handshake")]
+    findings.append(_check_live_version(result.version, expected.version))
+    findings.append(_check_live_tools(result.tool_names, expected.tool_total))
+    return findings
+
+
+def _check_live_version(found: str | None, expected: str) -> Finding:
+    if found == expected:
+        return _ok("live.version", f"the running server reports version {expected}")
+    direction = _which_side_is_behind(found, expected)
+    remedy = (
+        "A warm uv cache can keep serving an old wheel even with `--refresh-package`. Remedy: "
+        "`uv cache clean trace-mcp`, then restart the MCP server (in Claude Code, restart the session)."
+        if direction != "is NEWER than"
+        else "The CHECKER is the older side here: upgrade the trace-mcp you are running before trusting this report."
+    )
+    return _bad(
+        "live.version",
+        f"the running server reports version {found!r}, which {direction} this build's {expected!r} — the served "
+        f"build is not what this checker's expectations describe. {remedy}",
+    )
+
+
+def _check_live_tools(found: tuple[str, ...], expected_total: int) -> Finding:
+    surface = ExpectedToolSurface()
+    declared = set(surface.core_tools) | set(surface.learn_tools)
+    missing = sorted(declared - set(found))
+    extra = sorted(set(found) - declared)
+    if not missing and not extra:
+        return _ok("live.tool_surface", f"serves all {expected_total} expected tools")
+    detail = f"the running server serves {len(found)} tools, expected {expected_total}."
+    if missing:
+        detail += f" Missing: {missing}."
+        if set(missing) == set(surface.learn_tools):
+            detail += (
+                " Exactly the trace-learn tools are absent — the launch config is missing the "
+                f"`--with` extras {list(LEARN_EXTRAS)}."
+            )
+    if extra:
+        detail += f" Unexpected: {extra}."
+    return _bad("live.tool_surface", detail)
+
+
+def _handshake(entry: dict[str, Any], project_dir: Path, timeout: float | None) -> _LiveResult:
+    """Spawn the configured command and run initialize + tools/list over stdio.
+
+    Returns a ``_LiveResult`` for every outcome, including failure to start:
+    a broken deployment must produce a finding, never an exception.
+
+    Side effects: starts and terminates a subprocess.
+    """
+    command = entry.get("command")
+    if not isinstance(command, str) or not command:
+        return _LiveResult(error="the trace server entry declares no command to run")
+    budget = timeout if timeout is not None else float(os.environ.get(_LIVE_TIMEOUT, _DEFAULT_LIVE_TIMEOUT))
+    declared_env = entry.get("env")
+    overrides = declared_env if isinstance(declared_env, dict) else {}
+    env = {**os.environ, **{k: str(v) for k, v in overrides.items() if isinstance(k, str)}}
+
+    try:
+        proc = subprocess.Popen(  # noqa: S603 - the command is the project's own declared server, run on request
+            [command, *_args(entry)],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=str(project_dir),
+            env=env,
+            text=True,
+            bufsize=1,
+        )
+    except OSError as exc:
+        return _LiveResult(error=f"cannot execute {command!r}: {exc}")
+
+    lines: queue.Queue[str | None] = queue.Queue()
+    errors: list[str] = []
+    readers = [
+        threading.Thread(target=_pump, args=(proc.stdout, lines), daemon=True),
+        threading.Thread(target=_collect, args=(proc.stderr, errors), daemon=True),
+    ]
+    for reader in readers:
+        reader.start()
+
+    deadline = time.monotonic() + budget
+    try:
+        init = _request(
+            proc,
+            lines,
+            "initialize",
+            1,
+            deadline,
+            {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": "trace-mcp doctor", "version": ExpectedServedBuild().version},
+            },
+        )
+        if isinstance(init, str):
+            return _LiveResult(error=init, stderr_tail=_tail(errors))
+        _send(proc, {"jsonrpc": "2.0", "method": "notifications/initialized"})
+        tools = _request(proc, lines, "tools/list", 2, deadline, {})
+        if isinstance(tools, str):
+            return _LiveResult(error=tools, stderr_tail=_tail(errors))
+    finally:
+        _terminate(proc)
+
+    server_info = init.get("serverInfo")
+    raw_version = server_info.get("version") if isinstance(server_info, dict) else None
+    version = raw_version if isinstance(raw_version, str) else None
+    raw_tools = tools.get("tools")
+    names = (
+        tuple(t["name"] for t in raw_tools if isinstance(t, dict) and isinstance(t.get("name"), str))
+        if isinstance(raw_tools, list)
+        else ()
+    )
+    return _LiveResult(version=version, tool_names=names, stderr_tail=_tail(errors))
+
+
+_MAX_LINE = 4_000_000
+_OVERSIZE = "\x00trace-doctor:response-line-too-long\x00"
+"""Sentinel put in place of a line past the cap.
+
+The cap exists because the probe reads output from a process it did not write.
+It must sit far clear of the real protocol payload — a `tools/list` response
+for the current tool surface is already tens of kilobytes and grows with every
+tool and every description edit — and passing the cap must be REPORTED: a
+truncated line silently fails to parse as JSON, and skipping it turns a healthy
+server into a bogus timeout whose suggested remedy cannot help."""
+
+
+def _pump(stream: Any, sink: queue.Queue[str | None]) -> None:
+    """Feed a subprocess's stdout lines into a queue; ``None`` marks EOF."""
+    try:
+        for line in stream:
+            sink.put(line if len(line) <= _MAX_LINE else _OVERSIZE)
+    except ValueError:  # pragma: no cover - stream closed under us during teardown
+        pass
+    finally:
+        sink.put(None)
+
+
+def _collect(stream: Any, sink: list[str]) -> None:
+    """Accumulate a subprocess's stderr, bounded in both line count and length."""
+    try:
+        for line in stream:
+            if len(sink) < 200:
+                sink.append(line[:_MAX_LINE])
+    except ValueError:  # pragma: no cover - stream closed under us during teardown
+        pass
+
+
+def _tail(errors: list[str], limit: int = 800) -> str:
+    return "".join(errors).strip()[-limit:]
+
+
+def _send(proc: subprocess.Popen[str], message: dict[str, Any]) -> bool:
+    if proc.stdin is None:
+        return False
+    try:
+        proc.stdin.write(json.dumps(message) + "\n")
+        proc.stdin.flush()
+    except (BrokenPipeError, ValueError, OSError):
+        return False
+    return True
+
+
+def _request(
+    proc: subprocess.Popen[str],
+    lines: queue.Queue[str | None],
+    method: str,
+    request_id: int,
+    deadline: float,
+    params: dict[str, Any],
+) -> dict[str, Any] | str:
+    """Send one JSON-RPC request and return its ``result``, or an error string."""
+    if not _send(proc, {"jsonrpc": "2.0", "id": request_id, "method": method, "params": params}):
+        return f"the server closed its input before the {method} request could be sent"
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return f"no response to {method} within the timeout (raise {_LIVE_TIMEOUT} for a slow cold start)"
+        try:
+            line = lines.get(timeout=remaining)
+        except queue.Empty:
+            return f"no response to {method} within the timeout (raise {_LIVE_TIMEOUT} for a slow cold start)"
+        if line is None:
+            code = proc.poll()
+            return f"the server exited (status {code}) before answering {method}"
+        if line == _OVERSIZE:
+            return f"the server sent a response line larger than {_MAX_LINE} bytes while answering {method}"
+        try:
+            message = json.loads(line)
+        except json.JSONDecodeError:
+            continue  # servers may emit non-protocol chatter on stdout
+        if not isinstance(message, dict) or message.get("id") != request_id:
+            continue
+        if "error" in message:
+            return f"{method} returned a protocol error: {message['error']}"
+        result = message.get("result")
+        return result if isinstance(result, dict) else {}
+
+
+def _terminate(proc: subprocess.Popen[str]) -> None:
+    """Close the server down; kill it if it will not go."""
+    try:
+        if proc.stdin is not None:
+            proc.stdin.close()
+    except (BrokenPipeError, OSError):
+        pass
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait(timeout=5)
+
+
+__all__ = [
+    "CONFIG_CHECKS",
+    "HOOK_CHECKS",
+    "LIVE_CHECKS",
+    "PIN_CHECKS",
+    "check_config",
+    "check_hooks",
+    "check_pin_coherence",
+    "check_served_build",
+]

--- a/src/trace_mcp/server.py
+++ b/src/trace_mcp/server.py
@@ -993,6 +993,14 @@ def main() -> None:
 
         raise SystemExit(identity_main(sys.argv[2:]))
 
+    if len(sys.argv) > 1 and sys.argv[1] == "doctor":
+        # Imported lazily like the other subcommands: the conformance layer
+        # pulls in the adapter assets, which the running server must never
+        # depend on (adapters are pure installers).
+        from trace_mcp.conformance.cli import main as doctor_main
+
+        raise SystemExit(doctor_main(sys.argv[2:]))
+
     if len(sys.argv) > 1 and sys.argv[1] == "validate":
         # In-package validator (schema ships as package data) — the previous
         # repo-relative load of scripts/validate_session.py crashed on any

--- a/tests/test_conformance_doctor.py
+++ b/tests/test_conformance_doctor.py
@@ -1,0 +1,769 @@
+"""Deployed-state conformance — `trace-mcp doctor` (`trace_mcp.conformance`).
+
+The failure class this suite exists to catch is *source tree green, deployed
+system rotten*: hook copies that predate the current release, a PostToolUse
+matcher that never fires because it names a bare tool name instead of the
+host-namespaced one, a project carrying no `TRACE_PROJECT` pin, a served build
+that is a stale wheel from a warm uv cache. None of those are visible to the
+rest of the suite — every one of them was found by hand.
+
+The load-bearing property is **INV-11: a freshly initialized project is
+doctor-clean.** It ties the shipped installer to the shipped expectations, so
+template rot — a dead hook matcher shipped in `settings_template.json` for
+several releases — fails at PR time instead of on a consumer's machine months
+later. Every other test here breaks exactly one aspect of a fresh install and
+asserts exactly one check fails, which is also what pins the report's
+one-fail-per-root-cause contract.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import stat
+import sys
+from pathlib import Path
+
+import pytest
+
+import trace_mcp
+from trace_mcp import project_identity as pident
+from trace_mcp.adapters import get_adapter, list_adapters
+from trace_mcp.adapters.base import MCP_SERVER_KEY
+from trace_mcp.conformance import DoctorReport, expectations, run_doctor
+from trace_mcp.conformance.cli import main as doctor_main
+from trace_mcp.init_project import LEARN_EXTRAS, init_project
+
+REPO_ROOT = Path(__file__).parent.parent
+README = REPO_ROOT / "README.md"
+
+# The served-build checks are only evaluated under --live; every offline run
+# reports them as skipped, so assertions about "nothing unevaluated" exclude them.
+LIVE_CHECKS = {"live.spawn", "live.version", "live.tool_surface"}
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _failed(report: DoctorReport) -> set[str]:
+    return {f.check for f in report.findings if f.status == "fail"}
+
+
+def _skipped(report: DoctorReport) -> set[str]:
+    return {f.check for f in report.findings if f.status == "skip"}
+
+
+def _detail(report: DoctorReport, check: str) -> str:
+    return next(f.detail for f in report.findings if f.check == check)
+
+
+def _read_mcp_json(project_dir: Path) -> dict:
+    return json.loads((project_dir / ".mcp.json").read_text())
+
+
+def _write_mcp_json(project_dir: Path, config: dict) -> None:
+    (project_dir / ".mcp.json").write_text(json.dumps(config, indent=2) + "\n")
+
+
+def _without_with_pairs(args: list[str]) -> list[str]:
+    """Drop every ``--with <pkg>`` pair, leaving the rest of the launch args intact."""
+    stripped: list[str] = []
+    i = 0
+    while i < len(args):
+        if args[i] == "--with" and i + 1 < len(args):
+            i += 2
+            continue
+        stripped.append(args[i])
+        i += 1
+    return stripped
+
+
+def _settings_path(project_dir: Path) -> Path:
+    return project_dir / ".claude" / "settings.json"
+
+
+def _readme_tools(heading: str) -> list[str]:
+    """Tool names in the markdown table under *heading* in README.md."""
+    text = README.read_text()
+    start = text.index(heading) + len(heading)
+    rest = text[start:]
+    end = rest.find("\n## ")
+    nxt = rest.find("\n### ")
+    if nxt != -1 and (end == -1 or nxt < end):
+        end = nxt
+    section = rest if end == -1 else rest[:end]
+    return re.findall(r"^\|\s*`(trace_\w+)`", section, flags=re.MULTILINE)
+
+
+def _make_project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, client: str) -> Path:
+    """Initialize a project directory exactly as `trace-mcp-init` would.
+
+    Side effects: writes under *tmp_path*, enrolls the project in the
+    test-isolated registry, and points `TRACE_SOURCE_PATH` at a real directory
+    so the written `--from` source resolves (the doctor checks that a
+    filesystem source exists).
+    """
+    source = tmp_path / "TRACE-checkout"
+    source.mkdir(exist_ok=True)
+    monkeypatch.setenv("TRACE_SOURCE_PATH", str(source))
+    monkeypatch.setenv("TRACE_REGISTRY_PATH", str(tmp_path / "projects.json"))
+    pident._reset_registry_cache()
+    project_dir = tmp_path / "demo-project"
+    project_dir.mkdir(exist_ok=True)
+    init_project(str(project_dir), client=client)
+    pident._reset_registry_cache()
+    return project_dir
+
+
+@pytest.fixture()
+def project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A project freshly initialized with the Claude Code adapter."""
+    return _make_project(tmp_path, monkeypatch, client="claude-code")
+
+
+# ── INV-11: a fresh install is doctor-clean ─────────────────────────────────
+
+
+@pytest.mark.parametrize("adapter_name", sorted(list_adapters()))
+def test_fresh_init_is_doctor_clean(adapter_name: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """INV-11 — every adapter TRACE actually installs must produce a clean project.
+
+    Enumerated over the adapter registry rather than hard-coded to Claude Code:
+    when a new host adapter ships, this test starts exercising it, and the
+    doctor must learn that host's layout or the guard fails. That is the point
+    — the dead decision-audit matcher survived four releases precisely because
+    nothing compared the installer's output against the expectations.
+    """
+    probe = tmp_path / "adapter-probe"
+    probe.mkdir()
+    try:
+        get_adapter(adapter_name).install(probe, dry_run=True)
+    except NotImplementedError:
+        pytest.skip(f"{adapter_name} adapter is a placeholder — install() is not implemented")
+
+    project_dir = _make_project(tmp_path, monkeypatch, client=adapter_name)
+    report = run_doctor(project_dir)
+
+    assert report.ok, f"fresh {adapter_name} install is not doctor-clean: {_failed(report)}\n{report.render()}"
+    assert _skipped(report) <= LIVE_CHECKS, (
+        f"a fresh install should leave nothing unevaluated but the served build: {_skipped(report) - LIVE_CHECKS}"
+    )
+
+
+def test_report_ok_is_false_exactly_when_a_check_fails(project: Path) -> None:
+    assert run_doctor(project).ok
+    (project / ".claude" / "hooks" / "decision-audit.sh").unlink()
+    assert not run_doctor(project).ok
+
+
+# ── Expectations are derived, not restated ──────────────────────────────────
+
+
+def test_expected_tool_surface_matches_registered_tools() -> None:
+    """The declared surface must equal what the server actually registers."""
+    from trace_mcp.selfcost import _list_registered_tools
+
+    registered = {name for name, _desc, _schema in _list_registered_tools(include_extensions=True)}
+    surface = expectations.ExpectedToolSurface()
+    declared = set(surface.core_tools) | set(surface.learn_tools)
+    assert declared == registered, (
+        f"declared-but-unregistered: {sorted(declared - registered)}; "
+        f"registered-but-undeclared: {sorted(registered - declared)}"
+    )
+
+
+def test_expected_tool_surface_matches_readme_tables() -> None:
+    """README is the documented surface; the constants must not drift from it."""
+    surface = expectations.ExpectedToolSurface()
+    assert list(surface.core_tools) == _readme_tools("### Core tools (17)")
+    assert list(surface.learn_tools) == _readme_tools("### Extension: trace-learn (5)")
+
+
+def test_expected_tool_total_is_the_documented_22() -> None:
+    surface = expectations.ExpectedToolSurface()
+    assert surface.total == 22 == len(surface.core_tools) + len(surface.learn_tools)
+    assert "22 total" in README.read_text()
+
+
+def test_hook_expectations_derive_from_the_shipped_assets() -> None:
+    """Filenames and the version stamp come from the assets, never retyped."""
+    assets = REPO_ROOT / "src" / "trace_mcp" / "adapters" / "claude_code" / "assets" / "hooks"
+    shipped = {p.name for p in assets.glob("*.sh")}
+    hooks = expectations.ExpectedHookDeployment()
+
+    assert set(hooks.hook_files) == shipped
+    assert shipped, "positive control: the assets directory must not be empty"
+    assert re.fullmatch(r"\[trace-hooks v[\d.]+\]", hooks.version_stamp)
+    for name in shipped:
+        assert hooks.version_stamp in (assets / name).read_text()
+
+
+def test_decision_audit_matcher_derives_from_the_server_key() -> None:
+    """A bare tool-name matcher never fires; the namespaced form is mandatory."""
+    hooks = expectations.ExpectedHookDeployment()
+    assert hooks.decision_audit_matcher == f"mcp__{MCP_SERVER_KEY}__trace_end_session"
+
+
+def test_expected_served_build_reads_the_package_version() -> None:
+    assert expectations.ExpectedServedBuild().version == trace_mcp.__version__
+    assert expectations.ExpectedServedBuild().tool_total == expectations.ExpectedToolSurface().total
+
+
+# ── .mcp.json config checks ─────────────────────────────────────────────────
+
+
+def test_missing_mcp_json_fails_once_and_skips_dependents(project: Path) -> None:
+    """One fail per root cause: dependents report an explicit skip, not silence."""
+    (project / ".mcp.json").unlink()
+    report = run_doctor(project)
+
+    assert _failed(report) == {"config.file"}
+    assert {"config.command", "config.source", "config.learn_extras", "config.refresh"} <= _skipped(report)
+    assert "config.file" in _detail(report, "config.command")
+
+
+def test_unparseable_mcp_json_fails_config_file(project: Path) -> None:
+    (project / ".mcp.json").write_text("{not json")
+    assert _failed(run_doctor(project)) == {"config.file"}
+
+
+def test_absent_trace_entry_fails_server_entry(project: Path) -> None:
+    _write_mcp_json(project, {"mcpServers": {"other": {"command": "node"}}})
+    report = run_doctor(project)
+    assert "config.server_entry" in _failed(report)
+    assert MCP_SERVER_KEY in _detail(report, "config.server_entry")
+
+
+def test_missing_learn_extras_fails_and_explains_the_17_tool_symptom(project: Path) -> None:
+    config = _read_mcp_json(project)
+    assert all(pkg in config["mcpServers"][MCP_SERVER_KEY]["args"] for pkg in LEARN_EXTRAS), (
+        "positive control: a fresh init must carry the extras this test then strips"
+    )
+    entry = config["mcpServers"][MCP_SERVER_KEY]
+    entry["args"] = _without_with_pairs(entry["args"])
+    _write_mcp_json(project, config)
+
+    report = run_doctor(project)
+    assert _failed(report) == {"config.learn_extras"}
+    detail = _detail(report, "config.learn_extras")
+    assert "17" in detail and "22" in detail
+
+
+def test_missing_refresh_flag_fails(project: Path) -> None:
+    config = _read_mcp_json(project)
+    entry = config["mcpServers"][MCP_SERVER_KEY]
+    entry["args"] = [a for a in entry["args"] if a not in ("--refresh-package", "--refresh")]
+    _write_mcp_json(project, config)
+    assert _failed(run_doctor(project)) == {"config.refresh"}
+
+
+def test_non_uvx_command_fails(project: Path) -> None:
+    config = _read_mcp_json(project)
+    config["mcpServers"][MCP_SERVER_KEY]["command"] = "python"
+    _write_mcp_json(project, config)
+    assert _failed(run_doctor(project)) == {"config.command"}
+
+
+def _set_source(project_dir: Path, source: str) -> None:
+    config = _read_mcp_json(project_dir)
+    args = config["mcpServers"][MCP_SERVER_KEY]["args"]
+    args[args.index("--from") + 1] = source
+    _write_mcp_json(project_dir, config)
+
+
+def test_relative_source_resolves_against_the_project_not_the_checker(project: Path) -> None:
+    """`--from .` is what this repository's own config uses; uvx reads it relative
+    to the project, so a checker that resolves it against its own cwd reports the
+    same project healthy or broken depending on where it was run from."""
+    _set_source(project, ".")
+    assert run_doctor(project).ok
+
+
+def test_bare_pypi_name_source_fails_as_dependency_confusion(project: Path) -> None:
+    """`--from trace-mcp` would fetch an unrelated PyPI package and run it."""
+    _set_source(project, "trace-mcp")
+    report = run_doctor(project)
+    assert _failed(report) == {"config.source"}
+    assert "dependency confusion" in _detail(report, "config.source").lower()
+
+
+def test_git_ref_source_is_accepted(project: Path) -> None:
+    """The documented onboarding path pins a git ref rather than a local path."""
+    _set_source(project, "git+https://github.com/Thru-Echoes/TRACE@main")
+    assert run_doctor(project).ok
+
+
+def test_vanished_source_checkout_fails(project: Path) -> None:
+    """A `--from` path that no longer exists is a dead server, not a warning."""
+    config = _read_mcp_json(project)
+    args = config["mcpServers"][MCP_SERVER_KEY]["args"]
+    args[args.index("--from") + 1] = str(project / "does-not-exist")
+    _write_mcp_json(project, config)
+    assert _failed(run_doctor(project)) == {"config.source"}
+
+
+@pytest.mark.parametrize(
+    "entry",
+    [
+        "not-an-object",
+        {"command": "uvx", "args": {"not": "a list"}},
+        {"command": "uvx", "args": ["--from", "."], "env": ["not", "an", "object"]},
+        {},
+    ],
+    ids=["string-entry", "dict-args", "list-env", "empty-entry"],
+)
+def test_malformed_config_shapes_report_findings_rather_than_crashing(project: Path, entry: object) -> None:
+    """Fleet sweeps read configs nobody validated — a malformed one must not
+    take the checker down, and must not be waved through either."""
+    _write_mcp_json(project, {"mcpServers": {MCP_SERVER_KEY: entry}})
+    report = run_doctor(project)
+    assert not report.ok
+    assert not [f for f in report.findings if f.check.endswith(".probe_error")], report.render()
+
+
+# ── hook deployment checks ──────────────────────────────────────────────────
+
+
+def test_missing_hook_file_fails(project: Path) -> None:
+    (project / ".claude" / "hooks" / "pretool-guard.sh").unlink()
+    report = run_doctor(project)
+    assert _failed(report) == {"hooks.present"}
+    assert "pretool-guard.sh" in _detail(report, "hooks.present")
+
+
+def test_non_executable_hook_fails(project: Path) -> None:
+    hook = project / ".claude" / "hooks" / "session-reminder.sh"
+    hook.chmod(stat.S_IRUSR | stat.S_IWUSR)
+    report = run_doctor(project)
+    assert _failed(report) == {"hooks.executable"}
+    assert "session-reminder.sh" in _detail(report, "hooks.executable")
+
+
+def test_stale_hook_copy_fails_on_the_version_stamp(project: Path) -> None:
+    """The 17-project stale-fleet finding, reduced to a test."""
+    hook = project / ".claude" / "hooks" / "decision-audit.sh"
+    stamp = expectations.ExpectedHookDeployment().version_stamp
+    hook.write_text(hook.read_text().replace(stamp, "[trace-hooks v0.1]"))
+    report = run_doctor(project)
+    assert _failed(report) == {"hooks.stamp"}
+    assert "decision-audit.sh" in _detail(report, "hooks.stamp")
+
+
+def test_dead_short_decision_audit_matcher_fails(project: Path) -> None:
+    """The exact defect that left 15 of 17 deployed projects with a dead hook."""
+    settings = json.loads(_settings_path(project).read_text())
+    for entry in settings["hooks"]["PostToolUse"]:
+        entry["matcher"] = "trace_end_session"
+    _settings_path(project).write_text(json.dumps(settings, indent=2))
+
+    report = run_doctor(project)
+    assert _failed(report) == {"hooks.decision_audit_matcher"}
+    detail = _detail(report, "hooks.decision_audit_matcher")
+    assert "trace_end_session" in detail and f"mcp__{MCP_SERVER_KEY}__trace_end_session" in detail
+
+
+def test_unregistered_hook_script_fails(project: Path) -> None:
+    """A hook file on disk that nothing invokes is dead weight, not a deployment."""
+    settings = json.loads(_settings_path(project).read_text())
+    settings["hooks"].pop("UserPromptSubmit")
+    _settings_path(project).write_text(json.dumps(settings, indent=2))
+
+    report = run_doctor(project)
+    assert _failed(report) == {"hooks.registered"}
+    assert "prompt-reminder.sh" in _detail(report, "hooks.registered")
+
+
+def test_unparseable_settings_fails_once_and_skips_dependents(project: Path) -> None:
+    _settings_path(project).write_text("{not json")
+    report = run_doctor(project)
+    assert _failed(report) == {"hooks.settings"}
+    assert {"hooks.registered", "hooks.decision_audit_matcher"} <= _skipped(report)
+
+
+def test_missing_settings_fails(project: Path) -> None:
+    _settings_path(project).unlink()
+    assert _failed(run_doctor(project)) == {"hooks.settings"}
+
+
+def test_missing_hooks_directory_fails(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A project with `.mcp.json` but no adapter install: the 7-config population."""
+    project_dir = _make_project(tmp_path, monkeypatch, client="none")
+    report = run_doctor(project_dir)
+    assert {"hooks.present", "hooks.settings"} <= _failed(report)
+
+
+def test_hook_registered_under_the_wrong_event_fails(project: Path) -> None:
+    """A hook on the wrong event is installed, current, executable — and inert.
+
+    Moving the decision-audit registration off PostToolUse leaves it unable to
+    ever fire on session end: the same defect as a matcher that never matches,
+    one level up.
+    """
+    settings = json.loads(_settings_path(project).read_text())
+    settings["hooks"].setdefault("PreToolUse", []).extend(settings["hooks"].pop("PostToolUse"))
+    _settings_path(project).write_text(json.dumps(settings, indent=2))
+
+    report = run_doctor(project)
+    assert _failed(report) == {"hooks.registered"}
+    detail = _detail(report, "hooks.registered")
+    assert "decision-audit.sh" in detail and "PostToolUse" in detail
+    assert "hooks.decision_audit_matcher" in _skipped(report)
+
+
+def test_leftover_stamped_hook_from_an_older_release_fails(project: Path) -> None:
+    """A hook this build no longer ships keeps running old semantics forever."""
+    stamp = expectations.ExpectedHookDeployment().version_stamp
+    orphan = project / ".claude" / "hooks" / "legacy-check.sh"
+    orphan.write_text(f"#!/bin/bash\necho 'old behaviour {stamp}'\n")
+
+    report = run_doctor(project)
+    assert _failed(report) == {"hooks.unknown"}
+    assert "legacy-check.sh" in _detail(report, "hooks.unknown")
+
+
+def test_a_projects_own_unstamped_hook_is_not_flagged(project: Path) -> None:
+    """Only TRACE-stamped scripts are ours to judge."""
+    (project / ".claude" / "hooks" / "my-own-hook.sh").write_text("#!/bin/bash\necho hi\n")
+    assert run_doctor(project).ok
+
+
+def test_newer_deployed_hooks_blame_the_checker_not_the_project(project: Path) -> None:
+    """A sweep run with an older trace-mcp must not tell a current project to downgrade."""
+    hook = project / ".claude" / "hooks" / "decision-audit.sh"
+    stamp = expectations.ExpectedHookDeployment().version_stamp
+    hook.write_text(hook.read_text().replace(stamp, "[trace-hooks v99.9]"))
+
+    detail = _detail(run_doctor(project), "hooks.stamp")
+    assert "NEWER" in detail
+    assert "upgrade the trace-mcp" in detail
+
+
+def test_tilde_source_fails_because_only_a_shell_expands_it(project: Path) -> None:
+    """The host executes uvx directly, so a `~` is taken literally and resolved
+    against the working directory — verified against uv itself."""
+    _set_source(project, "~/Documents/TRACE")
+    report = run_doctor(project)
+    assert _failed(report) == {"config.source"}
+    assert "~" in _detail(report, "config.source")
+
+
+@pytest.mark.parametrize("spelling", ["trace_mcp", "Trace-MCP", "trace-mcp==0.5.0", "trace.mcp"])
+def test_pypi_name_variants_all_fail_as_dependency_confusion(project: Path, spelling: str) -> None:
+    """PyPI normalizes names, so an exact-string check would wave three of these through."""
+    _set_source(project, spelling)
+    report = run_doctor(project)
+    assert _failed(report) == {"config.source"}
+    assert "dependency confusion" in _detail(report, "config.source").lower()
+
+
+def test_source_pointing_at_a_plain_file_fails(project: Path) -> None:
+    """An existing path is not automatically something uvx can build."""
+    stray = project / "notes.txt"
+    stray.write_text("not a project\n")
+    _set_source(project, str(stray))
+    report = run_doctor(project)
+    assert _failed(report) == {"config.source"}
+
+
+def test_launch_args_without_a_command_fail(project: Path) -> None:
+    """`--refresh-package trace-mcp` ends with the same word as a correct entry
+    but names no command at all, so uvx starts nothing."""
+    config = _read_mcp_json(project)
+    entry = config["mcpServers"][MCP_SERVER_KEY]
+    entry["args"] = entry["args"][:-1]
+    _write_mcp_json(project, config)
+
+    report = run_doctor(project)
+    assert _failed(report) == {"config.entrypoint"}
+    assert "trace-mcp" in _detail(report, "config.entrypoint")
+
+
+def test_launch_args_running_the_wrong_command_fail(project: Path) -> None:
+    config = _read_mcp_json(project)
+    entry = config["mcpServers"][MCP_SERVER_KEY]
+    entry["args"] = [*entry["args"][:-1], "some-other-tool"]
+    _write_mcp_json(project, config)
+    assert _failed(run_doctor(project)) == {"config.entrypoint"}
+
+
+# ── project-pin coherence ───────────────────────────────────────────────────
+
+
+def test_missing_pin_file_fails_and_skips_coherence(project: Path) -> None:
+    (project / ".claude" / "trace.project").unlink()
+    report = run_doctor(project)
+    assert _failed(report) == {"pin.trace_project_file"}
+    assert "pin.coherence" in _skipped(report)
+
+
+def test_missing_env_pin_fails(project: Path) -> None:
+    config = _read_mcp_json(project)
+    config["mcpServers"][MCP_SERVER_KEY].pop("env")
+    _write_mcp_json(project, config)
+    report = run_doctor(project)
+    assert _failed(report) == {"pin.mcp_env"}
+    assert "TRACE_PROJECT" in _detail(report, "pin.mcp_env")
+
+
+def test_missing_claude_md_pin_line_fails(project: Path) -> None:
+    claude_md = project / "CLAUDE.md"
+    claude_md.write_text(re.sub(r'TRACE project name\**\s*:\s*"[^"]+"', "", claude_md.read_text()))
+    report = run_doctor(project)
+    assert _failed(report) == {"pin.claude_md_line"}
+
+
+def test_divergent_pins_fail_coherence(project: Path) -> None:
+    """Three pin sites, one identity: a disagreement mints two projects."""
+    (project / ".claude" / "trace.project").write_text("some-other-key\n")
+    report = run_doctor(project)
+    assert _failed(report) == {"pin.coherence"}
+    detail = _detail(report, "pin.coherence")
+    assert "some-other-key" in detail and "demo-project" in detail
+
+
+def test_bold_claude_md_pin_line_is_accepted(project: Path) -> None:
+    """The bold form is what this repository itself writes — it must not drift."""
+    claude_md = project / "CLAUDE.md"
+    claude_md.write_text(
+        re.sub(
+            r'TRACE project name\**\s*:\s*"([^"]+)"',
+            r'**TRACE project name**: "\1"',
+            claude_md.read_text(),
+        )
+    )
+    assert run_doctor(project).ok
+
+
+def test_case_and_separator_variants_are_the_same_pin(project: Path) -> None:
+    """Coherence compares canonical keys, never free-text labels (INV-4)."""
+    (project / ".claude" / "trace.project").write_text("Demo_Project\n")
+    assert run_doctor(project).ok
+
+
+# ── report + CLI surface ────────────────────────────────────────────────────
+
+
+def test_report_json_round_trips(project: Path) -> None:
+    report = run_doctor(project)
+    restored = DoctorReport.model_validate_json(report.model_dump_json())
+    assert restored.ok == report.ok
+    assert [f.check for f in restored.findings] == [f.check for f in report.findings]
+    assert "ok" in json.loads(report.model_dump_json()), "ok must survive serialization for fleet-check"
+
+
+def test_cli_exits_zero_on_a_clean_project(project: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    assert doctor_main([str(project)]) == 0
+    assert "PASS" in capsys.readouterr().out
+
+
+def test_cli_exits_nonzero_on_findings(project: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    (project / ".claude" / "trace.project").unlink()
+    assert doctor_main([str(project)]) == 1
+    assert "FAIL" in capsys.readouterr().out
+
+
+def test_cli_json_output_parses_as_a_report(project: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    assert doctor_main([str(project), "--json"]) == 0
+    report = DoctorReport.model_validate_json(capsys.readouterr().out)
+    assert report.ok
+
+
+def test_cli_rejects_a_non_directory_with_a_distinct_exit_code(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A bad path is not an unhealthy project, and `--json` stdout must stay parseable."""
+    assert doctor_main([str(tmp_path / "nope"), "--json"]) == 2
+    captured = capsys.readouterr()
+    assert "not a directory" in captured.err.lower()
+    assert captured.out.strip() == "", "a usage diagnostic on stdout would break a --json consumer"
+
+
+def test_offline_run_reports_the_live_probe_as_skipped(project: Path) -> None:
+    """Without --live the served build is unevaluated — say so, never imply pass."""
+    report = run_doctor(project)
+    assert LIVE_CHECKS <= _skipped(report)
+    for check in LIVE_CHECKS:
+        assert "--live" in _detail(report, check)
+
+
+def test_a_clean_run_emits_exactly_the_declared_check_ids(project: Path) -> None:
+    """Check ids are stable API for fleet tooling — a rename or a dropped check
+    must break here rather than silently in a consumer."""
+    from trace_mcp.conformance import CONFIG_CHECKS, HOOK_CHECKS, LIVE_CHECKS, PIN_CHECKS
+
+    declared = [*CONFIG_CHECKS, *HOOK_CHECKS, *PIN_CHECKS, *LIVE_CHECKS]
+    emitted = [f.check for f in run_doctor(project).findings]
+    assert sorted(emitted) == sorted(declared)
+    assert len(emitted) == len(set(emitted)), "each check must be reported exactly once"
+
+
+def test_a_crashing_probe_keeps_its_check_ids_present(project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A probe bug must not make a whole group of ids vanish from the report."""
+    import trace_mcp.conformance as conformance
+    from trace_mcp.conformance import HOOK_CHECKS
+
+    def boom(_project_dir: Path) -> list[expectations.Finding]:
+        raise RuntimeError("probe exploded")
+
+    monkeypatch.setattr(
+        conformance,
+        "_OFFLINE_PROBES",
+        tuple((name, boom if name == "hooks" else probe, owned) for name, probe, owned in conformance._OFFLINE_PROBES),
+    )
+    report = run_doctor(project)
+
+    assert not report.ok
+    assert "hooks.probe_error" in _failed(report)
+    assert set(HOOK_CHECKS) <= _skipped(report)
+    assert "probe exploded" in _detail(report, "hooks.probe_error")
+
+
+def test_server_cli_dispatches_doctor(project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """`trace-mcp doctor` must reach the doctor, not fall through to the server."""
+    from trace_mcp import server as srv
+
+    monkeypatch.setattr(sys, "argv", ["trace-mcp", "doctor", str(project)])
+    with pytest.raises(SystemExit) as exc:
+        srv.main()
+    assert exc.value.code == 0
+
+
+# ── --live: the served build ────────────────────────────────────────────────
+#
+# THE MOTIVATING INCIDENT: after a set of merges, a warm uv cache served a
+# STALE wheel for ~20 minutes despite `--refresh-package` — the source tree,
+# the config, and the hooks were all correct, and only the identity of the
+# RUNNING build was wrong. Nothing but a handshake against the project's own
+# configured command can catch that, so the probe is exercised here against
+# both a real server and a deliberately stale impostor.
+
+_FAKE_STALE_SERVER = """
+import json, sys
+for line in sys.stdin:
+    line = line.strip()
+    if not line:
+        continue
+    msg = json.loads(line)
+    if msg.get("id") is None:
+        continue
+    if msg.get("method") == "initialize":
+        result = {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "serverInfo": {"name": "trace", "version": "0.0.1"},
+        }
+    elif msg.get("method") == "tools/list":
+        result = {"tools": [{"name": "trace_start_session"}]}
+    else:
+        result = {}
+    print(json.dumps({"jsonrpc": "2.0", "id": msg["id"], "result": result}), flush=True)
+"""
+
+
+def _with_server_command(project_dir: Path, command: str, args: list[str], env: dict[str, str]) -> None:
+    """Point the project's trace entry at *command* so --live spawns it."""
+    config = _read_mcp_json(project_dir)
+    entry = config["mcpServers"][MCP_SERVER_KEY]
+    entry["command"] = command
+    entry["args"] = args
+    entry["env"] = {**entry.get("env", {}), **env}
+    _write_mcp_json(project_dir, config)
+
+
+def _offline_server_env() -> dict[str, str]:
+    """Deterministic, offline server env — mirrors the e2e harness."""
+    return {
+        "PYTHONPATH": str(REPO_ROOT / "src") + os.pathsep + os.environ.get("PYTHONPATH", ""),
+        "TRACE_EMBEDDING_BACKEND": "none",
+        "TRACE_LLM_ENABLED": "false",
+        "TRACE_STRICT_LLM": "false",
+    }
+
+
+class TestLiveProbe:
+    """`--live` spawns the project's OWN configured command and handshakes with it."""
+
+    def test_real_server_passes_version_and_tool_surface(self, project: Path) -> None:
+        _with_server_command(project, sys.executable, ["-m", "trace_mcp.server"], _offline_server_env())
+        report = run_doctor(project, live=True)
+
+        live = {f.check: f for f in report.findings if f.check.startswith("live.")}
+        assert live["live.spawn"].status == "pass", live["live.spawn"].detail
+        assert live["live.version"].status == "pass", live["live.version"].detail
+        assert live["live.tool_surface"].status == "pass", live["live.tool_surface"].detail
+        assert trace_mcp.__version__ in live["live.version"].detail
+
+    def test_stale_build_is_caught_and_the_remedy_is_named(self, project: Path) -> None:
+        script = project / "stale_server.py"
+        script.write_text(_FAKE_STALE_SERVER)
+        _with_server_command(project, sys.executable, [str(script)], {})
+        report = run_doctor(project, live=True)
+
+        failed = _failed(report)
+        assert "live.version" in failed and "live.tool_surface" in failed
+        version_detail = _detail(report, "live.version")
+        assert "0.0.1" in version_detail and trace_mcp.__version__ in version_detail
+        assert "uv cache clean" in version_detail, "the finding must carry the remedy, not just the diagnosis"
+        assert "22" in _detail(report, "live.tool_surface")
+
+    def test_spawn_failure_is_a_finding_not_an_exception(self, project: Path) -> None:
+        _with_server_command(
+            project,
+            sys.executable,
+            ["-c", "import sys; sys.stderr.write('boom: dependency resolution failed\\n'); raise SystemExit(3)"],
+            {},
+        )
+        report = run_doctor(project, live=True)
+
+        assert "live.spawn" in _failed(report)
+        assert "boom" in _detail(report, "live.spawn"), "a spawn failure must carry the server's stderr tail"
+        assert {"live.version", "live.tool_surface"} <= _skipped(report)
+
+    def test_a_newer_served_build_blames_the_checker(self, project: Path) -> None:
+        """When the running server is ahead, telling its owner to clear a cache is
+        the wrong instruction — the checker is the stale side."""
+        script = project / "future_server.py"
+        script.write_text(_FAKE_STALE_SERVER.replace('"0.0.1"', '"99.0.0"'))
+        _with_server_command(project, sys.executable, [str(script)], {})
+
+        detail = _detail(run_doctor(project, live=True), "live.version")
+        assert "NEWER" in detail
+        assert "upgrade the trace-mcp" in detail
+
+    def test_an_oversized_response_line_is_reported_explicitly(
+        self, project: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Silently dropping an over-long line turns a healthy server into a bogus
+        timeout whose suggested remedy cannot help. The real tools/list response
+        is already tens of kilobytes and grows with every tool."""
+        from trace_mcp.conformance import probes
+
+        monkeypatch.setattr(probes, "_MAX_LINE", 20)
+        script = project / "stale_server.py"
+        script.write_text(_FAKE_STALE_SERVER)
+        _with_server_command(project, sys.executable, [str(script)], {})
+
+        report = run_doctor(project, live=True)
+        detail = _detail(report, "live.spawn")
+        assert "larger than 20 bytes" in detail
+        assert "timeout" not in detail.lower(), "an over-long line must not be misreported as a timeout"
+
+    def test_malformed_env_block_does_not_crash_the_probe(self, project: Path) -> None:
+        """A hand-edited config can carry any shape; the probe spawns without it."""
+        script = project / "stale_server.py"
+        script.write_text(_FAKE_STALE_SERVER)
+        config = _read_mcp_json(project)
+        entry = config["mcpServers"][MCP_SERVER_KEY]
+        entry["command"], entry["args"], entry["env"] = sys.executable, [str(script)], ["not", "an", "object"]
+        _write_mcp_json(project, config)
+
+        report = run_doctor(project, live=True)
+        assert not [f for f in report.findings if f.check.endswith(".probe_error")], report.render()
+        assert _detail(report, "live.spawn").startswith("the configured command starts")
+
+    def test_unrunnable_config_skips_the_live_probe(self, project: Path) -> None:
+        (project / ".mcp.json").unlink()
+        report = run_doctor(project, live=True)
+        assert "live.spawn" in _skipped(report)
+        assert not report.ok  # the config failure still stands

--- a/tests/test_packaging_artifacts.py
+++ b/tests/test_packaging_artifacts.py
@@ -205,6 +205,73 @@ class TestWheelInstallE2E:
         assert bad.returncode == 1, f"Expected exit 1 for invalid doc, got {bad.returncode}: {bad.stdout}"
         assert "FAIL" in bad.stdout
 
+    def test_trace_mcp_doctor_works_from_wheel_install(self, built_dist: dict[str, Path], tmp_path: Path) -> None:
+        """INV-11 against the SHIPPED artifact, not the source tree.
+
+        `trace-mcp doctor` derives its expectations from packaged data (the
+        adapter's hook assets), exactly like `trace-mcp-init` copies them — so
+        a sdist-allowlist gap would leave the doctor dead on arrival from a
+        wheel install while every source-tree test stayed green. This installs
+        the wheel, initializes a project with the installed console script, and
+        checks it with the installed doctor: a fresh install must be clean.
+        """
+        venv_dir = tmp_path / "venv"
+        subprocess.run(["uv", "venv", str(venv_dir)], check=True, capture_output=True, timeout=120)
+        python = venv_dir / ("Scripts" if sys.platform == "win32" else "bin") / "python"
+        subprocess.run(
+            ["uv", "pip", "install", "--python", str(python), f"trace-mcp @ {built_dist['wheel'].as_uri()}"],
+            check=True,
+            capture_output=True,
+            timeout=300,
+        )
+
+        project = tmp_path / "consumer"
+        project.mkdir()
+        source = tmp_path / "TRACE-checkout"
+        source.mkdir()
+        env = {
+            **os.environ,
+            # An installed wheel has no safe `--from` to infer (the PyPI name
+            # belongs to another project), so init fails closed without this.
+            "TRACE_SOURCE_PATH": str(source),
+            "TRACE_REGISTRY_PATH": str(tmp_path / "projects.json"),
+            "TRACE_SESSIONS_DIR": str(tmp_path / "sessions"),
+            "TRACE_KNOWLEDGE_DIR": str(tmp_path / "knowledge"),
+        }
+        init = subprocess.run(
+            [str(python.parent / "trace-mcp-init"), str(project), "--client", "claude-code"],
+            capture_output=True,
+            text=True,
+            timeout=120,
+            env=env,
+        )
+        assert init.returncode == 0, f"trace-mcp-init failed from a wheel install:\n{init.stdout}\n{init.stderr}"
+
+        doctor = subprocess.run(
+            [str(python.parent / "trace-mcp"), "doctor", str(project)],
+            capture_output=True,
+            text=True,
+            timeout=120,
+            env=env,
+        )
+        assert doctor.returncode == 0, (
+            f"a freshly initialized project is not doctor-clean when both commands come from the shipped "
+            f"wheel (INV-11):\n{doctor.stdout}\n{doctor.stderr}"
+        )
+        assert "FAIL" not in doctor.stdout
+
+        # Negative control: an unrelated directory must fail, or the check above
+        # would pass just as happily against a doctor that rubber-stamps.
+        empty = subprocess.run(
+            [str(python.parent / "trace-mcp"), "doctor", str(tmp_path / "TRACE-checkout")],
+            capture_output=True,
+            text=True,
+            timeout=120,
+            env=env,
+        )
+        assert empty.returncode == 1, f"Expected findings for an uninitialized directory: {empty.stdout}"
+        assert "FAIL" in empty.stdout
+
 
 class TestShippedLaunchPath:
     """Resolve every dependency from scratch — the resolution consumers get —


### PR DESCRIPTION
## Summary

Adds `trace_mcp/conformance/` and a `trace-mcp doctor [DIR] [--live] [--json]`
subcommand that checks one project directory's **deployed** TRACE state against
the artifacts the installed build actually ships, and registers the property as
**INV-11** in `docs/INVARIANTS.md`.

| Group | Checks |
|---|---|
| `config.*` | `.mcp.json` parses and declares a `trace` server; launched with `uvx`; the `--from` source is something uvx can build (and is not the unrelated PyPI distribution name); the args actually name `trace-mcp` as the command to run; the three trace-learn `--with` extras are present; `--refresh-package trace-mcp` is set. |
| `hooks.*` | Every shipped hook script is installed, executable, and carries this build's `[trace-hooks vX.Y]` stamp; no TRACE-stamped leftovers from an older release remain; `settings.json` parses; every hook is registered under its own host event; the decision-audit hook uses the namespaced matcher that actually fires. |
| `pin.*` | The pin file, the `.mcp.json` `TRACE_PROJECT` env pin, and the CLAUDE.md pin line all exist and canonicalize to one project key. |
| `live.*` | With `--live` only: the project's own configured command starts, completes an MCP handshake, reports this build's version, and serves all 22 tools. |

Exit codes are `0` clean, `1` findings, `2` usage error, with diagnostics on
stderr so `--json` stdout is always a report or empty. Check ids are stable API.

## Why

A green test suite proves the *source tree* is correct. It cannot prove a
*deployed* project is, and every defect in that class has been found by hand,
months late:

- a hook matcher naming the bare tool name `trace_end_session` — which a host
  never matches, because MCP tools are namespaced `mcp__<server-key>__<tool>` —
  left the decision-audit hook dead in most deployed projects;
- hook copies frozen at an older release across deployed projects;
- launch configs missing the trace-learn `--with` extras, which silently yields
  a 17-tool server instead of the documented 22;
- a warm package cache serving a stale wheel despite `--refresh-package`, with
  correct config, hooks, and pins all the way down.

Only the last is invisible to a file-level check, which is why `--live` exists;
the finding names the remedy.

## Design

**Expectations are derived, never restated.** Hook filenames and the version
stamp are read from the adapter's shipped assets (`HOOK_ASSETS_DIR`), the host
event each hook must be registered under from the installer's own settings
template (`SETTINGS_TEMPLATE_PATH`), the decision-audit matcher from
`MCP_SERVER_KEY`, the expected served version from `__version__`, and the tool
total is computed from the declared tool names — themselves pinned against the
README table and against the tools the server registers. A restated expectation
is one more copy to rot, and rot in exactly this layer is what the doctor
exists to catch.

**A check that cannot fail is worse than no check.** Several checks are shaped
specifically so they cannot bless a broken deployment: a hook registered under
the wrong host event is installed, current, executable, and completely inert —
the same defect as the dead matcher, one level up — so the event is part of the
check; TRACE-stamped scripts this build no longer ships are reported rather than
ignored, since a removed hook otherwise keeps running old semantics forever;
launch args that name no command at all are caught even though their last word
looks correct (`--refresh-package trace-mcp` ends the same way a correct entry
does); the dependency-confusion guard normalizes distribution names the way an
index does, so `trace_mcp` and `trace-mcp==0.5.0` cannot slip past a check
written for one spelling; a `~` in a `--from` path is rejected, because the host
executes uvx directly and only a shell expands a tilde; and a version mismatch
names which side is behind instead of assuming the deployment is the stale one,
which would otherwise tell the owner of a current project to downgrade it.

**One fail per root cause.** A check that cannot be evaluated reports `skip`
naming the upstream check that made it impossible; a skip is never silence, and
never makes a report look healthy. A probe that raises is reported as a failed
check and still emits every check id it owns, so one malformed project cannot
take a sweep down or make ids disappear from a consumer's report.

**`--live` is opt-in** because it runs the command the project's `.mcp.json`
declares — an action, not an inspection. Documented as such in the CLI help, the
module docstring, and the README.

**INV-11** binds the installer's output to the checker's expectations: a freshly
initialized project must be conformance-clean. The guard is parametrized over
the adapter registry (skipping adapters whose `install()` is unimplemented), so
a new host adapter is checked the moment it ships. A second guard runs both
`trace-mcp-init` and `trace-mcp doctor` **from the built wheel**, with a
negative control: the doctor reads packaged assets at runtime, so an
sdist-allowlist gap would leave it dead on arrival while every source-tree test
stayed green.

## Also corrected

Two README statements the new checks contradicted: the hook table advertised the
bare `trace_end_session` matcher (the form that never fires), and the
project-detection order omitted the `.claude/trace.project` pin file that takes
precedence over `CLAUDE.md`.

## Verification

- Full suite: 1353 passed, 12 skipped.
- `ruff format --check .` and `ruff check .` clean; `pyright` clean on changed files.
- `uv build` + `pytest tests/test_packaging_artifacts.py` green, including the
  new wheel-install INV-11 guard; `pytest tests/test_invariants.py` green.
- `trace-mcp doctor .` reports this repository clean, and `--live` against the
  real `uvx` launch path confirms version 0.5.0 and all 22 tools.
- Run read-only against deployed projects, the doctor reproduces the known
  deployment gaps (stale hook stamps, missing pin files, the dead short
  matcher) that were previously found only by manual inspection.
- The tilde behaviour was confirmed against `uv` itself, which resolves a
  literal `~` against the working directory rather than the home directory.

## Risks / rollback

Additive: a new subpackage, a new CLI subcommand dispatched lazily (the running
server never imports it), two new public constants on the Claude Code adapter,
and documentation. No existing behaviour changes. Revert is a clean removal.

One design decision to carry forward: `--live` executes a directory's declared
command. That matches the host's own trust model for a single project, but an
aggregate sweep over many discovered directories should keep it off by default.
