### PR TITLE
feat(conformance): add `trace-mcp fleet-check` for fleet-wide sweeps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`trace-mcp fleet-check [ROOTS...] [--live] [--json]`.** Runs the deployed-state
+  doctor over every project declaring a TRACE server under the given roots and
+  rolls failures up by check, which is the view a fleet actually needs: not
+  "these 23 projects are broken" but "this one defect appears in 23 projects".
+  Roots come from arguments or `TRACE_FLEET_ROOTS`; with neither, the command
+  exits as a usage error rather than guessing a directory — a checker that
+  assumes one machine's layout silently surveys nothing on another and reports
+  that as a healthy fleet. The walk is depth-capped, skips dependency and VCS
+  directories, does not follow symlinks, and reports a project once however many
+  roots reach it. Unreadable roots and unparseable configs are reported and make
+  the sweep non-clean; a project whose check raises is reported as failed rather
+  than ending the sweep. Directories that cannot be read are reported and make
+  the sweep non-clean — a partial survey presented as a complete one is the
+  failure this tool exists to prevent — while branches left un-descended at the
+  depth cap are reported as a count (a real tree truncates thousands of times,
+  and a flag that is always false is a flag nobody reads); `--max-depth` raises
+  the limit. `--live` lists the commands it would run and requires `--yes` before
+  executing any of them, since a sweep reaches directories the operator never
+  named individually.
+
 ### Changed
 
 - **The OpenAI API key is now per project: `./.env` overrides `~/.trace/.env`.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@ python scripts/generate_schema.py   # Regenerate JSON Schema from Pydantic model
 uv build && uv run pytest tests/test_packaging_artifacts.py   # Verify the shipped wheel/sdist before tagging
 trace-mcp identity check            # Report project-identity drift (non-zero exit on findings)
 trace-mcp doctor [DIR] [--live]     # Report deployed-state drift for one project (non-zero exit on findings)
