### PR TITLE
feat(learn): scope the OpenAI key per project and make key failures loud

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,34 @@
+# TRACE — per-project configuration.
+#
+# Copy to `.env` in THIS project directory and fill in the key. `.env` is
+# gitignored; this example file is the committed documentation of what goes in
+# it. Restart the MCP server after any change — configuration is read once, when
+# the server starts.
+#
+# EVERY UNCOMMENTED LINE BELOW OVERRIDES the machine-global default for this
+# project, so delete the ones you do not mean to set. A blank value is the one
+# exception: it is treated as absent and never masks a key from another source,
+# so copying this file cannot silently switch a working project off.
+#
+# WHY PER PROJECT: each project gets its own OpenAI credential, so one leaked or
+# exhausted key exposes one project rather than every project on the machine.
+# This file wins over the machine-global `~/.trace/.env`, which is only a
+# fallback for projects that have not been given a key of their own — and TRACE
+# says so loudly at session start when a project is borrowing it.
+
+# The OpenAI API key for THIS project. Without it, recall and extraction fall
+# back to local keyword matching, and TRACE reports that on every response
+# rather than letting it pass for success.
+OPENAI_API_KEY=
+
+# Cloud LLM matching/extraction is opt-in: a key alone activates nothing.
+TRACE_LLM_ENABLED=false
+
+# Embedding backend: auto (local model2vec), none, model2vec, fastembed, or
+# openai. Cloud embeddings are never auto-selected — `openai` must be explicit.
+TRACE_EMBEDDING_BACKEND=auto
+
+# No-egress kill switch. This one RATCHETS: setting it true here turns cloud
+# access off for this project even if the machine-global file allows it, but
+# setting it false here can never re-enable egress that the global file forbids.
+TRACE_LOCAL_ONLY=false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **The OpenAI API key is now per project: `./.env` overrides `~/.trace/.env`.**
+  The precedence was inverted — the machine-global file shadowed every
+  project's own file — so a key placed in a project was silently ignored, which
+  is indistinguishable from having no key at all. An exported environment
+  variable still wins over both. Each project having its own credential means a
+  leaked or exhausted key exposes one project rather than every project on the
+  machine, the same isolation TRACE already gives sessions and knowledge stores.
+  `~/.trace/.env` remains a fallback for projects with no key of their own, and
+  that fallback is now announced instead of assumed. A committed `.env.example`
+  documents the file.
+- **A blank value never overrides a real one, in any source.** A copied
+  template containing a bare `OPENAI_API_KEY=` would otherwise mask a working
+  key from a lower-priority file — and, because such a template also leaves the
+  cloud flags off, without tripping the missing-key warning either. The same
+  applies to an exported-but-empty variable (`docker run -e OPENAI_API_KEY`).
+  To stop a project using an inherited key, set `TRACE_LOCAL_ONLY=true` rather
+  than blanking the value.
+- **`TRACE_LOCAL_ONLY` is a restrict-only ratchet.** It is ORed across every
+  configuration source: any source may switch the no-egress kill switch on, and
+  none may switch it off. Without this, the precedence change above would let a
+  project `.env` opt out of a machine-wide privacy policy.
+
 ### Added
 
 - **`trace-mcp doctor [DIR] [--live] [--json]` — deployed-state conformance
@@ -34,6 +58,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   A hook is checked under **its own host event** — one registered under the
   wrong event is installed, current, executable, and still never fires — and
   TRACE-stamped scripts this build no longer ships are reported as leftovers.