+trace-mcp fleet-check [ROOTS...]    # Same check across every TRACE project under the given roots
 ```
 
 Two console scripts ship with the package: `trace-mcp` (the MCP server) and
@@ -66,7 +67,7 @@ src/trace_mcp/
     project_identity.py    # Canonical project keys + alias registry (~/.trace/projects.json)
     identity_cli.py        # `trace-mcp identity` migration subcommands
     identity_report.py     # Read-only drift/stray-store reporting for the CLI
-    conformance/           # `trace-mcp doctor` — deployed-state checks (INV-11)
+    conformance/           # `trace-mcp doctor` / `fleet-check` — deployed-state checks (INV-11)
     init_project.py        # `trace-mcp-init`: .mcp.json, TRACE_PROJECT pin, adapter dispatch
     scratchpad.py           # Session-end scratchpad generator
     extension_hooks.py     # Hook registry for extension ↔ core integration

--- a/README.md
+++ b/README.md
@@ -198,6 +198,29 @@ Exit codes: `0` clean, `1` findings, `2` usage error — a bad path is not an un
 
 `--live` is opt-in because it **runs the command the project's `.mcp.json` declares** — an action, not an inspection. It is the only check that catches a project whose config, hooks, and pins are all correct while the running server is a stale build; a warm `uv` cache can serve an old wheel for minutes even with `--refresh-package`, and the finding names the remedy (`uv cache clean trace-mcp`, then restart the server).
 
+### Sweep every project
+
+`trace-mcp fleet-check` runs the doctor over every project declaring a TRACE server under the roots you give it, and rolls the failures up by check — the view that turns "23 projects are broken" into "one fix, applied 23 times".
+
+```bash
+trace-mcp fleet-check ~/code ~/work     # sweep these roots
+TRACE_FLEET_ROOTS=~/code trace-mcp fleet-check
+trace-mcp fleet-check ~/code --json     # per-project reports + totals
+```
+
+```
+fleet-check: 1/24 project(s) clean
+  FAIL /path/to/project  (3 finding(s))
+         hooks.stamp: installed hook version differs from this build's [trace-hooks v0.5] ...
+fleet-check: failing checks, most widespread first
+    23 project(s)  pin.trace_project_file
+    14 project(s)  hooks.decision_audit_matcher
+```
+
+No path is compiled in: with no roots and no `TRACE_FLEET_ROOTS`, the command exits `2` rather than guessing a directory to sweep — a checker that assumes one machine's layout would silently survey nothing on another and report a healthy fleet. The walk is depth-capped, skips dependency and VCS directories, does not follow symlinks, and reports a project once however many roots reach it. A root or `.mcp.json` that cannot be read is reported and makes the sweep non-clean, since a partial survey is not a clean bill of health.
+
+`--live` applies the doctor's live probe to every project found — which means **running the server command each of those projects declares**. Because a sweep reaches directories you never named one by one, the first `--live` only lists the commands it would run; adding `--yes` executes them. `--max-depth` raises the walk limit, and the number of branches left un-descended is reported rather than silently omitted.
+
 A finding is `pass`, `fail`, or `skip` — where `skip` means *not evaluated* and always names the upstream check that made evaluation impossible. Exactly one check fails per root cause.
 
 The hook checks describe the Claude Code deployment, which is the only host adapter that installs today. A project set up with `--client none` has no hooks by construction and reports the `hooks.*` checks as failures — deliberately: an MCP server without host-side enforcement is a real gap in the audit trail, not a supported configuration to be waved through.
@@ -369,7 +392,7 @@ src/trace_mcp/
     project_identity.py    # Canonical project keys + alias registry
     identity_cli.py        # `trace-mcp identity` migration subcommands
     identity_report.py     # Read-only drift and stray-store reporting
-    conformance/           # `trace-mcp doctor`: deployed-state checks (INV-11)
+    conformance/           # `trace-mcp doctor` / `fleet-check`: deployed-state checks (INV-11)
     init_project.py        # `trace-mcp-init`: .mcp.json, pin, adapter dispatch
     validate.py            # `trace-mcp validate` schema conformance CLI
     scratchpad.py          # Session-end scratchpad generator

--- a/src/trace_mcp/conformance/__init__.py
+++ b/src/trace_mcp/conformance/__init__.py
@@ -11,6 +11,7 @@ expectations.
 Public API:
 
     run_doctor(project_dir, *, live=False) -> DoctorReport
+    run_fleet_check(roots, *, live=False) -> FleetReport
 
 ``DoctorReport.ok`` is False when any check failed; ``skip`` findings name the
 upstream check that made evaluation impossible and never make a report
@@ -37,6 +38,16 @@ from trace_mcp.conformance.expectations import (
     ExpectedServedBuild,
     ExpectedToolSurface,
     Finding,
+)
+from trace_mcp.conformance.fleet import (
+    FLEET_ROOTS_ENV,
+    MAX_DEPTH,
+    Discovery,
+    FleetReport,
+    discover_projects,
+    planned_live_commands,
+    roots_from_env,
+    run_fleet_check,
 )
 from trace_mcp.conformance.probes import (
     CONFIG_CHECKS,
@@ -100,20 +111,28 @@ def _guarded(name: str, owned: tuple[str, ...], probe: Callable[[], list[Finding
 
 __all__ = [
     "CONFIG_CHECKS",
+    "FLEET_ROOTS_ENV",
+    "MAX_DEPTH",
     "CORE_TOOLS",
     "HOOK_CHECKS",
     "LIVE_CHECKS",
     "LEARN_TOOLS",
     "PIN_CHECKS",
     "ConformanceAssetError",
+    "Discovery",
     "DoctorReport",
     "ExpectedHookDeployment",
     "ExpectedServedBuild",
     "ExpectedToolSurface",
     "Finding",
+    "FleetReport",
     "check_config",
     "check_hooks",
     "check_pin_coherence",
     "check_served_build",
+    "discover_projects",
+    "planned_live_commands",
+    "roots_from_env",
     "run_doctor",
+    "run_fleet_check",
 ]

--- a/src/trace_mcp/conformance/cli.py
+++ b/src/trace_mcp/conformance/cli.py
@@ -1,4 +1,4 @@
-"""``trace-mcp doctor`` — check one project's deployed TRACE state.
+"""``trace-mcp doctor`` and ``trace-mcp fleet-check`` — deployed-state CLIs.
 
     trace-mcp doctor [DIR] [--live] [--json]
 
@@ -17,11 +17,21 @@ executing a command out of a config file is an action, not an inspection.
 from __future__ import annotations
 
 import argparse
+import os
 import sys
 from pathlib import Path
 from typing import TextIO
 
-from trace_mcp.conformance import run_doctor
+from trace_mcp.conformance import (
+    FLEET_ROOTS_ENV,
+    MAX_DEPTH,
+    DoctorReport,
+    discover_projects,
+    planned_live_commands,
+    roots_from_env,
+    run_doctor,
+    run_fleet_check,
+)
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -68,4 +78,97 @@ def main(argv: list[str] | None = None, out: TextIO | None = None, err: TextIO |
     return EXIT_OK if report.ok else EXIT_FINDINGS
 
 
-__all__ = ["EXIT_FINDINGS", "EXIT_OK", "EXIT_USAGE", "build_parser", "main"]
+def build_fleet_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="trace-mcp fleet-check",
+        description="Check every project declaring a TRACE MCP server under the given roots.",
+    )
+    parser.add_argument(
+        "roots",
+        nargs="*",
+        default=None,
+        help=f"directories to sweep (default: ${FLEET_ROOTS_ENV}, {os.pathsep}-separated)",
+    )
+    parser.add_argument(
+        "--live",
+        action="store_true",
+        help=(
+            "also start each project's configured server command and verify the build it serves. "
+            "This RUNS a command declared by every project found; without --yes it only lists them."
+        ),
+    )
+    parser.add_argument(
+        "--yes",
+        action="store_true",
+        help="required with --live: confirm that the listed commands may be executed",
+    )
+    parser.add_argument(
+        "--max-depth",
+        type=int,
+        default=MAX_DEPTH,
+        metavar="N",
+        help=f"how far below each root to look (default: {MAX_DEPTH}); un-descended branches are reported",
+    )
+    parser.add_argument("--json", action="store_true", help="print the report as JSON instead of text")
+    return parser
+
+
+def main_fleet_check(argv: list[str] | None = None, out: TextIO | None = None, err: TextIO | None = None) -> int:
+    """Entry point for ``trace-mcp fleet-check``. Returns a process exit code.
+
+    Roots come from the arguments, else ``TRACE_FLEET_ROOTS``. With neither, the
+    command fails as a usage error rather than guessing a directory to sweep: a
+    checker that assumes one machine's layout silently surveys nothing on any
+    other, and reports that as a healthy fleet.
+    """
+    stream = out if out is not None else sys.stdout
+    errors = err if err is not None else sys.stderr
+    ns = build_fleet_parser().parse_args(argv)
+
+    roots = [Path(r).expanduser() for r in (ns.roots or [])] or roots_from_env()
+    if not roots:
+        print(
+            f"Error: no roots to sweep. Pass one or more directories, or set {FLEET_ROOTS_ENV} "
+            f"to a {os.pathsep}-separated list.",
+            file=errors,
+        )
+        return EXIT_USAGE
+
+    if ns.live and not ns.yes:
+        # Reading a config and executing what it declares are different acts, and
+        # a sweep executes commands from directories the operator never named
+        # one by one. List them and stop; --yes is the informed second step.
+        found = discover_projects(roots, max_depth=ns.max_depth)
+        print(
+            f"--live would execute the server command declared by {len(found.projects)} project(s):",
+            file=errors,
+        )
+        for project_dir, command in planned_live_commands(found.projects):
+            print(f"  {project_dir}\n      {command}", file=errors)
+        print("Re-run with --yes to execute them.", file=errors)
+        return EXIT_USAGE
+
+    def show_progress(report: DoctorReport, index: int, total: int) -> None:
+        """Per-project line on stderr: a live sweep budgets minutes per project,
+        and a silent terminal is indistinguishable from a hang."""
+        status = "ok  " if report.ok else "FAIL"
+        print(f"  [{index}/{total}] {status} {report.project_dir}", file=errors)
+
+    # JSON consumers get a pure stdout; progress would still go to stderr, but a
+    # machine-read sweep has no one watching it.
+    progress = None if ns.json else show_progress
+
+    report = run_fleet_check(roots, live=ns.live, max_depth=ns.max_depth, on_project=progress)
+    print(report.model_dump_json(indent=2) if ns.json else report.render(), file=stream)
+    return EXIT_OK if report.ok else EXIT_FINDINGS
+
+
+__all__ = [
+    "EXIT_FINDINGS",
+    "EXIT_OK",
+    "EXIT_USAGE",
+    "build_fleet_parser",
+    "build_parser",
+    "main",
+    "main_fleet_check",
+]

--- a/src/trace_mcp/conformance/fleet.py
+++ b/src/trace_mcp/conformance/fleet.py
@@ -1,0 +1,387 @@
+"""Fleet-wide deployed-state sweep: run the doctor over every TRACE project.
+
+``run_doctor`` answers "is this project's deployment sound?". The failures this
+codebase actually accumulates are fleet-shaped — one defect replicated across
+every consumer and found months later by hand: a hook matcher that never fired
+in most projects, hook copies frozen at an old release, identity pins that were
+never minted. Answering that question previously meant a bespoke shell loop,
+which is why it got answered about once.
+
+Discovery walks the roots the caller supplies — command-line arguments, or
+``TRACE_FLEET_ROOTS`` (``os.pathsep``-separated). **No path is ever compiled
+in**: a checker that assumes one machine's layout is a checker that silently
+surveys nothing on any other. The walk is depth-capped, skips dependency and
+VCS directories, does not follow symlinks (a loop would otherwise never
+terminate), and reports each project once however many roots reach it.
+
+Output shape is API. ``trace-mcp fleet-check --json`` is consumed by tooling as
+well as read by a person, so field names, the check ids inside each project's
+report, and the path ordering are stable; rename them with the care given a
+wire field.
+
+Nothing here writes. The one action available — ``--live``, which starts each
+project's configured server to see what it actually serves — is off by default
+and carries a warning of its own, because running the commands declared by every
+directory found in a sweep is a materially bigger act than reading their files.
+
+Exports: ``FleetReport``, ``discover_projects``, ``run_fleet_check``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Callable
+from pathlib import Path
+
+from pydantic import BaseModel, Field, computed_field
+
+from trace_mcp.adapters.base import MCP_SERVER_KEY
+from trace_mcp.conformance.expectations import DoctorReport, Finding
+
+FLEET_ROOTS_ENV = "TRACE_FLEET_ROOTS"
+
+MAX_DEPTH = 5
+"""How far below a root to look. Deep enough for the nested layouts consumers
+actually use (``<area>/<client>/<project>``), shallow enough that pointing this
+at a home directory finishes."""
+
+SKIP_DIRS = frozenset(
+    {
+        ".git",
+        ".hg",
+        ".svn",
+        "node_modules",
+        ".venv",
+        "venv",
+        "__pycache__",
+        ".mypy_cache",
+        ".pytest_cache",
+        ".ruff_cache",
+        "site-packages",
+        "Library",
+        ".Trash",
+    }
+)
+"""Directories a sweep never needs to enter. Dependency trees are the expensive
+ones: a vendored copy of some other project's config is not a deployment."""
+
+
+class FleetReport(BaseModel):
+    """Result of checking every discovered project under a set of roots."""
+
+    roots: list[Path] = Field(default_factory=list, description="Roots that were swept.")
+    projects: list[DoctorReport] = Field(
+        default_factory=list, description="Per-project reports, ordered by project path."
+    )
+    unreadable_roots: list[Path] = Field(
+        default_factory=list, description="Roots that do not exist or could not be read."
+    )
+    unreadable_configs: list[Path] = Field(
+        default_factory=list,
+        description="`.mcp.json` files that could not be parsed, so could not be classified as TRACE projects.",
+    )
+    unreadable_dirs: list[Path] = Field(
+        default_factory=list,
+        description="Directories that could not be read (permissions, dead mounts); anything below them is unsurveyed.",
+    )
+    truncated_dirs: list[Path] = Field(
+        default_factory=list,
+        description="Directories not descended into because the depth cap was reached; projects below are unsurveyed.",
+    )
+
+    @computed_field(description="Projects discovered and checked.")
+    @property
+    def total(self) -> int:
+        return len(self.projects)
+
+    @computed_field(description="Projects with no failing check.")
+    @property
+    def clean(self) -> int:
+        return sum(1 for p in self.projects if p.ok)
+
+    @computed_field(description="Projects with at least one failing check.")
+    @property
+    def with_findings(self) -> int:
+        return self.total - self.clean
+
+    @computed_field(
+        description="Failing check id -> number of projects failing it. The actionable fleet view: "
+        "which defect, how many consumers."
+    )
+    @property
+    def findings_by_check(self) -> dict[str, int]:
+        counts: dict[str, int] = {}
+        for project in self.projects:
+            for finding in project.failures():
+                counts[finding.check] = counts.get(finding.check, 0) + 1
+        return dict(sorted(counts.items(), key=lambda kv: (-kv[1], kv[0])))
+
+    @computed_field(
+        description="True when every discovered project is clean AND nothing was unreadable. "
+        "Depth truncation deliberately does NOT count: on a real tree it happens thousands of times, "
+        "and a flag that is always false is a flag nobody reads. It is reported as a count instead."
+    )
+    @property
+    def ok(self) -> bool:
+        return (
+            self.with_findings == 0
+            and not self.unreadable_roots
+            and not self.unreadable_configs
+            and not self.unreadable_dirs
+        )
+
+    def render(self) -> str:
+        """Human-readable summary: the counts, the failing projects, the rollup."""
+        lines = [f"fleet-check: {self.clean}/{self.total} project(s) clean"]
+        if self.total == 0:
+            lines.append("  0 projects discovered — check the roots, the depth cap, and the skip list.")
+        for path in self.unreadable_roots:
+            lines.append(f"  UNREADABLE ROOT   {path}")
+        for path in self.unreadable_configs:
+            lines.append(f"  UNREADABLE CONFIG {path}")
+        for path in self.unreadable_dirs:
+            lines.append(f"  UNREADABLE DIR    {path} (anything below it was not surveyed)")
+        if self.truncated_dirs:
+            shown = ", ".join(str(p) for p in self.truncated_dirs[:3])
+            more = f" (+{len(self.truncated_dirs) - 3} more)" if len(self.truncated_dirs) > 3 else ""
+            lines.append(
+                f"  note: {len(self.truncated_dirs)} director(ies) not descended at the depth cap — "
+                f"raise --max-depth to include them. First: {shown}{more}"
+            )
+        for project in self.projects:
+            if project.ok:
+                lines.append(f"  ok   {project.project_dir}")
+                continue
+            failed = project.failures()
+            lines.append(f"  FAIL {project.project_dir}  ({len(failed)} finding(s))")
+            lines += [f"         {f.check}: {f.detail.splitlines()[0]}" for f in failed]
+        if self.total == 0:
+            pass
+        elif self.findings_by_check:
+            lines.append("fleet-check: failing checks, most widespread first")
+            lines += [f"  {count:>4} project(s)  {check}" for check, count in self.findings_by_check.items()]
+        else:
+            lines.append("fleet-check: every discovered project matches this build's expectations.")
+        return "\n".join(lines)
+
+
+def roots_from_env() -> list[Path]:
+    """Roots declared in ``TRACE_FLEET_ROOTS``, or [] when unset.
+
+    Side effects: reads the environment.
+    """
+    raw = os.environ.get(FLEET_ROOTS_ENV, "")
+    return [Path(part).expanduser() for part in raw.split(os.pathsep) if part.strip()]
+
+
+def _declares_trace_server(config_path: Path) -> bool | None:
+    """True/False for a parseable config, None when it could not be read.
+
+    None is distinct on purpose: an unparseable `.mcp.json` might be a TRACE
+    project, so it is reported rather than quietly treated as somebody else's.
+    """
+    try:
+        data = json.loads(config_path.read_text(encoding="utf-8", errors="replace"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    servers = data.get("mcpServers")
+    return isinstance(servers, dict) and MCP_SERVER_KEY in servers
+
+
+class Discovery(BaseModel):
+    """What a walk found, and what it could not see."""
+
+    projects: list[Path] = Field(default_factory=list)
+    unreadable_roots: list[Path] = Field(default_factory=list)
+    unreadable_configs: list[Path] = Field(default_factory=list)
+    unreadable_dirs: list[Path] = Field(default_factory=list)
+    truncated_dirs: list[Path] = Field(default_factory=list)
+
+
+def discover_projects(roots: list[Path], *, max_depth: int = MAX_DEPTH) -> Discovery:
+    """Find every project under *roots* declaring a TRACE MCP server.
+
+    Every list is deterministically ordered, and a project reached through more
+    than one root appears once, resolved, so overlapping arguments do not
+    double-report it.
+
+    Nothing here raises for a hostile tree. A directory the process cannot stat
+    or list is recorded rather than propagated: on macOS a terminal without Full
+    Disk Access gets EPERM on TCC-gated directories, and a sweep that dies on the
+    first of them surveys nothing. What it could NOT see is reported, because a
+    partial survey presented as a complete one is the failure this tool exists to
+    prevent.
+
+    Side effects: reads directories and `.mcp.json` files under *roots*.
+    """
+    found = Discovery()
+    projects: set[Path] = set()
+    unreadable_configs: set[Path] = set()
+    unreadable_dirs: set[Path] = set()
+    truncated: set[Path] = set()
+
+    for root in roots:
+        expanded = root.expanduser()
+        try:
+            if not expanded.is_dir():
+                found.unreadable_roots.append(root)
+                continue
+            base = expanded.resolve(strict=True)
+        except OSError:
+            found.unreadable_roots.append(root)
+            continue
+        _walk(base, 0, max_depth, projects, unreadable_configs, unreadable_dirs, truncated)
+
+    found.projects = sorted(projects)
+    found.unreadable_configs = sorted(unreadable_configs)
+    found.unreadable_dirs = sorted(unreadable_dirs)
+    found.truncated_dirs = sorted(truncated)
+    return found
+
+
+def _walk(
+    directory: Path,
+    depth: int,
+    max_depth: int,
+    projects: set[Path],
+    unreadable_configs: set[Path],
+    unreadable_dirs: set[Path],
+    truncated: set[Path],
+) -> None:
+    """Depth-first scan for `.mcp.json`, bounded, symlink-safe, and total.
+
+    Symlinked directories are not followed: a link pointing at an ancestor
+    would otherwise walk forever, and the target is either inside a root
+    already or deliberately outside the sweep.
+    """
+    config = directory / ".mcp.json"
+    try:
+        is_config = config.is_file()
+    except OSError:
+        unreadable_dirs.add(directory)
+        return
+    if is_config:
+        declares = _declares_trace_server(config)
+        if declares is None:
+            unreadable_configs.add(config)
+        elif declares:
+            projects.add(directory)
+
+    try:
+        entries = sorted(directory.iterdir())
+    except OSError:
+        unreadable_dirs.add(directory)
+        return
+
+    candidates: list[Path] = []
+    for entry in entries:
+        if entry.name in SKIP_DIRS or entry.name.startswith("."):
+            continue
+        try:
+            if entry.is_symlink() or not entry.is_dir():
+                continue
+        except OSError:
+            unreadable_dirs.add(entry)
+            continue
+        candidates.append(entry)
+
+    if depth >= max_depth:
+        # Record the branch instead of dropping it: a project below the cap is
+        # simply absent from the report, which reads as "not there".
+        truncated.update(candidates)
+        return
+    for entry in candidates:
+        _walk(entry, depth + 1, max_depth, projects, unreadable_configs, unreadable_dirs, truncated)
+
+
+def planned_live_commands(project_dirs: list[Path]) -> list[tuple[Path, str]]:
+    """The command each project would run under ``--live``, for review first.
+
+    Reading a config is not the same act as executing what it declares, and a
+    sweep executes commands from directories the operator never named
+    individually. Listing them is what makes ``--live`` an informed choice.
+
+    Side effects: reads each project's `.mcp.json`.
+    """
+    planned: list[tuple[Path, str]] = []
+    for project_dir in project_dirs:
+        try:
+            data = json.loads((project_dir / ".mcp.json").read_text(encoding="utf-8", errors="replace"))
+            entry = data["mcpServers"][MCP_SERVER_KEY]
+            argv = [str(entry.get("command", "?"))] + [str(a) for a in entry.get("args", [])]
+            planned.append((project_dir, " ".join(argv)))
+        except (OSError, json.JSONDecodeError, KeyError, TypeError, AttributeError):
+            planned.append((project_dir, "<unreadable server entry>"))
+    return planned
+
+
+def run_fleet_check(
+    roots: list[Path],
+    *,
+    live: bool = False,
+    max_depth: int = MAX_DEPTH,
+    on_project: Callable[[DoctorReport, int, int], None] | None = None,
+) -> FleetReport:
+    """Check every TRACE project under *roots*.
+
+    *live* is passed through to each project's doctor, which starts that
+    project's own configured server command. Across a sweep that means running a
+    command declared by every directory found, so it stays opt-in and the CLI
+    lists the commands before executing any of them.
+
+    *on_project* is called with each finished report plus its 1-based position
+    and the total, so a caller can show progress: sequential live probes budget
+    up to three minutes each, and a silent terminal for an hour is
+    indistinguishable from a hang.
+
+    Side effects: reads files under *roots*; with *live*, starts and terminates
+    one subprocess per project. Never writes.
+
+    A project whose check raises is reported as a failed project rather than
+    ending the sweep: surveying two dozen directories is the entire point, and
+    one pathological config must not cost the rest of the results.
+    """
+    from trace_mcp import conformance
+
+    found = discover_projects(roots, max_depth=max_depth)
+    reports: list[DoctorReport] = []
+    total = len(found.projects)
+    for index, project_dir in enumerate(found.projects, start=1):
+        try:
+            report = conformance.run_doctor(project_dir, live=live)
+        except Exception as exc:  # noqa: BLE001 - one bad project must not end the sweep
+            report = DoctorReport(
+                project_dir=project_dir,
+                findings=[
+                    Finding(
+                        check="doctor.crashed",
+                        status="fail",
+                        detail=f"checking this project raised {type(exc).__name__}: {exc}",
+                    )
+                ],
+            )
+        reports.append(report)
+        if on_project is not None:
+            on_project(report, index, total)
+    return FleetReport(
+        roots=list(roots),
+        projects=reports,
+        unreadable_roots=found.unreadable_roots,
+        unreadable_configs=found.unreadable_configs,
+        unreadable_dirs=found.unreadable_dirs,
+        truncated_dirs=found.truncated_dirs,
+    )
+
+
+__all__ = [
+    "FLEET_ROOTS_ENV",
+    "Discovery",
+    "FleetReport",
+    "discover_projects",
+    "planned_live_commands",
+    "roots_from_env",
+    "run_fleet_check",
+]

--- a/src/trace_mcp/server.py
+++ b/src/trace_mcp/server.py
@@ -1001,6 +1001,11 @@ def main() -> None:
 
         raise SystemExit(doctor_main(sys.argv[2:]))
 
+    if len(sys.argv) > 1 and sys.argv[1] == "fleet-check":
+        from trace_mcp.conformance.cli import main_fleet_check
+
+        raise SystemExit(main_fleet_check(sys.argv[2:]))
+
     if len(sys.argv) > 1 and sys.argv[1] == "validate":
         # In-package validator (schema ships as package data) — the previous
         # repo-relative load of scripts/validate_session.py crashed on any

--- a/tests/test_conformance_fleet_check.py
+++ b/tests/test_conformance_fleet_check.py
@@ -1,0 +1,422 @@
+"""Fleet-wide deployed-state sweep — `trace-mcp fleet-check`.
+
+The doctor answers "is THIS project's deployment sound?". The failure this
+codebase keeps hitting is fleet-shaped: one defect replicated across every
+consumer, discovered months later by hand — a matcher that never fired in most
+projects, hook copies frozen at an old release, pins that were never minted.
+Answering that at all previously meant a bespoke shell loop, which is why it
+was answered roughly once.
+
+Two properties matter beyond "it runs the doctor N times". The output is
+consumed by tooling as well as by a person, so **field names and check ids are
+stable and ordering is deterministic**. And a sweep reads configuration from
+directories nobody validated, so **one unreadable or malformed project must not
+end the sweep** — it is reported and the walk continues.
+
+Every test builds its own tree under tmp_path. Nothing here walks a real home
+directory.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from trace_mcp import project_identity as pident
+from trace_mcp.adapters.base import MCP_SERVER_KEY
+from trace_mcp.conformance import FleetReport, run_fleet_check
+from trace_mcp.conformance.cli import main_fleet_check as fleet_main
+from trace_mcp.init_project import init_project
+
+LIVE_CHECKS = {"live.spawn", "live.version", "live.tool_surface"}
+
+
+def _make_project(root: Path, name: str, monkeypatch: pytest.MonkeyPatch, *, client: str = "claude-code") -> Path:
+    """Initialize a project under *root* exactly as `trace-mcp-init` would."""
+    source = root / "TRACE-checkout"
+    source.mkdir(exist_ok=True)
+    monkeypatch.setenv("TRACE_SOURCE_PATH", str(source))
+    monkeypatch.setenv("TRACE_REGISTRY_PATH", str(root / "projects.json"))
+    pident._reset_registry_cache()
+    project_dir = root / name
+    project_dir.mkdir(parents=True, exist_ok=True)
+    init_project(str(project_dir), client=client)
+    pident._reset_registry_cache()
+    return project_dir
+
+
+def _break_hooks(project_dir: Path) -> None:
+    """Remove a hook script — the shape most deployed projects actually fail."""
+    (project_dir / ".claude" / "hooks" / "decision-audit.sh").unlink()
+
+
+@pytest.fixture()
+def fleet(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path, Path, Path]:
+    """A root holding one healthy project, one broken one, and a non-TRACE one."""
+    root = tmp_path / "fleet"
+    root.mkdir()
+    healthy = _make_project(root, "alpha", monkeypatch)
+    broken = _make_project(root, "beta", monkeypatch)
+    _break_hooks(broken)
+    unrelated = root / "gamma"
+    unrelated.mkdir()
+    (unrelated / ".mcp.json").write_text(json.dumps({"mcpServers": {"other-server": {"command": "node"}}}))
+    return root, healthy, broken
+
+
+# ── discovery ───────────────────────────────────────────────────────────────
+
+
+def test_finds_every_trace_project_and_ignores_the_rest(fleet) -> None:
+    root, healthy, broken = fleet
+    report = run_fleet_check([root])
+
+    checked = [p.project_dir for p in report.projects]
+    assert checked == sorted([healthy, broken]), "projects are reported in a deterministic path order"
+    assert not any("gamma" in str(p) for p in checked), "a config with no trace server is not this tool's business"
+
+
+def test_walk_is_depth_capped_and_skips_heavy_directories(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A sweep of a home directory must not descend forever or into dependency trees."""
+    root = tmp_path / "fleet"
+    root.mkdir()
+    shallow = _make_project(root, "shallow", monkeypatch)
+
+    deep = root / "a" / "b" / "c" / "d" / "e" / "f" / "deep"
+    deep.mkdir(parents=True)
+    (deep / ".mcp.json").write_text(json.dumps({"mcpServers": {MCP_SERVER_KEY: {"command": "uvx"}}}))
+
+    for ignored in (root / "node_modules" / "pkg", root / ".git" / "modules" / "x"):
+        ignored.mkdir(parents=True)
+        (ignored / ".mcp.json").write_text(json.dumps({"mcpServers": {MCP_SERVER_KEY: {"command": "uvx"}}}))
+
+    found = [p.project_dir for p in run_fleet_check([root]).projects]
+    assert shallow in found
+    assert deep not in found, "the walk must be depth-capped"
+    assert not any("node_modules" in str(p) or "/.git/" in str(p) for p in found)
+
+
+def test_a_symlink_loop_does_not_hang_the_walk(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    root = tmp_path / "fleet"
+    root.mkdir()
+    _make_project(root, "alpha", monkeypatch)
+    (root / "loop").symlink_to(root, target_is_directory=True)
+
+    report = run_fleet_check([root])
+    assert len(report.projects) == 1
+
+
+def test_the_same_project_reached_twice_is_reported_once(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Overlapping roots are the normal case when a user passes several paths."""
+    root = tmp_path / "fleet"
+    root.mkdir()
+    project = _make_project(root, "alpha", monkeypatch)
+
+    report = run_fleet_check([root, project, root])
+    assert [p.project_dir for p in report.projects] == [project]
+
+
+def test_a_root_that_does_not_exist_is_reported_not_ignored(tmp_path: Path) -> None:
+    """Silently sweeping nothing would report a perfectly healthy fleet."""
+    report = run_fleet_check([tmp_path / "no-such-place"])
+    assert report.unreadable_roots == [tmp_path / "no-such-place"]
+    assert not report.ok, "a root that could not be read means the sweep is not a clean bill of health"
+
+
+def test_an_unparseable_config_is_counted_rather_than_skipped(fleet) -> None:
+    """It might be a trace config; it cannot be classified, so it is surfaced."""
+    root, _healthy, _broken = fleet
+    (root / "delta").mkdir()
+    (root / "delta" / ".mcp.json").write_text("{not json")
+
+    report = run_fleet_check([root])
+    assert report.unreadable_configs == [root / "delta" / ".mcp.json"]
+    assert not report.ok
+
+
+@pytest.mark.skipif(os.geteuid() == 0, reason="root bypasses permission bits")
+def test_an_unreadable_directory_is_reported_and_the_sweep_continues(fleet) -> None:
+    """A directory the process cannot stat must not end the run.
+
+    This is the ordinary case on macOS, where a terminal without Full Disk
+    Access gets EPERM on TCC-gated directories — sweeping a home directory
+    would otherwise traceback instead of surveying the fleet.
+    """
+    root, _healthy, _broken = fleet
+    locked = root / "locked"
+    locked.mkdir()
+    locked.chmod(0o000)
+    try:
+        report = run_fleet_check([root])
+    finally:
+        locked.chmod(0o755)
+
+    assert report.total == 2, "the readable projects are still checked"
+    assert locked in report.unreadable_dirs
+    assert not report.ok, "a sweep that could not read part of the tree is not a clean bill of health"
+
+
+@pytest.mark.skipif(os.geteuid() == 0, reason="root bypasses permission bits")
+def test_an_unlistable_directory_is_reported_rather_than_silently_skipped(fleet) -> None:
+    """`iterdir` failing hides every project below that point; saying nothing
+    would report a partial survey as a healthy fleet."""
+    root, _healthy, _broken = fleet
+    blind = root / "blind"
+    blind.mkdir()
+    (blind / "nested").mkdir()
+    blind.chmod(0o111)  # traversable, not listable
+    try:
+        report = run_fleet_check([root])
+    finally:
+        blind.chmod(0o755)
+
+    assert blind in report.unreadable_dirs
+    assert not report.ok
+
+
+def test_depth_truncation_is_recorded_not_silent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A project below the cap is absent from the report, so the report says how
+    many branches were cut rather than implying it surveyed everything."""
+    root = tmp_path / "fleet"
+    root.mkdir()
+    deep = root / "a" / "b" / "c" / "d" / "e" / "f"
+    deep.mkdir(parents=True)
+    (deep / ".mcp.json").write_text(json.dumps({"mcpServers": {MCP_SERVER_KEY: {"command": "uvx"}}}))
+
+    report = run_fleet_check([root])
+    assert report.truncated_dirs, "the walk stopped at the cap and must say so"
+    rendered = report.render()
+    assert "depth cap" in rendered and "--max-depth" in rendered
+    # Truncation is a note, not a defect: a real tree truncates thousands of
+    # times, and tying `ok` to it would make the flag permanently false and
+    # therefore permanently ignored.
+    assert report.ok
+
+
+def test_a_raised_max_depth_reaches_a_deeper_project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    root = tmp_path / "fleet"
+    root.mkdir()
+    nested = root / "a" / "b" / "c" / "d" / "e"
+    nested.mkdir(parents=True)
+    deep = _make_project(nested, "deep", monkeypatch)
+
+    assert deep not in [p.project_dir for p in run_fleet_check([root]).projects]
+    assert deep in [p.project_dir for p in run_fleet_check([root], max_depth=10).projects]
+
+
+# ── aggregation ─────────────────────────────────────────────────────────────
+
+
+def test_totals_match_the_per_project_reports(fleet) -> None:
+    root, healthy, _broken = fleet
+    report = run_fleet_check([root])
+
+    assert report.total == 2
+    assert report.clean == 1
+    assert report.with_findings == 1
+    assert {p.project_dir for p in report.projects if p.ok} == {healthy}
+
+
+def test_findings_are_rolled_up_by_check(fleet) -> None:
+    """The actionable view for a fleet: which defect, how many projects — that is
+    how one fix gets planned across many consumers."""
+    root, _healthy, _broken = fleet
+    report = run_fleet_check([root])
+
+    assert report.findings_by_check["hooks.present"] == 1
+    assert all(count >= 1 for count in report.findings_by_check.values())
+    assert "hooks.executable" not in report.findings_by_check, "only FAILING checks are rolled up"
+
+
+def test_an_empty_fleet_says_so_instead_of_printing_an_all_clear(tmp_path: Path) -> None:
+    """Nothing failed, but "every discovered project matches" over zero projects
+    reads as a healthy fleet when the likely cause is a mistyped root."""
+    root = tmp_path / "empty"
+    root.mkdir()
+    report = run_fleet_check([root])
+
+    assert report.total == 0
+    assert report.ok, "no projects is not the same as broken projects"
+    rendered = report.render()
+    assert "0 project" in rendered
+    assert "every discovered project matches" not in rendered
+
+
+def test_one_crashing_project_does_not_end_the_sweep(fleet, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A sweep exists to survey many directories; a single pathological one must
+    not cost the operator the other twenty-three results."""
+    import trace_mcp.conformance as conformance
+
+    real = conformance.run_doctor
+    root, healthy, broken = fleet
+
+    def explode(project_dir: Path, *, live: bool = False):
+        if project_dir == broken:
+            raise RuntimeError("doctor exploded")
+        return real(project_dir, live=live)
+
+    monkeypatch.setattr(conformance, "run_doctor", explode)
+    report = run_fleet_check([root])
+
+    assert report.total == 2, "the crashed project is still reported"
+    crashed = next(p for p in report.projects if p.project_dir == broken)
+    assert not crashed.ok
+    assert any("exploded" in f.detail for f in crashed.findings)
+    assert next(p for p in report.projects if p.project_dir == healthy).ok
+
+
+# ── report shape (consumed by tooling) ──────────────────────────────────────
+
+
+def test_report_json_round_trips_with_its_totals(fleet) -> None:
+    root, _healthy, _broken = fleet
+    report = run_fleet_check([root])
+    payload = json.loads(report.model_dump_json())
+
+    for field in ("total", "clean", "with_findings", "ok", "projects", "findings_by_check"):
+        assert field in payload, f"{field} is part of the documented output shape"
+    restored = FleetReport.model_validate_json(report.model_dump_json())
+    assert restored.total == report.total
+    assert [p.project_dir for p in restored.projects] == [p.project_dir for p in report.projects]
+
+
+def test_offline_sweep_leaves_the_live_checks_unevaluated(fleet) -> None:
+    root, _healthy, _broken = fleet
+    report = run_fleet_check([root])
+    for project in report.projects:
+        skipped = {f.check for f in project.findings if f.status == "skip"}
+        assert LIVE_CHECKS <= skipped, "a sweep must not spawn servers unless asked"
+
+
+# ── CLI ─────────────────────────────────────────────────────────────────────
+
+
+def test_cli_exit_codes_distinguish_findings_from_usage(fleet, tmp_path: Path, capsys) -> None:
+    root, healthy, _broken = fleet
+
+    assert fleet_main([str(root)]) == 1, "a broken project means findings"
+    assert fleet_main([str(healthy)]) == 0
+    capsys.readouterr()
+
+    assert fleet_main([]) == 2, "no roots given and none configured is a usage error"
+    assert "TRACE_FLEET_ROOTS" in capsys.readouterr().err
+
+
+def test_cli_reads_roots_from_the_environment(fleet, monkeypatch: pytest.MonkeyPatch, capsys) -> None:
+    """No personal path is ever compiled in; the operator supplies the roots."""
+    root, _healthy, _broken = fleet
+    monkeypatch.setenv("TRACE_FLEET_ROOTS", str(root))
+
+    assert fleet_main([]) == 1
+    assert "alpha" in capsys.readouterr().out
+
+
+def test_cli_json_output_parses(fleet, capsys) -> None:
+    root, _healthy, _broken = fleet
+    fleet_main([str(root), "--json"])
+    report = FleetReport.model_validate_json(capsys.readouterr().out)
+    assert report.total == 2
+
+
+def test_cli_summary_names_the_failing_projects_and_the_common_defects(fleet, capsys) -> None:
+    root, _healthy, _broken = fleet
+    fleet_main([str(root)])
+    out = capsys.readouterr().out
+
+    assert "beta" in out, "a failing project must be named"
+    assert "hooks.present" in out, "the rollup tells the operator what to fix across the fleet"
+    assert "1/2" in out or "1 of 2" in out
+
+
+def test_server_cli_dispatches_fleet_check(fleet, monkeypatch: pytest.MonkeyPatch) -> None:
+    """`trace-mcp fleet-check` must reach the sweep, not fall through to the server."""
+    import sys
+
+    from trace_mcp import server as srv
+
+    _root, healthy, _broken = fleet
+    monkeypatch.setattr(sys, "argv", ["trace-mcp", "fleet-check", str(healthy)])
+    with pytest.raises(SystemExit) as exc:
+        srv.main()
+    assert exc.value.code == 0
+
+
+def test_live_is_not_implied_by_a_plain_sweep(fleet, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A sweep runs the commands declared by every directory it finds when --live
+    is given, so nothing may turn it on implicitly."""
+    from trace_mcp.conformance import fleet as fleet_mod
+
+    seen: list[bool] = []
+    real = fleet_mod.discover_projects
+
+    import trace_mcp.conformance as conformance
+
+    real_doctor = conformance.run_doctor
+
+    def spy(project_dir, *, live: bool = False):
+        seen.append(live)
+        return real_doctor(project_dir, live=live)
+
+    monkeypatch.setattr(conformance, "run_doctor", spy)
+    root, _healthy, _broken = fleet
+    fleet_mod.run_fleet_check([root])
+    assert seen and not any(seen)
+    assert real is fleet_mod.discover_projects
+
+
+# ── --live is an informed second step ───────────────────────────────────────
+
+
+def test_live_without_confirmation_lists_commands_and_runs_nothing(fleet, monkeypatch, capsys) -> None:
+    """A sweep executes commands from directories the operator never named one
+    by one, so the first `--live` shows what would run and stops."""
+    import trace_mcp.conformance as conformance
+
+    spawned: list[bool] = []
+    real = conformance.run_doctor
+    monkeypatch.setattr(
+        conformance,
+        "run_doctor",
+        lambda d, *, live=False: (spawned.append(live), real(d, live=False))[1],
+    )
+
+    root, _healthy, _broken = fleet
+    assert fleet_main([str(root), "--live"]) == 2
+    err = capsys.readouterr().err
+    assert "would execute" in err and "uvx" in err and "--yes" in err
+    assert not spawned, "nothing may be started before the operator has seen the list"
+
+
+def test_live_with_confirmation_passes_through(fleet, monkeypatch, capsys) -> None:
+    import trace_mcp.conformance as conformance
+
+    seen: list[bool] = []
+    real = conformance.run_doctor
+
+    def spy(project_dir, *, live: bool = False):
+        seen.append(live)
+        return real(project_dir, live=False)  # do not actually spawn in tests
+
+    monkeypatch.setattr(conformance, "run_doctor", spy)
+    root, _healthy, _broken = fleet
+    fleet_main([str(root), "--live", "--yes"])
+    assert seen and all(seen)
+
+
+def test_progress_is_streamed_so_a_long_sweep_is_not_a_silent_terminal(fleet, capsys) -> None:
+    root, _healthy, _broken = fleet
+    fleet_main([str(root)])
+    err = capsys.readouterr().err
+    assert "[1/2]" in err and "[2/2]" in err
+
+
+def test_json_mode_keeps_stdout_pure(fleet, capsys) -> None:
+    """Progress goes to stderr; a --json consumer must get only the report."""
+    root, _healthy, _broken = fleet
+    fleet_main([str(root), "--json"])
+    captured = capsys.readouterr()
+    FleetReport.model_validate_json(captured.out)
+    assert "[1/2]" not in captured.out


### PR DESCRIPTION
## Summary

`trace-mcp fleet-check [ROOTS...] [--live] [--yes] [--max-depth N] [--json]` runs
the deployed-state doctor over every project declaring a TRACE server under the
given roots, and rolls the failures up by check.

```
fleet-check: 1/24 project(s) clean
  FAIL /path/to/project  (3 finding(s))
         hooks.stamp: installed hook version differs from this build's [trace-hooks v0.5] ...
fleet-check: failing checks, most widespread first
    23 project(s)  pin.trace_project_file
    14 project(s)  hooks.decision_audit_matcher
```

## Why

The doctor answers whether one project is sound. The failures this codebase
accumulates are fleet-shaped — one defect replicated across every consumer,
found months later by hand. The rollup is the point: a fleet needs "this one
defect appears in 23 projects", not 23 reports to read.

## Notes

- Roots come from arguments or `TRACE_FLEET_ROOTS`; with neither, exit `2`
  rather than guessing a directory, since a checker that assumes one machine's
  layout silently surveys nothing on another and calls it healthy.
- The walk is depth-capped, skips dependency and VCS directories, does not
  follow symlinks, and reports a project once however many roots reach it.
- It is total: every stat and listing is guarded. `Path.is_file()` propagates
  EACCES, so one unreadable directory would otherwise abort the sweep — the
  ordinary case on macOS without Full Disk Access. Unreadable paths are reported
  and make the sweep non-clean; a project whose check raises is reported as
  failed rather than ending the run.
- Branches left un-descended at the cap are a counted note with a `--max-depth`
  escape, not defects — a real tree truncates thousands of times.
- `--live` lists the commands it would run and requires `--yes`, because a sweep
  reaches directories the operator never named individually.
- Progress streams to stderr; stdout stays pure for `--json`.
- Exit codes match the doctor: 0 clean, 1 findings, 2 usage.

## Verification

1404 passed, 12 skipped — 26 new cases covering discovery (depth cap and its
reporting, skip list, symlink loop, overlapping roots, unreadable and unlistable
directories), aggregation and the rollup, crash containment, report
round-tripping, the `--live` gate, progress streaming, and exit codes. Both ruff
gates and pyright clean. Run against a real 24-project fleet, the output matches
the hand census that previously took a manual sweep.