+- **A missing or refused OpenAI key is now loud.** Cloud access requested with
+  no key resolvable is reported in the `trace_start_session` banner and in every
+  affected `trace_learn_*` response, naming the three places searched and the
+  file to fix; a key the provider rejects (401/403) raises `ApiKeyRejectedError`
+  regardless of `TRACE_STRICT_LLM` — on the matching, extraction, and embedding
+  paths alike — with the credential scrubbed from the message and its own error
+  code, so it is never reported as a strict-mode problem the reader cannot fix.
+  Only a 401 counts: a 403 also covers model access, region, and proxy failures,
+  which stay on the strict-mode path rather than being misdiagnosed as a bad
+  key. Strict mode governs whether degradation is acceptable, never whether
+  the user is told their credential was refused — silently returning
+  keyword-ranked results from a broken configuration hands back plausible output
+  and looks exactly like success.
+- **The trace-learn extension no longer fails to register when its configured
+  backend cannot be built.** Strict mode's refusal to degrade previously escaped
+  into the extension loader, so the server came up with the 17 core tools and no
+  explanation — the same silent-degradation shape the refusal exists to prevent.
+  It now registers with keyword matching and repeats the reason on every
+  affected response.
 - **INV-11 — a freshly initialized project is conformance-clean.** A new
   registry row binds the installer's output to the checker's expectations, so
   template rot (a hook matcher that never fires, a stale asset, a launch config

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,17 @@ migration tooling (`snapshot`, `scan`, `apply`, `check`, `merge-stores`,
 - **Label repair is alias-table-first** — a mislabelled project is fixed by adding an alias, never by rewriting a capture record. `auto` and `shared` are reserved keys.
 - **Cross-project reads and writes fail closed** when the server is pinned via `TRACE_PROJECT`; `TRACE_REQUIRE_PIN` additionally refuses both session-creation paths on an unpinned process.
 - `server.py` imports `__version__` from `trace_mcp` for startup log
+- **Per-project OpenAI key**: the key lives in the project's own `.env`, which
+  overrides the machine-global `~/.trace/.env` (an exported env var still wins
+  over both). `TRACE_LOCAL_ONLY` is the one exception — a restrict-only ratchet
+  ORed across sources, so no project can switch a machine-wide kill switch off.
+  Config is read once at server start; a `.env` edit needs a server restart.
+- **A missing or refused key is loud**: reported in the `trace_start_session`
+  banner and in the affected `trace_learn_*` responses, and a provider 401/403
+  raises `ApiKeyRejectedError` regardless of `TRACE_STRICT_LLM`. A backend that
+  cannot be built degrades to keyword matching *with a notice* rather than
+  failing registration — an unregistered extension is indistinguishable from an
+  uninstalled one.
 - **Line length**: 120 (ruff configured)
 
 ### Architecture Quick Reference

--- a/README.md
+++ b/README.md
@@ -276,11 +276,36 @@ Claude: -> trace_end_session(summary="Analyzed 47 passages...")
 
 ## Knowledge persistence (trace-learn)
 
-The default `trace-learn` extension surfaces relevant past learnings at session start, on-demand via `trace_learn_recall`, and when decisions are proposed — and auto-extracts new learnings at session end. Matching uses cloud LLM scoring only when explicitly opted in (`TRACE_LLM_ENABLED=true` plus an `OPENAI_API_KEY`), with BM25 fallback otherwise. Storage: `~/.trace/knowledge/{project_key}.json`, named by the canonical project key rather than the display label (env: `TRACE_KNOWLEDGE_DIR`).
+The default `trace-learn` extension surfaces relevant past learnings at session start, on-demand via `trace_learn_recall`, and when decisions are proposed — and auto-extracts new learnings at session end. Matching uses cloud LLM scoring only when explicitly opted in (`TRACE_LLM_ENABLED=true` plus an `OPENAI_API_KEY` in the project's `.env`), with BM25 fallback otherwise — and a fallback caused by a missing or refused key is reported rather than passed off as a result. Storage: `~/.trace/knowledge/{project_key}.json`, named by the canonical project key rather than the display label (env: `TRACE_KNOWLEDGE_DIR`).
 
 See [`docs/extensions/trace-learn.md`](https://github.com/Thru-Echoes/TRACE/blob/main/docs/extensions/trace-learn.md) for matching backends, BM25 stemming, per-backend thresholds, extraction details, and LLM configuration.
 
 ## Configuration
+
+### Where configuration is read from
+
+TRACE reads settings from three sources, highest priority first:
+
+1. an environment variable already exported in the process
+2. **`./.env` — this project's own file**, read from the directory the host launches the MCP server in
+3. `~/.trace/.env` — machine-wide defaults
+
+**The OpenAI API key belongs in the project's own `.env`.** Each project gets its own credential, so one leaked or exhausted key exposes one project rather than every project on the machine — the same isolation TRACE gives sessions and knowledge stores, applied to the credential that reaches a third party. `.env` is gitignored; [`.env.example`](https://github.com/Thru-Echoes/TRACE/blob/main/.env.example) is the committed template. `~/.trace/.env` still works as a fallback for projects that have not been given a key, and TRACE says so at session start rather than letting a project quietly borrow the shared one.
+
+One setting does not follow that order. **`TRACE_LOCAL_ONLY` is a restrict-only ratchet**: any source can turn the no-egress kill switch *on*, and none can turn it *off*. Without that exception, a project `.env` could opt out of a machine-wide privacy policy.
+
+Configuration is read **once, at server start** — restart the MCP server after editing a `.env`.
+
+#### When the key is missing or refused
+
+A cloud call attempted with no key, or with a key the provider rejects, is reported loudly — never quietly downgraded:
+
+- **No key, cloud path requested** → the `trace_start_session` banner and every affected `trace_learn_*` response carry a warning naming the three places searched and the file to fix. Recall still answers, on local keyword matching, and says so.
+- **Key rejected (401/403)** → an explicit error, *regardless* of `TRACE_STRICT_LLM`. Strict mode governs whether degradation is acceptable, not whether you are told your credential was refused. The key is scrubbed from the message.
+- **Key borrowed from `~/.trace/.env`** → a session-start notice, since a project silently using the machine-wide credential is the thing per-project keys exist to prevent.
+- **Configured backend cannot be built** → the extension still registers, with keyword matching and a notice on every recall. It never disappears silently: an extension that fails to register looks identical to one that was never installed.
+
+### Environment variables
 
 | Variable | Default | Description |
 |----------|---------|-------------|
@@ -290,11 +315,12 @@ See [`docs/extensions/trace-learn.md`](https://github.com/Thru-Echoes/TRACE/blob
 | `TRACE_DEFAULT_PROJECT` | `auto` | Quarantine key used when a session is auto-created with no project available. |
 | `TRACE_REGISTRY_PATH` | `~/.trace/projects.json` | Canonical-key alias registry. |
 | `TRACE_LOCK_TIMEOUT` | `15` | Seconds to wait for the knowledge-store lock before failing closed. |
+| `TRACE_LOCAL_ONLY` | `false` | No-egress kill switch. **Ratchets**: any source may set it `true`; none may set it `false` over a source that set it `true`. |
 | `TRACE_SESSIONS_DIR` | `~/.trace/sessions/` | Directory for session JSON files |
 | `TRACE_KNOWLEDGE_DIR` | `~/.trace/knowledge/` | Directory for trace-learn knowledge stores |
 | `TRACE_EGRESS_LOG` | `~/.trace/egress.jsonl` | Cloud-egress ledger: one JSONL line per cloud call trace-learn makes (the fact of the call — provider, endpoint, model, purpose, item count — never the content) |
 | `TRACE_LOG_LEVEL` | `INFO` | Logging verbosity |
-| `OPENAI_API_KEY` | — | OpenAI API key for LLM matching and extraction |
+| `OPENAI_API_KEY` | — | OpenAI API key for LLM matching, extraction, and cloud embeddings. **Put it in this project's `.env`** — see above; `~/.trace/.env` is a fallback, not the home for it |
 | `TRACE_LLM_MODEL` | `gpt-5.4-mini` | Model for LLM relevance scoring |
 | `TRACE_LLM_EXTRACTION_MODEL` | `gpt-5.4-mini` | Model for LLM learning extraction |
 | `TRACE_LLM_ENABLED` | `false` | Cloud LLM matching/extraction is opt-in: set `true` (with `OPENAI_API_KEY`) to enable |

--- a/docs/extensions/trace-learn.md
+++ b/docs/extensions/trace-learn.md
@@ -62,8 +62,7 @@ Both backends are **idempotent** — running extraction twice on the same sessio
 
 Cloud LLM features are **off by default** (local-first): an API key on the
 machine does not, by itself, send any session content to OpenAI. To opt in,
-place your key in `~/.trace/.env` (shared across all TRACE projects) **and**
-set `TRACE_LLM_ENABLED=true`:
+place the key in **this project's own `.env`** and set `TRACE_LLM_ENABLED=true`:
 
 ```bash
 OPENAI_API_KEY=sk-...
@@ -73,7 +72,44 @@ TRACE_LLM_EXTRACTION_MODEL=gpt-5.4-mini  # Model for extraction (can be differen
 TRACE_STRICT_LLM=true                    # Fail loudly on LLM errors (default: true when key set)
 ```
 
-Environment variables take precedence over `.env` file values for CI/container use.
+### Where the key is read from
+
+Highest priority first:
+
+1. an environment variable already exported in the process (CI, containers)
+2. **`./.env` — this project's own file**, read from the directory the host launches the server in
+3. `~/.trace/.env` — machine-wide defaults
+
+**The key belongs in the project's own file.** Each project having its own
+credential means a leaked or exhausted key exposes one project rather than every
+project on the machine. `~/.trace/.env` still works as a fallback, and TRACE
+names it at session start rather than letting a project quietly borrow it.
+
+A **blank value never overrides a real one** in any source, so copying a
+template with a bare `OPENAI_API_KEY=` cannot mask a working key. To stop a
+project using an inherited key, set `TRACE_LOCAL_ONLY=true` instead of blanking
+the value.
+
+`TRACE_LOCAL_ONLY` is the one setting that does not follow that order: it is a
+**restrict-only ratchet**, ORed across sources, so any source may switch the
+no-egress kill switch on and none may switch it off.
+
+Configuration is read **once, at server start** — restart the MCP server after
+editing a `.env`.
+
+### When the key is missing or refused
+
+- **No key, cloud path requested** — reported in the `trace_start_session`
+  banner and in the affected `trace_learn_*` responses (a `warnings` field),
+  naming the three places searched and the file to fix. Recall still answers on
+  BM25 and says so.
+- **Key rejected (401)** — raises `ApiKeyRejectedError` on the matching,
+  extraction, and embedding paths *regardless of* `TRACE_STRICT_LLM`, with the
+  credential scrubbed from the message. Strict mode governs whether degradation
+  is acceptable, not whether you are told your credential was refused. A 403 is
+  deliberately excluded — it also covers model access, region, and proxy
+  failures — and stays on the strict-mode path.
+- **Key borrowed from `~/.trace/.env`** — named at session start.
 
 ### Strict vs permissive LLM mode
 

--- a/src/trace_mcp/adapters/claude_code/assets/CLAUDE_BLOCK.md
+++ b/src/trace_mcp/adapters/claude_code/assets/CLAUDE_BLOCK.md
@@ -24,6 +24,15 @@ read as separate projects.
 - Never repair a wrong label by editing a captured session. Add an alias to
   the registry instead — capture records are not rewritten.
 
+**OpenAI key (optional, for semantic recall)**
+
+This project's OpenAI key belongs in its own `.env` file, not in a machine-wide
+one — per-project credentials keep one project's key from covering every
+project on the machine. `~/.trace/.env` is only a fallback, and TRACE reports at
+session start when a project is borrowing it. If a key is missing or refused,
+TRACE says so in the session banner and in the affected tool responses instead
+of quietly returning keyword-ranked results.
+
 **Session lifecycle**
 
 - **Start** a TRACE session at the beginning of any multi-step workflow.

--- a/src/trace_mcp/extension_status.py
+++ b/src/trace_mcp/extension_status.py
@@ -1,4 +1,4 @@
-"""User-facing TRACE extension-status banner.
+"""User-facing TRACE extension-status banner and OpenAI-credential warnings.
 
 A brief, obvious, consistent one-line notification of which learning-
 extension mode is active, plus a short upgrade hint. Surfaced in the
@@ -38,22 +38,63 @@ def get_extension_status() -> str:
         )
 
     try:
-        provider = get_embedding_provider(load_config())
+        config = load_config()
+    except Exception:
+        return f"{_BANNER} — learning extension (configuration unreadable)."
+
+    try:
+        provider = get_embedding_provider(config)
     except Exception:
         provider = None
 
     name = type(provider).__name__ if provider is not None else None
 
     if name == "OpenAIEmbeddingProvider":
-        return f"{_BANNER} — learning extension (LLM embeddings via OpenAI)."
-    if name == "Model2VecEmbeddingProvider":
-        return (
+        mode = f"{_BANNER} — learning extension (LLM embeddings via OpenAI)."
+    elif name == "Model2VecEmbeddingProvider":
+        mode = (
             f"{_BANNER} — learning extension (local embeddings, no LLM). "
-            "To upgrade: set OPENAI_API_KEY and embedding_backend=openai for "
-            "LLM-grade semantic recall."
+            "To upgrade: put an OpenAI key in this project's .env and set "
+            "TRACE_EMBEDDING_BACKEND=openai for LLM-grade semantic recall."
         )
-    return (
-        f"{_BANNER} — learning extension (keyword recall only, no embeddings). "
-        "To upgrade: install `model2vec` (local, no LLM) or set OPENAI_API_KEY "
-        "for semantic recall."
-    )
+    else:
+        mode = (
+            f"{_BANNER} — learning extension (keyword recall only, no embeddings). "
+            "To upgrade: install `model2vec` (local, no LLM) or put an OpenAI key "
+            "in this project's .env for semantic recall."
+        )
+
+    return " ".join([mode, *key_warnings(config)])
+
+
+def key_warnings(config: object) -> list[str]:
+    """Loud, user-facing notices about the OpenAI credential, or [] when fine.
+
+    Shared by the session-start banner and the learn tools' responses so the
+    same words reach the user through whichever surface they are looking at.
+    A missing key is stated at the moment it matters rather than left to a
+    server log the user never opens: the failure it causes — keyword results
+    instead of semantic ones — looks exactly like success.
+
+    Never raises: a status probe must not be able to break session start.
+    """
+    warnings: list[str] = []
+    try:
+        if getattr(config, "missing_key_for_cloud", False):
+            warnings.append(
+                "⚠️ NO OPENAI_API_KEY FOUND, but this project asks for a cloud path — "
+                f"searched {config.key_search_description()}. "  # type: ignore[attr-defined]
+                f"Recall and extraction are running on local keyword matching only. "
+                f"Put this project's key in {getattr(config, 'project_env_path', None) or './.env'} "
+                "and restart the MCP server."
+            )
+        elif getattr(config, "key_source", None) == "global":
+            warnings.append(
+                "⚠️ Using the machine-global OpenAI key at "
+                f"{getattr(config, 'key_source_path', None) or '~/.trace/.env'} — this project has no key of its own. "
+                f"Give it one in {getattr(config, 'project_env_path', None) or './.env'} so its cloud usage is "
+                "scoped to this project."
+            )
+    except Exception:  # pragma: no cover - a status probe must never break session start
+        return []
+    return warnings

--- a/src/trace_mcp/extensions/learn/__init__.py
+++ b/src/trace_mcp/extensions/learn/__init__.py
@@ -12,8 +12,9 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import TYPE_CHECKING, cast, get_args
+from typing import TYPE_CHECKING, Any, cast, get_args
 
+from trace_mcp import extension_status
 from trace_mcp import project_identity as pident
 from trace_mcp.extension_hooks import register_extract_hook, register_recall_hook
 from trace_mcp.extensions.learn import extraction, matching, store
@@ -73,8 +74,41 @@ def register(mcp: FastMCP, storage: TraceStorage) -> None:
     """Register trace-learn tools and hooks on the MCP server."""
 
     _config = load_config()
-    _backend = matching.get_default_backend(_config)
-    _embedding_provider = get_embedding_provider(_config)
+    # Registration must survive a backend that cannot be built. `get_default_backend`
+    # refuses to degrade to keyword matching in strict mode — correct for a caller
+    # that can report it, but here the exception would escape the extension loader
+    # and the server would come up with the 17 core tools and no explanation. That
+    # is the silent-degradation failure this project treats as the worst outcome,
+    # so the failure is captured and re-reported on every affected response instead.
+    _startup_error: str | None = None
+    try:
+        _backend = matching.get_default_backend(_config)
+        _embedding_provider = get_embedding_provider(_config)
+    except Exception as exc:  # noqa: BLE001 - a broken backend must not unregister the tools
+        _startup_error = str(exc)
+        logger.error(
+            "trace-learn: could not build the configured matching backend (%s). Registering with keyword "
+            "matching only; every recall response will carry this notice.",
+            exc,
+        )
+        _backend = matching.BM25Backend(k1=_config.bm25_k1, b=_config.bm25_b, tag_weight=_config.tag_weight)
+        _embedding_provider = None
+
+    def _key_notices(config: LearnConfig | None = None) -> list[str]:
+        """Loud notices to attach to any response that would have used the cloud.
+
+        Takes the EFFECTIVE config for the calling project, not the process-wide
+        one: a project the registry ratchets offline asks for no cloud path and
+        must not be told it is missing a key for one.
+        """
+        notices = list(extension_status.key_warnings(config if config is not None else _config))
+        if _startup_error:
+            notices.append(
+                f"⚠️ The configured matching backend could not be built, so recall is running on local "
+                f"keyword matching: {_startup_error}"
+            )
+        return notices
+
     _decay_params = DecayParams(
         enabled=_config.decay_enabled,
         half_life_days=_config.decay_half_life_days,
@@ -138,6 +172,17 @@ def register(mcp: FastMCP, storage: TraceStorage) -> None:
                 lrn.embedding_model = active.model_name
             return True
         except Exception as exc:
+            from trace_mcp.extensions.learn.config import ApiKeyRejectedError
+
+            if isinstance(exc, ApiKeyRejectedError):
+                # Strict mode decides whether degradation is acceptable, never
+                # whether a refused credential is reported. Swallowing it here
+                # is the one path that would leave the headline guarantee false:
+                # recall's lazy-embed step would be skipped, everything would
+                # fall to keyword scoring, and the response would carry no
+                # notice because a key IS configured.
+                logger.error("OpenAI rejected the API key while embedding: %s", exc)
+                raise
             if _config.strict_llm:
                 logger.error(
                     "Embedding generation failed in strict mode (provider=%s) — "
@@ -331,9 +376,18 @@ def register(mcp: FastMCP, storage: TraceStorage) -> None:
             with store.project_lock(project), egress_project(pident.key_for_label(project) or None):
                 ks = store.load_store(project)
                 if not ks.learnings:
-                    return json.dumps(
-                        {"project": project, "results": [], "total": 0, "backend": matching.describe_backend(backend)}
-                    )
+                    empty: dict[str, Any] = {
+                        "project": project,
+                        "results": [],
+                        "total": 0,
+                        "backend": matching.describe_backend(backend),
+                    }
+                    # A first-run project is exactly where a missing key is most
+                    # worth saying out loud, so this early return carries the
+                    # notices too.
+                    if notices := _key_notices(_eff):
+                        empty["warnings"] = notices
+                    return json.dumps(empty)
                 # Lazy-embed: generate (or regenerate) embeddings for learnings that need them
                 stale = _needs_embedding(ks, provider)
                 embedded = await _embed_learnings(stale, provider) if stale else False
@@ -348,19 +402,26 @@ def register(mcp: FastMCP, storage: TraceStorage) -> None:
                 )
                 if results or embedded:
                     store.save_store(ks)
-                return json.dumps(
-                    {
-                        "project": project,
-                        "results": results,
-                        "total": len(results),
-                        "backend": matching.describe_backend(backend),
-                    }
-                )
+                payload: dict[str, Any] = {
+                    "project": project,
+                    "results": results,
+                    "total": len(results),
+                    "backend": matching.describe_backend(backend),
+                }
+                if notices := _key_notices(_eff):
+                    payload["warnings"] = notices
+                return json.dumps(payload)
         except pident.RegistryUnavailableError as exc:
             return _registry_unavailable_error(project, exc)
         except Exception as exc:
-            from trace_mcp.extensions.learn.config import LLMFallbackError
+            from trace_mcp.extensions.learn.config import ApiKeyRejectedError, LLMFallbackError
 
+            if isinstance(exc, ApiKeyRejectedError):
+                # Checked BEFORE LLMFallbackError, which it subclasses: labelling
+                # a refused credential "strict mode blocked fallback" sends the
+                # reader to TRACE_STRICT_LLM, where nothing they change will fix it.
+                logger.error("OpenAI rejected the API key: %s", exc)
+                return json.dumps({"error": "OpenAI API key rejected", "detail": str(exc), "project": project})
             if isinstance(exc, LLMFallbackError):
                 logger.error("Strict LLM mode blocked fallback in trace_learn_recall: %s", exc)
                 return json.dumps(
@@ -446,8 +507,14 @@ def register(mcp: FastMCP, storage: TraceStorage) -> None:
         except pident.RegistryUnavailableError as exc:
             return _registry_unavailable_error(project, exc)
         except Exception as exc:
-            from trace_mcp.extensions.learn.config import LLMFallbackError
+            from trace_mcp.extensions.learn.config import ApiKeyRejectedError, LLMFallbackError
 
+            if isinstance(exc, ApiKeyRejectedError):
+                # Checked BEFORE LLMFallbackError, which it subclasses: labelling
+                # a refused credential "strict mode blocked fallback" sends the
+                # reader to TRACE_STRICT_LLM, where nothing they change will fix it.
+                logger.error("OpenAI rejected the API key: %s", exc)
+                return json.dumps({"error": "OpenAI API key rejected", "detail": str(exc), "project": project})
             if isinstance(exc, LLMFallbackError):
                 logger.error("Strict LLM mode blocked fallback in trace_learn_add: %s", exc)
                 return json.dumps(
@@ -573,14 +640,15 @@ def register(mcp: FastMCP, storage: TraceStorage) -> None:
                     await _embed_learnings(to_embed, provider)
                     store.save_store(ks)
 
-                return json.dumps(
-                    {
-                        "project": project,
-                        "new_learnings": len(all_new_ids),
-                        "new_ids": all_new_ids,
-                        "total_learnings": len(ks.learnings),
-                    }
-                )
+                payload: dict[str, Any] = {
+                    "project": project,
+                    "new_learnings": len(all_new_ids),
+                    "new_ids": all_new_ids,
+                    "total_learnings": len(ks.learnings),
+                }
+                if notices := _key_notices(eff):
+                    payload["warnings"] = notices
+                return json.dumps(payload)
         except pident.RegistryUnavailableError as exc:
             return _registry_unavailable_error(project, exc)
         except (pident.ProjectMismatchError, pident.ProjectKeyError) as exc:
@@ -588,8 +656,14 @@ def register(mcp: FastMCP, storage: TraceStorage) -> None:
                 {"error": "project/session coherence check failed", "detail": str(exc), "project": project}
             )
         except Exception as exc:
-            from trace_mcp.extensions.learn.config import LLMFallbackError
+            from trace_mcp.extensions.learn.config import ApiKeyRejectedError, LLMFallbackError
 
+            if isinstance(exc, ApiKeyRejectedError):
+                # Checked BEFORE LLMFallbackError, which it subclasses: labelling
+                # a refused credential "strict mode blocked fallback" sends the
+                # reader to TRACE_STRICT_LLM, where nothing they change will fix it.
+                logger.error("OpenAI rejected the API key: %s", exc)
+                return json.dumps({"error": "OpenAI API key rejected", "detail": str(exc), "project": project})
             if isinstance(exc, LLMFallbackError):
                 logger.error("Strict LLM mode blocked fallback in trace_learn_extract: %s", exc)
                 return json.dumps(

--- a/src/trace_mcp/extensions/learn/config.py
+++ b/src/trace_mcp/extensions/learn/config.py
@@ -1,31 +1,62 @@
 """Configuration for the trace-learn extension.
 
-Loads settings from environment variables and ~/.trace/.env.
+**A project's OpenAI key lives in that project's own ``.env``.** Each project
+gets its own credential, so one leaked or exhausted key exposes one project
+rather than every project on the machine — the same isolation ADR-006 gives
+sessions and knowledge stores, applied to the credential that reaches a third
+party.
 
-Resolution order for OPENAI_API_KEY and every other setting
-(highest priority first):
-  1. Environment variable (already set in shell)
-  2. ~/.trace/.env (shared across all TRACE projects)
-  3. ./.env in the current working directory
+Resolution order for OPENAI_API_KEY and every other setting (highest priority
+first):
 
-Precedence is a MERGE, not first-match-wins: when the same key is set in more
-than one place, the highest-priority source above supplies its value. Note the
-consequence — the global ~/.trace/.env OVERRIDES a project-local ./.env for a
-shared key, so ./.env is the LOWEST-priority source, not a "project override".
-A project's ./.env can still set keys that ~/.trace/.env does not (e.g.
-TRACE_EMBEDDING_BACKEND, TRACE_LOCAL_ONLY), and those do take effect.
+  1. Environment variable already exported in the process
+  2. ``./.env`` — the project's own file, read from the working directory the
+     host launches the MCP server in
+  3. ``~/.trace/.env`` — machine-wide defaults, a fallback for projects that
+     have not been given their own key
+
+Precedence is a MERGE, not first-match-wins: for a setting present in more than
+one source, the highest-priority source above supplies the value. The more
+specific file wins, which is what "put the key in the project's .env" has to
+mean for it to mean anything.
+
+**One exception — ``TRACE_LOCAL_ONLY`` is a restrict-only ratchet.** It is ORed
+across every source, so a project ``.env`` (or an exported variable) can turn
+the no-egress kill switch ON but can never turn a machine-global one OFF.
+Without that exception, the precedence rule above would hand every project a
+way to opt out of a machine-wide privacy policy. This mirrors the registry
+privacy ratchet in ``effective_learn_config`` (ADR-006).
+
+Configuration is read ONCE, when the extension registers at server start:
+editing a ``.env`` requires restarting the MCP server before the change is
+live.
+
+A key that cannot be found, or that the provider rejects, is reported loudly —
+see ``missing_key_for_cloud``, ``key_search_description`` and
+``ApiKeyRejectedError``. Silence there is the worst outcome available: recall
+still answers, just without the semantic path, and nothing says so.
 """
 
 from __future__ import annotations
 
 import logging
 import os
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
 _TRACE_ENV_PATH = Path.home() / ".trace" / ".env"
+
+
+def _nonempty(values: dict[str, str]) -> dict[str, str]:
+    """Drop blank values, so a placeholder cannot shadow a real setting."""
+    return {k: v for k, v in values.items() if v and v.strip()}
+
+
+def _truthy(value: str | None) -> bool:
+    """Shared truthiness for the string flags every source supplies."""
+    return (value or "").strip().lower() in ("true", "1", "yes")
 
 
 def _parse_dotenv(path: Path) -> dict[str, str]:
@@ -66,12 +97,60 @@ def _parse_dotenv(path: Path) -> dict[str, str]:
     return result
 
 
+_AUTH_ERROR_NAMES = frozenset({"AuthenticationError"})
+_AUTH_STATUS_CODES = frozenset({401})
+
+
+def is_auth_error(exc: BaseException) -> bool:
+    """True when *exc* is the provider rejecting the credential itself (401).
+
+    Deliberately narrow. A 403 (``PermissionDeniedError``) is NOT treated as a
+    rejected key: the provider also returns it for a model the account cannot
+    access, an unsupported region, and a corporate proxy sitting in front of a
+    custom ``base_url``. Reporting those as "your API key was rejected" would
+    misdiagnose them, and raising unconditionally would turn an error that used
+    to degrade gracefully into an outage. A 403 therefore stays on the ordinary
+    strict-mode path — which is loud by default, since strict mode defaults ON
+    whenever a key is configured.
+
+    Matched by HTTP status and by exception class name rather than by importing
+    the SDK's exception types, so this stays correct when ``openai`` is absent
+    (the extension's optional dependency) and when the SDK reorganizes them.
+    """
+    status = getattr(exc, "status_code", None)
+    if status in _AUTH_STATUS_CODES:
+        return True
+    return type(exc).__name__ in _AUTH_ERROR_NAMES
+
+
 class LLMFallbackError(RuntimeError):
     """Raised when an LLM operation fails and strict mode forbids falling back.
 
     In strict mode, the user has signalled that LLM features must work.
     Silent fallback to BM25/rule-based would hide degraded quality, so
     we surface the failure instead.
+    """
+
+
+def redact_key(text: str, api_key: str | None) -> str:
+    """Remove *api_key* from *text* before it reaches a log or a tool response.
+
+    Provider errors sometimes echo the credential they rejected, and these
+    messages are written to logs and returned to clients.
+    """
+    if not api_key or len(api_key) < 8:
+        return text
+    return text.replace(api_key, "<redacted>")
+
+
+class ApiKeyRejectedError(LLMFallbackError):
+    """The provider refused the API key itself (401/403).
+
+    Raised regardless of strict mode, which is the point: strict mode governs
+    whether *degradation* is acceptable, not whether the user is told their
+    credential was refused. Quietly returning keyword results from a rejected
+    key hands back plausible output produced by a broken configuration — the
+    one failure shape this project treats as worse than an error.
     """
 
 
@@ -113,6 +192,39 @@ class LearnConfig:
     # point it at any local server (Ollama / LM Studio / text-embeddings-inference
     # / vLLM). None → the SDK default (api.openai.com or its own OPENAI_BASE_URL).
     embedding_base_url: str | None = None
+    # Where the key came from — "environment", "project", "global", or None.
+    # Reported (never the key itself) so a project silently borrowing the
+    # machine-wide credential is visible rather than assumed intentional.
+    key_source: str | None = None
+    key_source_path: str | None = None
+    # True when a cloud path was asked for (LLM features, or the OpenAI
+    # embedding backend) but no key resolved anywhere. Deliberately offline
+    # setups (TRACE_LOCAL_ONLY) are not flagged — they are not a mistake.
+    missing_key_for_cloud: bool = False
+    project_env_path: str | None = None
+    global_env_path: str | None = None
+
+    def key_search_description(self) -> str:
+        """Every place a key was looked for, in priority order.
+
+        A "no key found" message that does not say where it looked leaves the
+        reader guessing which of three files to edit.
+        """
+        return (
+            f"the OPENAI_API_KEY environment variable, "
+            f"the project's own {self.project_env_path or './.env'}, "
+            f"and the machine-global {self.global_env_path or '~/.trace/.env'}"
+        )
+
+    def key_origin(self) -> str:
+        """One phrase naming where the active key came from."""
+        if self.key_source == "environment":
+            return "the OPENAI_API_KEY environment variable"
+        if self.key_source == "project":
+            return f"this project's {self.project_env_path or './.env'}"
+        if self.key_source == "global":
+            return f"the machine-global {self.global_env_path or '~/.trace/.env'}"
+        return "no source (no key configured)"
 
 
 def load_config() -> LearnConfig:
@@ -127,11 +239,22 @@ def load_config() -> LearnConfig:
     embeddings require an explicit ``TRACE_EMBEDDING_BACKEND=openai``.
     ``TRACE_LOCAL_ONLY=1`` overrides both (no egress anywhere).
     """
-    # Low-priority → high-priority merge
-    project_env = _parse_dotenv(Path.cwd() / ".env")
+    # Low-priority → high-priority merge. The project's own file wins over the
+    # machine-global one: "put the key in the project's .env" has to mean the
+    # project's key is the one used, or it means nothing. (The order was once
+    # reversed, which silently ignored every per-project key.)
+    project_env_path = Path.cwd() / ".env"
+    project_env = _parse_dotenv(project_env_path)
     global_env = _parse_dotenv(_TRACE_ENV_PATH)
 
-    merged = {**project_env, **global_env}
+    # An EMPTY value never overrides a real one. Copying a template that
+    # contains a bare `OPENAI_API_KEY=` would otherwise mask a working key from
+    # a lower-priority source — and, because the same template leaves the cloud
+    # flags off, without tripping the missing-key warning either. Same hazard
+    # for an exported-but-empty variable (`docker run -e OPENAI_API_KEY`).
+    # To deliberately stop a project using an inherited key, set
+    # TRACE_LOCAL_ONLY=true rather than blanking the value.
+    merged = {**_nonempty(global_env), **_nonempty(project_env)}
     for key in (
         "OPENAI_API_KEY",
         "TRACE_LLM_MODEL",
@@ -154,11 +277,27 @@ def load_config() -> LearnConfig:
         "TRACE_OPENAI_BASE_URL",
     ):
         env_val = os.environ.get(key)
-        if env_val is not None:
+        if env_val is not None and env_val.strip():
             merged[key] = env_val
 
     api_key = merged.get("OPENAI_API_KEY") or None
-    local_only = merged.get("TRACE_LOCAL_ONLY", "false").lower() in ("true", "1", "yes")
+
+    # Which source supplied the key. Reported (never the key) so that a project
+    # quietly borrowing the machine-wide credential is visible.
+    key_source: str | None = None
+    key_source_path: str | None = None
+    if api_key:
+        if os.environ.get("OPENAI_API_KEY"):
+            key_source = "environment"
+        elif project_env.get("OPENAI_API_KEY"):
+            key_source, key_source_path = "project", str(project_env_path)
+        else:
+            key_source, key_source_path = "global", str(_TRACE_ENV_PATH)
+
+    # RESTRICT-ONLY RATCHET: any source may switch no-egress ON; none may
+    # switch it OFF. Without this, the precedence flip above would let a
+    # project .env opt out of a machine-wide privacy policy.
+    local_only = any(_truthy(source.get("TRACE_LOCAL_ONLY")) for source in (global_env, project_env, dict(os.environ)))
 
     # Cloud LLM matching/extraction is OPT-IN (local-first): unset means OFF,
     # even when an API key is present. Distinguish "unset" from an explicit
@@ -172,12 +311,30 @@ def load_config() -> LearnConfig:
     strict_default = "true" if api_key else "false"
     strict_llm = merged.get("TRACE_STRICT_LLM", strict_default).lower() in ("true", "1", "yes")
 
-    if llm_enabled and not api_key:
-        # No key at all — this is a legitimate config, not a failure.
-        logger.info(
-            "No OPENAI_API_KEY found (checked env, ~/.trace/.env, ./.env). "
-            "LLM features disabled — using BM25/rule-based matching."
+    embedding_backend_requested = merged.get("TRACE_EMBEDDING_BACKEND", "auto")
+    cloud_requested = llm_enabled or embedding_backend_requested == "openai"
+    # A cloud path was asked for and there is no credential for it. Recorded on
+    # the config rather than swallowed here: registration must still succeed
+    # (a server that refuses to start over a missing optional key is a worse
+    # failure than a loud one), so the callers surface it — the session-start
+    # banner and every learn-tool response that would have used the cloud.
+    # Deliberately-offline setups are not a mistake and are not flagged.
+    missing_key_for_cloud = cloud_requested and not api_key and not local_only
+
+    if missing_key_for_cloud:
+        logger.error(
+            "No OPENAI_API_KEY found, but a cloud path was requested "
+            "(TRACE_LLM_ENABLED=%s, TRACE_EMBEDDING_BACKEND=%s). Looked in: the OPENAI_API_KEY "
+            "environment variable, the project's own %s, and the machine-global %s. "
+            "Falling back to local keyword matching — results will NOT use semantic ranking. "
+            "Put this project's key in %s, then restart the MCP server.",
+            raw_llm_enabled,
+            embedding_backend_requested,
+            project_env_path,
+            _TRACE_ENV_PATH,
+            project_env_path,
         )
+    if llm_enabled and not api_key:
         llm_enabled = False
     elif llm_enabled and api_key and strict_llm:
         logger.warning(
@@ -229,7 +386,24 @@ def load_config() -> LearnConfig:
         embedding_backend=embedding_backend,
         embedding_model=merged.get("TRACE_EMBEDDING_MODEL", "text-embedding-3-small"),
         embedding_base_url=merged.get("TRACE_OPENAI_BASE_URL") or merged.get("OPENAI_BASE_URL") or None,
+        key_source=key_source,
+        key_source_path=key_source_path,
+        missing_key_for_cloud=missing_key_for_cloud,
+        project_env_path=str(project_env_path),
+        global_env_path=str(_TRACE_ENV_PATH),
     )
+
+
+def _clear_cloud_expectation(config: LearnConfig) -> LearnConfig:
+    """Drop the missing-key flag once a config has been ratcheted offline.
+
+    A project the registry forces local-only is not asking for a cloud path, so
+    warning that it has no key for one would be noise on every response — and
+    noise is how a real warning stops being read.
+    """
+    if not config.missing_key_for_cloud:
+        return config
+    return replace(config, missing_key_for_cloud=False)
 
 
 def effective_learn_config(base: LearnConfig, project: str) -> LearnConfig:
@@ -282,13 +456,14 @@ def effective_learn_config(base: LearnConfig, project: str) -> LearnConfig:
     ):
         return base
 
-    from dataclasses import replace
-
     eff = base
     if force_local and not base.local_only:
         # Mirror load_config's own TRACE_LOCAL_ONLY semantics: one switch, all
         # three egress paths.
         eff = replace(eff, local_only=True, llm_enabled=False)
+        # A project ratcheted offline is not asking for a cloud path, so it must
+        # not be warned about lacking a key for one.
+        eff = _clear_cloud_expectation(eff)
         if eff.embedding_backend == "openai":
             eff = replace(eff, embedding_backend="auto")
     if force_llm_off and eff.llm_enabled:

--- a/src/trace_mcp/extensions/learn/embeddings.py
+++ b/src/trace_mcp/extensions/learn/embeddings.py
@@ -114,6 +114,7 @@ class OpenAIEmbeddingProvider:
         model: str = "text-embedding-3-small",
         dimensions: int = 0,
         base_url: str | None = None,
+        key_hint: str | None = None,
     ) -> None:
         if not _HAS_OPENAI:
             raise RuntimeError("openai package is required for OpenAI embeddings")
@@ -131,6 +132,8 @@ class OpenAIEmbeddingProvider:
         self.model_name = model
         self.dimensions = dimensions  # 0 = use model default
         self.base_url = base_url
+        self._api_key = api_key
+        self._key_hint = key_hint or "Check the OpenAI key in this project's .env and restart the MCP server."
 
     async def embed_texts(self, texts: list[str]) -> list[list[float]]:
         # Egress-as-provenance: record the fact of the cloud call before making
@@ -152,7 +155,20 @@ class OpenAIEmbeddingProvider:
         kwargs: dict = {"model": self.model_name, "input": texts}
         if self.dimensions > 0:
             kwargs["dimensions"] = self.dimensions
-        response = await self._client.embeddings.create(**kwargs)
+        try:
+            response = await self._client.embeddings.create(**kwargs)
+        except Exception as exc:
+            from trace_mcp.extensions.learn.config import ApiKeyRejectedError, is_auth_error, redact_key
+
+            if not is_auth_error(exc):
+                raise
+            # A refused credential is a configuration failure, not a provider
+            # hiccup: re-raised as its own type so callers report the file to
+            # fix instead of counting it as one more retryable embedding error.
+            detail = redact_key(str(exc), self._api_key)
+            raise ApiKeyRejectedError(
+                f"OpenAI REJECTED the API key while embedding (model={self.model_name}): {detail}. {self._key_hint}"
+            ) from exc
         return [item.embedding for item in response.data]
 
 
@@ -323,13 +339,17 @@ def get_embedding_provider(config: LearnConfig | None = None) -> EmbeddingProvid
             api_key=config.openai_api_key,
             model=config.embedding_model,
             base_url=config.embedding_base_url,
+            key_hint=(
+                f"The key in use came from {config.key_origin()}. Replace it there and restart the MCP "
+                f"server. Searched, in order: {config.key_search_description()}."
+            ),
         )
     if backend == "openai":
         # User explicitly asked for OpenAI embeddings but they're unavailable.
         msg = (
             f"OpenAI embeddings requested (TRACE_EMBEDDING_BACKEND=openai) but "
             f"unavailable: openai_package={_HAS_OPENAI}, api_key_present="
-            f"{bool(config.openai_api_key)}."
+            f"{bool(config.openai_api_key)}. Searched for a key in: {config.key_search_description()}."
         )
         if config.strict_llm:
             logger.error("%s Refusing to fall back.", msg)

--- a/src/trace_mcp/extensions/learn/extraction.py
+++ b/src/trace_mcp/extensions/learn/extraction.py
@@ -283,7 +283,12 @@ async def extract_from_session_llm(
     synthesising cross-event patterns and generating quality tags.
     Falls back to rule-based extraction on any error (unless strict mode).
     """
-    from trace_mcp.extensions.learn.config import LLMFallbackError
+    from trace_mcp.extensions.learn.config import (
+        ApiKeyRejectedError,
+        LLMFallbackError,
+        is_auth_error,
+        redact_key,
+    )
 
     if not _HAS_OPENAI or not config.openai_api_key:
         if config.strict_llm and config.openai_api_key:
@@ -394,6 +399,20 @@ async def extract_from_session_llm(
         return new_ids
 
     except Exception as exc:
+        if is_auth_error(exc):
+            # Same rule as matching: strict mode decides whether degradation is
+            # acceptable, never whether a refused credential is reported.
+            detail = redact_key(str(exc), config.openai_api_key)
+            logger.error(
+                "OpenAI rejected the API key during extraction (model=%s): %s",
+                config.llm_extraction_model,
+                detail,
+            )
+            raise ApiKeyRejectedError(
+                f"OpenAI REJECTED the API key (model={config.llm_extraction_model}): {detail}. "
+                f"The key in use came from {config.key_origin()}. Replace it there and restart the MCP "
+                f"server. Searched, in order: {config.key_search_description()}."
+            ) from exc
         if config.strict_llm:
             logger.error(
                 "LLM extraction failed in strict mode (model=%s) — "

--- a/src/trace_mcp/extensions/learn/matching.py
+++ b/src/trace_mcp/extensions/learn/matching.py
@@ -293,6 +293,11 @@ class LLMBackend:
         self._model = config.llm_model
         self._tag_weight = config.tag_weight
         self._strict = config.strict_llm
+        # Kept so a rejected credential can name the file to edit, and so the
+        # credential itself can be scrubbed from any provider message.
+        self._key_origin = config.key_origin()
+        self._key_search = config.key_search_description()
+        self._api_key = config.openai_api_key
         self._bm25_fallback = BM25Backend(
             k1=config.bm25_k1,
             b=config.bm25_b,
@@ -323,8 +328,25 @@ class LLMBackend:
         try:
             scores = await self._llm_score(candidates, context, context_tags)
         except Exception as exc:
-            from trace_mcp.extensions.learn.config import LLMFallbackError
+            from trace_mcp.extensions.learn.config import (
+                ApiKeyRejectedError,
+                LLMFallbackError,
+                is_auth_error,
+                redact_key,
+            )
 
+            if is_auth_error(exc):
+                # Independent of strict mode: strict governs whether degradation
+                # is acceptable, not whether the user is told their credential
+                # was refused. Returning keyword results here would hand back
+                # plausible output from a broken configuration.
+                detail = redact_key(str(exc), self._api_key)
+                logger.error("OpenAI rejected the API key during matching (model=%s): %s", self._model, detail)
+                raise ApiKeyRejectedError(
+                    f"OpenAI REJECTED the API key (model={self._model}): {detail}. "
+                    f"The key in use came from {self._key_origin}. Replace it there and restart the MCP server. "
+                    f"Searched, in order: {self._key_search}."
+                ) from exc
             if self._strict:
                 logger.error(
                     "LLM scoring failed in strict mode (model=%s) — "

--- a/tests/test_openai_key_scope.py
+++ b/tests/test_openai_key_scope.py
@@ -1,0 +1,437 @@
+"""Per-project OpenAI keys: `./.env` is the key's home, and its absence is loud.
+
+Two properties are pinned here.
+
+**Scope.** A project's own `.env` is the place a key lives, so it overrides the
+machine-global `~/.trace/.env` (shell environment still wins over both). The
+previous order was inverted — the global file shadowed every project file — so a
+key placed in a project was silently ignored, which is indistinguishable from
+having no key at all. One exception survives the flip: `TRACE_LOCAL_ONLY` is a
+restrict-only ratchet, ORed across every source, so a project `.env` can turn
+the kill switch ON but can never turn a machine-global one OFF.
+
+**Loudness.** A cloud call attempted with no key, or with a key the provider
+rejects, must be visible to the person running the session. Silence here is the
+worst outcome: recall still returns results, they are just keyword-ranked, and
+nothing says the semantic path was skipped. Per-project keys make "this project
+has no key yet" routine, so the quiet path had to go.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from mcp.server.fastmcp import FastMCP
+
+import trace_mcp.extensions.learn.config as _cfg
+import trace_mcp.project_identity as pident
+from trace_mcp.extensions.learn.config import (
+    ApiKeyRejectedError,
+    is_auth_error,
+    load_config,
+)
+from trace_mcp.storage.json_file import JsonFileStorage
+
+_KEY_VARS = (
+    "OPENAI_API_KEY",
+    "TRACE_LLM_ENABLED",
+    "TRACE_LOCAL_ONLY",
+    "TRACE_LLM_MODEL",
+    "TRACE_EMBEDDING_BACKEND",
+    "TRACE_STRICT_LLM",
+)
+
+
+@pytest.fixture()
+def env_files(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Isolated project + global .env files, with the real environment scrubbed.
+
+    Returns (write_project, write_global): each takes a dict and writes that
+    file. The working directory is the project, which is what a host gives an
+    MCP server it launches.
+    """
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    global_env = tmp_path / "home" / ".trace" / ".env"
+    global_env.parent.mkdir(parents=True)
+    monkeypatch.chdir(project_dir)
+    monkeypatch.setattr(_cfg, "_TRACE_ENV_PATH", global_env)
+    for var in _KEY_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+    def write(path: Path):
+        def _write(values: dict[str, str]) -> None:
+            path.write_text("".join(f"{k}={v}\n" for k, v in values.items()))
+
+        return _write
+
+    return write(project_dir / ".env"), write(global_env)
+
+
+# ── scope: which file supplies the key ──────────────────────────────────────
+
+
+def test_project_env_overrides_the_global_file(env_files) -> None:
+    """The defect this closes: a key placed in a project was silently ignored."""
+    write_project, write_global = env_files
+    write_global({"OPENAI_API_KEY": "global-key"})
+    write_project({"OPENAI_API_KEY": "project-key"})
+
+    config = load_config()
+    assert config.openai_api_key == "project-key"
+    assert config.key_source == "project"
+
+
+def test_environment_variable_still_wins_over_both(env_files, monkeypatch: pytest.MonkeyPatch) -> None:
+    """An explicitly exported key is a deliberate override (CI, containers)."""
+    write_project, write_global = env_files
+    write_global({"OPENAI_API_KEY": "global-key"})
+    write_project({"OPENAI_API_KEY": "project-key"})
+    monkeypatch.setenv("OPENAI_API_KEY", "env-key")
+
+    config = load_config()
+    assert config.openai_api_key == "env-key"
+    assert config.key_source == "environment"
+
+
+def test_global_file_is_the_fallback_and_says_so(env_files) -> None:
+    """A project with no key of its own borrows the shared one — visibly."""
+    _write_project, write_global = env_files
+    write_global({"OPENAI_API_KEY": "global-key"})
+
+    config = load_config()
+    assert config.openai_api_key == "global-key"
+    assert config.key_source == "global"
+    assert config.key_source_path is not None and config.key_source_path.endswith(".env")
+
+
+def test_no_key_anywhere_reports_no_source(env_files) -> None:
+    config = load_config()
+    assert config.openai_api_key is None
+    assert config.key_source is None
+
+
+def test_project_env_overrides_ordinary_settings_too(env_files) -> None:
+    """The flip is a general precedence rule, not a special case for the key."""
+    write_project, write_global = env_files
+    write_global({"TRACE_LLM_MODEL": "global-model"})
+    write_project({"TRACE_LLM_MODEL": "project-model"})
+    assert load_config().llm_model == "project-model"
+
+
+# ── the one exception: TRACE_LOCAL_ONLY ratchets, never loosens ─────────────
+
+
+def test_project_can_turn_the_kill_switch_on(env_files) -> None:
+    write_project, _write_global = env_files
+    write_project({"TRACE_LOCAL_ONLY": "true"})
+    assert load_config().local_only is True
+
+
+def test_project_cannot_turn_a_global_kill_switch_off(env_files) -> None:
+    """Otherwise the precedence flip would hand every project a way to opt out
+    of a machine-wide no-egress policy."""
+    write_project, write_global = env_files
+    write_global({"TRACE_LOCAL_ONLY": "true"})
+    write_project({"TRACE_LOCAL_ONLY": "false", "OPENAI_API_KEY": "project-key"})
+
+    config = load_config()
+    assert config.local_only is True
+    assert config.llm_enabled is False
+
+
+def test_environment_variable_cannot_turn_a_global_kill_switch_off(env_files, monkeypatch: pytest.MonkeyPatch) -> None:
+    _write_project, write_global = env_files
+    write_global({"TRACE_LOCAL_ONLY": "1"})
+    monkeypatch.setenv("TRACE_LOCAL_ONLY", "false")
+    assert load_config().local_only is True
+
+
+# ── loudness: a cloud call with no usable key ───────────────────────────────
+
+
+def test_llm_requested_without_a_key_is_flagged_not_swallowed(env_files) -> None:
+    """Previously this logged at INFO and disabled LLM features in silence."""
+    write_project, _write_global = env_files
+    write_project({"TRACE_LLM_ENABLED": "true"})
+
+    config = load_config()
+    assert config.missing_key_for_cloud is True
+    assert config.llm_enabled is False, "nothing may attempt a cloud call without a key"
+
+
+def test_openai_embedding_backend_without_a_key_is_flagged(env_files) -> None:
+    write_project, _write_global = env_files
+    write_project({"TRACE_EMBEDDING_BACKEND": "openai"})
+    assert load_config().missing_key_for_cloud is True
+
+
+def test_local_only_is_not_a_missing_key(env_files) -> None:
+    """Deliberately offline is not a misconfiguration — it must not warn."""
+    write_project, _write_global = env_files
+    write_project({"TRACE_LOCAL_ONLY": "true", "TRACE_LLM_ENABLED": "true"})
+    assert load_config().missing_key_for_cloud is False
+
+
+def test_key_search_path_names_every_place_that_was_checked(env_files) -> None:
+    """A 'no key found' message that does not say where it looked is not actionable."""
+    config = load_config()
+    searched = config.key_search_description()
+    assert ".env" in searched
+    assert str(Path.cwd()) in searched
+
+
+# ── loudness: a key the provider rejects ────────────────────────────────────
+
+
+class _FakeAuthError(Exception):
+    """Shaped like an OpenAI 401 without depending on the SDK's constructors."""
+
+    status_code = 401
+
+
+def test_only_a_401_counts_as_a_rejected_credential() -> None:
+    """403 is deliberately excluded.
+
+    The provider returns 403 for a model the account cannot access, an
+    unsupported region, and a proxy in front of a custom base_url. Calling
+    those "your API key was rejected" misdiagnoses them, and raising
+    unconditionally would turn an error that degraded gracefully into an
+    outage. 403 stays on the strict-mode path, which is loud by default.
+    """
+    assert is_auth_error(_FakeAuthError())
+    assert is_auth_error(type("AuthenticationError", (Exception,), {})())
+    assert not is_auth_error(type("PermissionDeniedError", (Exception,), {})())
+    assert not is_auth_error(type("Whatever", (Exception,), {"status_code": 403})())
+    assert not is_auth_error(TimeoutError("network hiccup"))
+
+
+async def test_rejected_key_raises_even_when_strict_mode_is_off(env_files, monkeypatch) -> None:
+    """A rejected key is a configuration failure, not a transient one.
+
+    Strict mode governs whether *degradation* is acceptable; it must not govern
+    whether the user is told their key was refused. Falling back to keyword
+    results here would hand back plausible output from a broken setup.
+    """
+    pytest.importorskip("openai")
+    from trace_mcp.extensions.learn.matching import LLMBackend
+    from trace_mcp.extensions.learn.models import Learning
+
+    write_project, _write_global = env_files
+    write_project({"OPENAI_API_KEY": "sk-rejected", "TRACE_LLM_ENABLED": "true", "TRACE_STRICT_LLM": "false"})
+    config = load_config()
+    assert config.strict_llm is False
+
+    backend = LLMBackend(config)
+
+    async def _reject(*_args: Any, **_kwargs: Any) -> list[float]:
+        raise _FakeAuthError("Incorrect API key provided")
+
+    monkeypatch.setattr(backend, "_llm_score", _reject)
+    learning = Learning(id="lrn_001", content="something", category="learning")
+
+    with pytest.raises(ApiKeyRejectedError) as exc:
+        await backend.score_batch([learning], "context")
+    assert "sk-rejected" not in str(exc.value), "an error message must never echo the key"
+    assert ".env" in str(exc.value), "the message must point at the file to fix"
+
+
+def test_a_blank_value_never_overrides_a_real_one(env_files) -> None:
+    """Copying a template with a bare `OPENAI_API_KEY=` must not mask a real key.
+
+    The template also leaves the cloud flags off, so nothing would have tripped
+    the missing-key warning either: the project would simply have stopped using
+    the key it had, silently. That is the failure this whole change exists to
+    prevent, arriving through the documentation for the change.
+    """
+    write_project, write_global = env_files
+    write_global({"OPENAI_API_KEY": "real-global-key"})
+    write_project({"OPENAI_API_KEY": "", "TRACE_LLM_ENABLED": "false"})
+
+    config = load_config()
+    assert config.openai_api_key == "real-global-key"
+    assert config.key_source == "global"
+
+
+def test_an_exported_but_empty_variable_does_not_mask_a_key(env_files, monkeypatch: pytest.MonkeyPatch) -> None:
+    """`docker run -e OPENAI_API_KEY` exports the name with an empty value."""
+    write_project, _write_global = env_files
+    write_project({"OPENAI_API_KEY": "project-key"})
+    monkeypatch.setenv("OPENAI_API_KEY", "")
+
+    config = load_config()
+    assert config.openai_api_key == "project-key"
+    assert config.key_source == "project"
+
+
+def test_the_shipped_example_file_cannot_disable_a_working_key(env_files) -> None:
+    """Belt and braces: the committed template itself, verbatim."""
+    _write_project, write_global = env_files
+    write_global({"OPENAI_API_KEY": "real-global-key", "TRACE_LLM_ENABLED": "true"})
+    example = Path(__file__).parent.parent / ".env.example"
+    (Path.cwd() / ".env").write_text(example.read_text())
+
+    config = load_config()
+    assert config.openai_api_key == "real-global-key"
+
+
+# ── loudness: what the user actually sees ───────────────────────────────────
+
+
+def test_session_start_banner_warns_when_a_cloud_call_has_no_key(env_files) -> None:
+    """The banner is surfaced in the trace_start_session response — the one place
+    every session looks."""
+    write_project, _write_global = env_files
+    write_project({"TRACE_LLM_ENABLED": "true"})
+
+    from trace_mcp.extension_status import get_extension_status
+
+    banner = get_extension_status().lower()
+    assert "no openai_api_key found" in banner
+    assert ".env" in banner
+
+
+def test_session_start_banner_flags_a_borrowed_global_key(env_files) -> None:
+    """A project silently using the machine-wide key is the thing per-project
+    keys exist to prevent, so it is stated rather than assumed acceptable."""
+    _write_project, write_global = env_files
+    write_global({"OPENAI_API_KEY": "global-key"})
+
+    from trace_mcp.extension_status import get_extension_status
+
+    assert "machine-global" in get_extension_status().lower()
+
+
+def test_session_start_banner_is_quiet_when_the_project_has_its_own_key(env_files) -> None:
+    write_project, _write_global = env_files
+    write_project({"OPENAI_API_KEY": "project-key"})
+
+    from trace_mcp.extension_status import get_extension_status
+
+    banner = get_extension_status().lower()
+    assert "no openai_api_key found" not in banner
+    assert "machine-global" not in banner
+
+
+def test_a_project_ratcheted_offline_is_not_warned_about_a_missing_key(env_files) -> None:
+    """A registry entry that forces local-only means the project asks for no
+    cloud path at all — warning it about a key it does not want is noise, and
+    noise is how a real warning stops being read."""
+    from dataclasses import replace as dc_replace
+
+    from trace_mcp.extensions.learn.config import _clear_cloud_expectation
+
+    write_project, _write_global = env_files
+    write_project({"TRACE_LLM_ENABLED": "true"})
+    base = load_config()
+    assert base.missing_key_for_cloud is True
+
+    offline = _clear_cloud_expectation(dc_replace(base, local_only=True, llm_enabled=False))
+    assert offline.missing_key_for_cloud is False
+
+    from trace_mcp.extension_status import key_warnings
+
+    assert key_warnings(offline) == []
+
+
+# ── loudness: the learn tools' own responses ────────────────────────────────
+
+
+@pytest.fixture()
+def learn_mcp(env_files, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """A registered learn extension over isolated dirs, honouring env_files."""
+    monkeypatch.setenv("TRACE_KNOWLEDGE_DIR", str(tmp_path / "knowledge"))
+    monkeypatch.setenv("TRACE_SESSIONS_DIR", str(tmp_path / "sessions"))
+    monkeypatch.setenv("TRACE_REGISTRY_PATH", str(tmp_path / "projects.json"))
+    monkeypatch.setenv("TRACE_PROJECT", "keyscope")
+    pident._reset_registry_cache()
+    yield env_files
+    pident._reset_registry_cache()
+
+
+async def _call(mcp: FastMCP, tool: str, args: dict[str, Any]) -> dict:
+    out = await mcp.call_tool(tool, args)
+    if isinstance(out, tuple):
+        out = out[0]
+    return json.loads(out[0].text)  # type: ignore[union-attr]
+
+
+async def test_recall_response_carries_the_missing_key_warning(learn_mcp, tmp_path: Path) -> None:
+    """The warning rides along with the results, so the answer that gets used
+    carries the caveat that produced it."""
+    write_project, _write_global = learn_mcp
+    write_project({"TRACE_LLM_ENABLED": "true"})
+
+    from trace_mcp.extensions.learn import register
+
+    mcp = FastMCP("key-scope-test")
+    register(mcp, JsonFileStorage(directory=str(tmp_path / "sessions")))
+
+    await _call(mcp, "trace_learn_add", {"content": "a learning about widgets"})
+    result = await _call(mcp, "trace_learn_recall", {"context": "widgets"})
+
+    warnings = " ".join(result.get("warnings", []))
+    assert "OPENAI_API_KEY" in warnings
+    assert ".env" in warnings
+
+
+async def test_a_rejected_key_surfaces_as_its_own_error_not_a_strict_mode_one(
+    learn_mcp, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Covers the two paths a rejected credential could have escaped through:
+    the embed step swallowing it with strict mode off, and the handler labelling
+    it "strict mode blocked fallback" — advice that sends the reader to a knob
+    which cannot fix it."""
+    import trace_mcp.extensions.learn as learn_pkg
+
+    class _RejectingProvider:
+        model_name = "text-embedding-3-small"
+
+        async def embed_texts(self, texts: list[str]) -> list[list[float]]:
+            raise ApiKeyRejectedError("OpenAI REJECTED the API key. The key came from this project's .env.")
+
+    write_project, _write_global = learn_mcp
+    write_project({"OPENAI_API_KEY": "sk-rejected", "TRACE_STRICT_LLM": "false"})
+    monkeypatch.setattr(learn_pkg, "get_embedding_provider", lambda _config: _RejectingProvider())
+
+    mcp = FastMCP("key-scope-test")
+    learn_pkg.register(mcp, JsonFileStorage(directory=str(tmp_path / "sessions")))
+
+    result = await _call(mcp, "trace_learn_add", {"content": "a learning about widgets"})
+    assert result.get("error") == "OpenAI API key rejected", result
+    assert "strict" not in result["error"].lower()
+
+
+async def test_recall_on_an_empty_store_still_carries_the_warning(learn_mcp, tmp_path: Path) -> None:
+    """A first-run project is where a missing key most needs saying out loud."""
+    write_project, _write_global = learn_mcp
+    write_project({"TRACE_LLM_ENABLED": "true"})
+
+    from trace_mcp.extensions.learn import register
+
+    mcp = FastMCP("key-scope-test")
+    register(mcp, JsonFileStorage(directory=str(tmp_path / "sessions")))
+
+    result = await _call(mcp, "trace_learn_recall", {"context": "anything"})
+    assert result["total"] == 0
+    assert "OPENAI_API_KEY" in " ".join(result.get("warnings", []))
+
+
+async def test_recall_has_no_warnings_when_the_key_is_present(learn_mcp, tmp_path: Path) -> None:
+    write_project, _write_global = learn_mcp
+    # Strict mode off so keyword matching is a legitimate backend here; with it
+    # on and no embedding provider, a warning is the CORRECT output and the
+    # sibling test above covers that.
+    write_project({"OPENAI_API_KEY": "project-key", "TRACE_EMBEDDING_BACKEND": "none", "TRACE_STRICT_LLM": "false"})
+
+    from trace_mcp.extensions.learn import register
+
+    mcp = FastMCP("key-scope-test")
+    register(mcp, JsonFileStorage(directory=str(tmp_path / "sessions")))
+
+    await _call(mcp, "trace_learn_add", {"content": "a learning about widgets"})
+    result = await _call(mcp, "trace_learn_recall", {"context": "widgets"})
+    assert not result.get("warnings")


### PR DESCRIPTION
## Summary

The OpenAI API key is now per project: a project's own `.env` overrides the
machine-global `~/.trace/.env` (an exported environment variable still wins over
both). A missing or refused key is reported instead of silently degrading to
keyword matching.

## Why

Precedence was inverted — the global file shadowed every project's `.env` — so a
key placed in a project was silently ignored. Per-project credentials keep one
leaked or exhausted key from covering every project on the machine.

That makes "this project has no key yet" routine, and that case used to be
invisible: recall returned keyword-ranked results with nothing to say the
semantic path had been skipped.

## What changed

Scope:

- `./.env` > `~/.trace/.env`, with an exported variable above both.
- A blank value never overrides a real one in any source, so copying a template
  with a bare `OPENAI_API_KEY=` cannot mask a working key.
- `TRACE_LOCAL_ONLY` is exempt — a restrict-only ratchet ORed across sources, so
  no project can switch a machine-wide kill switch off.

Loud failures:

- No key while a cloud path is requested → a warning in the
  `trace_start_session` banner and in the affected `trace_learn_*` responses,
  naming where it looked and which file to fix. Recall still answers on BM25 and
  says so.
- Key rejected (401) → `ApiKeyRejectedError` on the matching, extraction, and
  embedding paths regardless of `TRACE_STRICT_LLM`, with the key scrubbed from
  the message. 403 is excluded — it also covers model access, region, and proxy
  failures — and stays on the strict-mode path.
- A project borrowing the global key is named at session start; a project
  ratcheted offline is not warned about a key it does not want.

Also fixed: a matching backend that could not be built used to escape into the
extension loader, so the server came up with the 17 core tools and no
explanation. It now registers with keyword matching and reports the reason.

Docs: `.env.example` added; README, CLAUDE.md, `docs/extensions/trace-learn.md`,
and the consumer CLAUDE.md block updated. Configuration is read once at server
start, so a `.env` edit needs a server restart.

## Verification

1378 passed, 12 skipped — 25 new cases covering precedence in both directions,
blank-value shadowing (including the shipped template verbatim), the ratchet,
key provenance, 401 vs 403, message redaction, and each warning surface. Both
ruff gates, pyright, and the invariant guard clean. Checked against a real
installation: a project's key is now the one resolved, reported as coming from
that project's file.

## Risks / rollback

An installation with keys in more than one place switches to the project's key.
A stale one surfaces as an explicit error naming the file to fix rather than as
degraded results. Revert restores the previous order.
