### PR TITLE
docs(examples): add a golden walkthrough generated from one scenario

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **A golden walkthrough of the provenance loop, generated from one scenario**
+  (`examples/walkthrough/`). A single scenario definition
+  (`scenario.py`) — start a session, propose a decision, a human accepts it,
+  log a contribution and a correction, end the session and read the attribution
+  audit, query the decision back to confirm it was proposed by the AI and
+  resolved by the human, add and extract learnings (idempotently), recall one
+  with a score, and watch a cross-project read *and* write both fail closed
+  with no foreign store created — feeds two consumers that cannot disagree:
+  the committed `WALKTHROUGH.md` a person reads (rendered by
+  `render_walkthrough.py`), and `tests/test_walkthrough_e2e.py`, which drives
+  the same steps against a live server over MCP stdio. A sync test re-renders
+  the scenario and diffs it against the committed markdown, so the manual doc
+  and the automated run can never drift — the exact failure mode a walkthrough
+  is meant to prevent. The run pins a hermetic project with all data
+  directories redirected to a scratch location, so it also serves as the
+  post-deploy canary flow without touching a real `~/.trace`.
 - **Cross-process concurrency smoke for the knowledge store**
   (`tests/test_concurrency_smoke.py`). Two real server processes speaking MCP
   over stdio share one temporary TRACE home and add learnings in interleaved

--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -1,0 +1,1 @@
+"""Runnable examples for TRACE. Not part of the installed package."""

--- a/examples/walkthrough/WALKTHROUGH.md
+++ b/examples/walkthrough/WALKTHROUGH.md
@@ -1,0 +1,297 @@
+<!-- GENERATED FILE — do not edit by hand.
+Regenerate with: python examples/walkthrough/render_walkthrough.py
+Source of truth: examples/walkthrough/scenario.py -->
+
+# TRACE walkthrough
+
+A single pass through the TRACE provenance loop, from opening a session to a
+cross-project denial. Every step below is one MCP tool call and the response to
+look for. This same scenario is replayed against a live server by
+`tests/test_walkthrough_e2e.py`, which asserts the responses shown here, so what
+you read is what the server does.
+
+To follow along hermetically — never touching your real `~/.trace` — launch a
+server pinned to the `walkthrough` project with every data path redirected to a
+fresh scratch location (knowledge store, sessions, scratchpads, the egress
+ledger, and the registry):
+
+```bash
+DIR="$(mktemp -d)"; mkdir -p "$DIR/knowledge"
+TRACE_PROJECT=walkthrough \
+  TRACE_KNOWLEDGE_DIR="$DIR/knowledge" \
+  TRACE_SESSIONS_DIR="$DIR/sessions" \
+  TRACE_SCRATCHPAD_DIR="$DIR/scratchpads" \
+  TRACE_EGRESS_LOG="$DIR/egress.log" \
+  TRACE_REGISTRY_PATH="$DIR/projects.json" \
+  TRACE_EMBEDDING_BACKEND=none TRACE_LLM_ENABLED=false \
+  trace-mcp
+```
+
+`$SESSION_ID` stands for the session id printed in step 1;
+substitute the real one as you go.
+
+## Step 1 — Start a session
+
+Open a session at the start of a workflow. The server is pinned, so `project` is omitted and resolves to the pinned key. The banner reports the session id used below.
+
+```json
+{
+  "tool": "trace_start_session",
+  "arguments": {
+    "description": "Golden walkthrough of the TRACE provenance loop.",
+    "participants": [
+      {
+        "id": "human",
+        "type": "human",
+        "role": "researcher"
+      },
+      {
+        "id": "claude",
+        "type": "ai",
+        "role": "assistant"
+      }
+    ],
+    "tags": [
+      "walkthrough"
+    ]
+  }
+}
+```
+
+Look for in the response:
+
+- `TRACE audit logging is now active`
+- `Project: walkthrough`
+- `Session:`
+
+## Step 2 — Propose a decision (AI)
+
+Log the decision BEFORE acting. The AI authored the proposal, so `proposed_by` is the AI — regardless of who later accepts it. It stays in the proposed state until resolved. It is the first event of the session, `evt_001`, which the next steps reference.
+
+```json
+{
+  "tool": "trace_propose_decision",
+  "arguments": {
+    "description": "Use median imputation for the three missing station readings.",
+    "proposed_by_type": "ai",
+    "proposed_by_id": "claude",
+    "suggestion_type": "proactive",
+    "rationale": "Median resists the two outliers a mean would chase.",
+    "session_id": "$SESSION_ID"
+  }
+}
+```
+
+Look for in the response:
+
+- `Decision proposed: evt_001`
+
+## Step 3 — Resolve the decision (human accepts)
+
+The human accepts the AI's proposal. Proposer stays the AI, resolver is the human — the attribution the record is built to keep. The proposal was `evt_001` in this session.
+
+```json
+{
+  "tool": "trace_resolve_decision",
+  "arguments": {
+    "event_id": "evt_001",
+    "disposition": "accepted",
+    "resolved_by_type": "human",
+    "resolved_by_id": "human",
+    "session_id": "$SESSION_ID"
+  }
+}
+```
+
+Look for in the response:
+
+- `Decision evt_001 resolved: accepted`
+
+## Step 4 — Log a contribution
+
+One contribution per artifact, splitting who had the idea (direction) from who did the work (execution), and linked to the decision that motivated it.
+
+```json
+{
+  "tool": "trace_log_contribution",
+  "arguments": {
+    "description": "Imputation applied to the station-readings table.",
+    "direction": "human",
+    "execution": "ai",
+    "artifact": "data/stations.csv",
+    "related_decision_ids": [
+      "evt_001"
+    ],
+    "conversation_snippet": "use median imputation for the missing readings",
+    "session_id": "$SESSION_ID"
+  }
+}
+```
+
+Look for in the response:
+
+- `Logged contribution:`
+
+## Step 5 — Log a correction
+
+A correction records a caught mistake and links to what it corrects. This is how the record keeps the mistakes, not just the tidy final answer.
+
+```json
+{
+  "tool": "trace_log_annotation",
+  "arguments": {
+    "category": "correction",
+    "content": "The mean was used at first; the human caught it and the median was applied.",
+    "corrects_event_ids": [
+      "evt_001"
+    ],
+    "conversation_snippet": "that's wrong, use the median not the mean",
+    "session_id": "$SESSION_ID"
+  }
+}
+```
+
+Look for in the response:
+
+- `Logged annotation:`
+
+## Step 6 — End the session
+
+Ending the session prints the Attribution Audit, and this is where the attribution is read back: the contribution's direction and execution, the decision proposed by the AI and accepted, and the correction linked to `evt_001`. The audit names the session id.
+
+```json
+{
+  "tool": "trace_end_session",
+  "arguments": {
+    "session_id": "$SESSION_ID",
+    "summary": "Walkthrough complete: one decision proposed, accepted, applied, and corrected.",
+    "write_scratchpad": false
+  }
+}
+```
+
+Look for in the response:
+
+- `Session ended:`
+- `--- Attribution Audit ---`
+- `Contributions (1):`
+- `direction=human, execution=ai`
+- `artifact=data/stations.csv`
+- `Decisions (1):`
+- `proposed_by=ai`
+- `disposition=accepted`
+- `Corrections: 1 (corrects: evt_001)`
+
+## Step 7 — Read the decision back
+
+Query the completed session's decisions. The record kept both halves of the attribution: proposed by the AI, resolved by the human, accepted. That proposer-vs-resolver split is the distinction the whole system exists to preserve.
+
+```json
+{
+  "tool": "trace_get_decisions",
+  "arguments": {
+    "session_id": "$SESSION_ID"
+  }
+}
+```
+
+Look for in the response:
+
+- `"proposed_by":{"type":"ai"`
+- `"resolved_by":{"type":"human"`
+- `"disposition":"accepted"`
+
+## Step 8 — Add a learning
+
+Learnings persist in the project's knowledge store on disk. `project` is omitted and resolves to the pin, the same as the session tools. The response echoes the new learning's id and content.
+
+```json
+{
+  "tool": "trace_learn_add",
+  "arguments": {
+    "content": "peregrine falcon telemetry sentinel: median imputation beat the mean on the station readings.",
+    "category": "learning"
+  }
+}
+```
+
+Look for in the response:
+
+- `"added"`
+- `"id": "lrn_`
+- `peregrine falcon telemetry sentinel`
+
+## Step 9 — Extract learnings from the record
+
+Extraction mines the session's decisions and annotations into durable learnings. It already ran when the session ended, so running it again here adds nothing: extraction is idempotent, and this call reports `new_learnings: 0`.
+
+```json
+{
+  "tool": "trace_learn_extract",
+  "arguments": {}
+}
+```
+
+Look for in the response:
+
+- `"new_learnings": 0`
+
+## Step 10 — Recall a learning
+
+Recall ranks the store against a query and reports the backend that ranked it. The sentinel learning comes back with a score; the backend name makes a degraded ranker visible, never silent.
+
+```json
+{
+  "tool": "trace_learn_recall",
+  "arguments": {
+    "context": "peregrine falcon telemetry sentinel"
+  }
+}
+```
+
+Look for in the response:
+
+- `"results"`
+- `"score"`
+- `"backend"`
+- `peregrine falcon telemetry sentinel`
+
+## Step 11 — A write is denied across projects
+
+Under a pin, WRITING to another project fails closed the same way reading does — the error names both the pinned key and the label asked for, and no foreign store is created.
+
+```json
+{
+  "tool": "trace_learn_add",
+  "arguments": {
+    "project": "some-other-project",
+    "content": "should never be written"
+  }
+}
+```
+
+Look for in the response:
+
+- `"error"`
+- `walkthrough`
+- `some-other-project`
+
+## Step 12 — A read is denied across projects
+
+And reading another project fails closed too. Cross-project reads and writes do not silently cross; a follow-up check confirms no `some-other-project` store was created.
+
+```json
+{
+  "tool": "trace_learn_recall",
+  "arguments": {
+    "project": "some-other-project",
+    "context": "peregrine falcon telemetry sentinel"
+  }
+}
+```
+
+Look for in the response:
+
+- `"error"`
+- `walkthrough`
+- `some-other-project`

--- a/examples/walkthrough/__init__.py
+++ b/examples/walkthrough/__init__.py
@@ -1,0 +1,1 @@
+"""The golden walkthrough: one scenario, two consumers (a rendered doc and an E2E test)."""

--- a/examples/walkthrough/render_walkthrough.py
+++ b/examples/walkthrough/render_walkthrough.py
@@ -1,0 +1,99 @@
+"""Render the walkthrough scenario to the committed ``WALKTHROUGH.md``.
+
+`render_markdown` is pure — same scenario in, same bytes out, no timestamps or
+environment — so a test can re-render and diff against the committed file to
+prove the doc has not drifted from the scenario. Running this module as a script
+rewrites the file.
+
+Usage:
+    python examples/walkthrough/render_walkthrough.py
+
+Exports:
+    WALKTHROUGH_PATH   the committed markdown file this renders to
+    render_markdown    scenario -> markdown string (pure)
+    main               rewrite WALKTHROUGH_PATH from the current scenario
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+
+# Runnable as a plain script (`python examples/walkthrough/render_walkthrough.py`):
+# put the repo root on the path so the `examples` package imports either way.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from examples.walkthrough.scenario import PROJECT, SESSION_ID_PLACEHOLDER, STEPS, Step  # noqa: E402
+
+WALKTHROUGH_PATH = Path(__file__).resolve().parent / "WALKTHROUGH.md"
+
+_PREAMBLE = f"""<!-- GENERATED FILE — do not edit by hand.
+Regenerate with: python examples/walkthrough/render_walkthrough.py
+Source of truth: examples/walkthrough/scenario.py -->
+
+# TRACE walkthrough
+
+A single pass through the TRACE provenance loop, from opening a session to a
+cross-project denial. Every step below is one MCP tool call and the response to
+look for. This same scenario is replayed against a live server by
+`tests/test_walkthrough_e2e.py`, which asserts the responses shown here, so what
+you read is what the server does.
+
+To follow along hermetically — never touching your real `~/.trace` — launch a
+server pinned to the `{PROJECT}` project with every data path redirected to a
+fresh scratch location (knowledge store, sessions, scratchpads, the egress
+ledger, and the registry):
+
+```bash
+DIR="$(mktemp -d)"; mkdir -p "$DIR/knowledge"
+TRACE_PROJECT={PROJECT} \\
+  TRACE_KNOWLEDGE_DIR="$DIR/knowledge" \\
+  TRACE_SESSIONS_DIR="$DIR/sessions" \\
+  TRACE_SCRATCHPAD_DIR="$DIR/scratchpads" \\
+  TRACE_EGRESS_LOG="$DIR/egress.log" \\
+  TRACE_REGISTRY_PATH="$DIR/projects.json" \\
+  TRACE_EMBEDDING_BACKEND=none TRACE_LLM_ENABLED=false \\
+  trace-mcp
+```
+
+`{SESSION_ID_PLACEHOLDER}` stands for the session id printed in step 1;
+substitute the real one as you go.
+"""
+
+
+def _format_call(step: Step) -> str:
+    """A tool call rendered as a compact, copy-pasteable JSON block."""
+    payload = {"tool": step.tool, "arguments": step.arguments}
+    return json.dumps(payload, indent=2, ensure_ascii=False)
+
+
+def render_markdown(steps: Sequence[Step]) -> str:
+    """Render *steps* to the walkthrough markdown. Pure: no time, no environment."""
+    parts: list[str] = [_PREAMBLE.rstrip()]
+    for i, step in enumerate(steps, start=1):
+        expectations = "\n".join(f"- `{needle}`" for needle in step.expect_substrings)
+        parts.append(
+            f"## Step {i} — {step.name}\n\n"
+            f"{step.narration}\n\n"
+            f"```json\n{_format_call(step)}\n```\n\n"
+            f"Look for in the response:\n\n{expectations}"
+        )
+    return "\n\n".join(parts) + "\n"
+
+
+def main() -> None:
+    """Rewrite WALKTHROUGH_PATH from the current scenario. Side effect: writes a file.
+
+    Writes explicit LF bytes (``newline=""`` disables platform translation) so the
+    committed file is identical on every OS and the byte-for-byte sync test holds.
+    """
+    WALKTHROUGH_PATH.write_text(render_markdown(STEPS), encoding="utf-8", newline="")
+    print(f"wrote {WALKTHROUGH_PATH} ({len(STEPS)} steps)")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/walkthrough/scenario.py
+++ b/examples/walkthrough/scenario.py
@@ -1,0 +1,248 @@
+"""The golden-walkthrough scenario: one ordered list of steps, two consumers.
+
+This module is the single source of truth for the walkthrough. It is consumed
+by:
+
+- ``render_walkthrough.py`` → the committed ``WALKTHROUGH.md`` a human reads.
+- ``tests/test_walkthrough_e2e.py`` → the same steps driven over MCP stdio.
+
+A test re-renders this scenario and diffs it against the committed markdown, so
+the manual doc and the automated run can never drift apart.
+
+Each :class:`Step` is pure data: the tool to call, the arguments to call it
+with, the substrings its response must contain, and a one-line narration for
+the doc. The one dynamic value — the session id minted by ``start_session`` —
+is written as :data:`SESSION_ID_PLACEHOLDER` in the arguments; the E2E runner
+substitutes the captured id, and the renderer prints the placeholder verbatim.
+
+Exports:
+    PROJECT                  the hermetic project the walkthrough pins to
+    SESSION_ID_PLACEHOLDER   sentinel replaced with the live session id
+    Step                     one walkthrough step (frozen Pydantic model)
+    STEPS                    the ordered scenario
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+# The walkthrough pins a hermetic project so the golden doc is self-contained
+# and the cross-project denial step has a concrete pinned key to name.
+PROJECT = "walkthrough"
+
+# A distinctive phrase planted by the learn_add step and recalled verbatim, so
+# the recall step returns a scored hit deterministically — independent of what
+# offline rule-based extraction happens to produce from the session's events.
+SENTINEL = "peregrine falcon telemetry sentinel"
+
+# Written wherever a step needs the id that start_session mints at run time. The
+# renderer prints it literally; the E2E runner replaces it with the real id.
+SESSION_ID_PLACEHOLDER = "$SESSION_ID"
+
+# A label that is not the pinned project, used to show cross-project denial.
+FOREIGN_PROJECT = "some-other-project"
+
+
+class Step(BaseModel):
+    """One walkthrough step: a tool call, what to expect, and how to narrate it."""
+
+    model_config = ConfigDict(frozen=True)
+
+    name: str = Field(description="Short title for this step, shown as the doc heading.")
+    tool: str = Field(description="The MCP tool to call.")
+    arguments: dict[str, Any] = Field(description="Arguments for the call; may hold SESSION_ID_PLACEHOLDER.")
+    expect_substrings: tuple[str, ...] = Field(description="Substrings the response must contain.")
+    narration: str = Field(description="One or two sentences on what this step shows and what to look for.")
+    capture_session_id: bool = Field(default=False, description="Capture the session id from this step's response.")
+    expect_session_id: bool = Field(
+        default=False, description="Assert the captured session id appears in the response."
+    )
+
+
+STEPS: tuple[Step, ...] = (
+    Step(
+        name="Start a session",
+        tool="trace_start_session",
+        arguments={
+            "description": "Golden walkthrough of the TRACE provenance loop.",
+            "participants": [
+                {"id": "human", "type": "human", "role": "researcher"},
+                {"id": "claude", "type": "ai", "role": "assistant"},
+            ],
+            "tags": ["walkthrough"],
+        },
+        expect_substrings=("TRACE audit logging is now active", f"Project: {PROJECT}", "Session:"),
+        narration=(
+            "Open a session at the start of a workflow. The server is pinned, so `project` is "
+            "omitted and resolves to the pinned key. The banner reports the session id used below."
+        ),
+        capture_session_id=True,
+    ),
+    Step(
+        name="Propose a decision (AI)",
+        tool="trace_propose_decision",
+        arguments={
+            "description": "Use median imputation for the three missing station readings.",
+            "proposed_by_type": "ai",
+            "proposed_by_id": "claude",
+            "suggestion_type": "proactive",
+            "rationale": "Median resists the two outliers a mean would chase.",
+            "session_id": SESSION_ID_PLACEHOLDER,
+        },
+        expect_substrings=("Decision proposed: evt_001",),
+        narration=(
+            "Log the decision BEFORE acting. The AI authored the proposal, so `proposed_by` is the "
+            "AI — regardless of who later accepts it. It stays in the proposed state until resolved. "
+            "It is the first event of the session, `evt_001`, which the next steps reference."
+        ),
+    ),
+    Step(
+        name="Resolve the decision (human accepts)",
+        tool="trace_resolve_decision",
+        arguments={
+            "event_id": "evt_001",
+            "disposition": "accepted",
+            "resolved_by_type": "human",
+            "resolved_by_id": "human",
+            "session_id": SESSION_ID_PLACEHOLDER,
+        },
+        expect_substrings=("Decision evt_001 resolved: accepted",),
+        narration=(
+            "The human accepts the AI's proposal. Proposer stays the AI, resolver is the human — the "
+            "attribution the record is built to keep. The proposal was `evt_001` in this session."
+        ),
+    ),
+    Step(
+        name="Log a contribution",
+        tool="trace_log_contribution",
+        arguments={
+            "description": "Imputation applied to the station-readings table.",
+            "direction": "human",
+            "execution": "ai",
+            "artifact": "data/stations.csv",
+            "related_decision_ids": ["evt_001"],
+            "conversation_snippet": "use median imputation for the missing readings",
+            "session_id": SESSION_ID_PLACEHOLDER,
+        },
+        expect_substrings=("Logged contribution:",),
+        narration=(
+            "One contribution per artifact, splitting who had the idea (direction) from who did the "
+            "work (execution), and linked to the decision that motivated it."
+        ),
+    ),
+    Step(
+        name="Log a correction",
+        tool="trace_log_annotation",
+        arguments={
+            "category": "correction",
+            "content": "The mean was used at first; the human caught it and the median was applied.",
+            "corrects_event_ids": ["evt_001"],
+            "conversation_snippet": "that's wrong, use the median not the mean",
+            "session_id": SESSION_ID_PLACEHOLDER,
+        },
+        expect_substrings=("Logged annotation:",),
+        narration=(
+            "A correction records a caught mistake and links to what it corrects. This is how the "
+            "record keeps the mistakes, not just the tidy final answer."
+        ),
+    ),
+    Step(
+        name="End the session",
+        tool="trace_end_session",
+        arguments={
+            "session_id": SESSION_ID_PLACEHOLDER,
+            "summary": "Walkthrough complete: one decision proposed, accepted, applied, and corrected.",
+            "write_scratchpad": False,
+        },
+        expect_substrings=(
+            "Session ended:",
+            "--- Attribution Audit ---",
+            "Contributions (1):",
+            "direction=human, execution=ai",
+            "artifact=data/stations.csv",
+            "Decisions (1):",
+            "proposed_by=ai",
+            "disposition=accepted",
+            "Corrections: 1 (corrects: evt_001)",
+        ),
+        expect_session_id=True,
+        narration=(
+            "Ending the session prints the Attribution Audit, and this is where the attribution is "
+            "read back: the contribution's direction and execution, the decision proposed by the AI "
+            "and accepted, and the correction linked to `evt_001`. The audit names the session id."
+        ),
+    ),
+    Step(
+        name="Read the decision back",
+        tool="trace_get_decisions",
+        arguments={"session_id": SESSION_ID_PLACEHOLDER},
+        expect_substrings=(
+            '"proposed_by":{"type":"ai"',
+            '"resolved_by":{"type":"human"',
+            '"disposition":"accepted"',
+        ),
+        narration=(
+            "Query the completed session's decisions. The record kept both halves of the "
+            "attribution: proposed by the AI, resolved by the human, accepted. That proposer-"
+            "vs-resolver split is the distinction the whole system exists to preserve."
+        ),
+    ),
+    Step(
+        name="Add a learning",
+        tool="trace_learn_add",
+        arguments={
+            "content": f"{SENTINEL}: median imputation beat the mean on the station readings.",
+            "category": "learning",
+        },
+        expect_substrings=('"added"', '"id": "lrn_', SENTINEL),
+        narration=(
+            "Learnings persist in the project's knowledge store on disk. `project` is omitted and "
+            "resolves to the pin, the same as the session tools. The response echoes the new "
+            "learning's id and content."
+        ),
+    ),
+    Step(
+        name="Extract learnings from the record",
+        tool="trace_learn_extract",
+        arguments={},
+        expect_substrings=('"new_learnings": 0',),
+        narration=(
+            "Extraction mines the session's decisions and annotations into durable learnings. It "
+            "already ran when the session ended, so running it again here adds nothing: extraction "
+            "is idempotent, and this call reports `new_learnings: 0`."
+        ),
+    ),
+    Step(
+        name="Recall a learning",
+        tool="trace_learn_recall",
+        arguments={"context": SENTINEL},
+        expect_substrings=('"results"', '"score"', '"backend"', SENTINEL),
+        narration=(
+            "Recall ranks the store against a query and reports the backend that ranked it. The "
+            "sentinel learning comes back with a score; the backend name makes a degraded ranker "
+            "visible, never silent."
+        ),
+    ),
+    Step(
+        name="A write is denied across projects",
+        tool="trace_learn_add",
+        arguments={"project": FOREIGN_PROJECT, "content": "should never be written"},
+        expect_substrings=('"error"', PROJECT, FOREIGN_PROJECT),
+        narration=(
+            "Under a pin, WRITING to another project fails closed the same way reading does — the "
+            "error names both the pinned key and the label asked for, and no foreign store is created."
+        ),
+    ),
+    Step(
+        name="A read is denied across projects",
+        tool="trace_learn_recall",
+        arguments={"project": FOREIGN_PROJECT, "context": SENTINEL},
+        expect_substrings=('"error"', PROJECT, FOREIGN_PROJECT),
+        narration=(
+            "And reading another project fails closed too. Cross-project reads and writes do not "
+            "silently cross; a follow-up check confirms no `some-other-project` store was created."
+        ),
+    ),
+)

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,6 +1,7 @@
 {
-  "include": ["src", "tests", "scripts"],
+  "include": ["src", "tests", "scripts", "examples"],
   "exclude": ["**/__pycache__"],
+  "extraPaths": ["."],
   "pythonVersion": "3.11",
   "typeCheckingMode": "basic",
   "reportMissingImports": true,

--- a/tests/test_walkthrough_e2e.py
+++ b/tests/test_walkthrough_e2e.py
@@ -1,0 +1,133 @@
+"""The golden walkthrough, driven end-to-end over MCP stdio.
+
+One scenario definition (`examples/walkthrough/scenario.py`) is the single
+source for two artifacts: the committed `examples/walkthrough/WALKTHROUGH.md`
+(rendered by `render_walkthrough.py`) and the run below. This module pins two
+properties:
+
+1. **The doc is in sync with the scenario.** Re-rendering the scenario must
+   reproduce the committed markdown byte-for-byte; otherwise the manual
+   walkthrough and the automated one have drifted — the exact failure mode the
+   walkthrough exists to prevent.
+2. **The scenario actually works against a real server.** Every step is issued
+   to a live server over stdio; the response must not be an MCP error and must
+   contain the substrings the scenario declares, which pin the observable
+   behavior (the resolved decision's id and disposition, the attribution read
+   back at session end, the sentinel learning recalled with a score, and a
+   cross-project read and write both failing closed with no foreign store
+   created).
+
+The server runs from this source tree (`PYTHONPATH=src`) pinned to a hermetic
+``walkthrough`` project with all data directories redirected into ``tmp_path``;
+nothing touches the developer's real ``~/.trace``. The same scenario can drive
+a *deployed* server as a canary — that is a separate invocation, not this test.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import copy
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+from test_e2e_server import (
+    _call_tool,
+    _initialize_server,
+    _shutdown_server,
+    _start_server,
+)
+
+# The examples/ tree is not on the default import path (only src/ is), so make
+# the repo root importable for the scenario package.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from examples.walkthrough.render_walkthrough import WALKTHROUGH_PATH, render_markdown  # noqa: E402
+from examples.walkthrough.scenario import FOREIGN_PROJECT, PROJECT, SESSION_ID_PLACEHOLDER, STEPS  # noqa: E402
+
+
+def test_walkthrough_doc_is_in_sync_with_the_scenario() -> None:
+    """The committed WALKTHROUGH.md must equal a fresh render of the scenario, byte for byte."""
+    rendered = render_markdown(STEPS).encode("utf-8")
+    committed = WALKTHROUGH_PATH.read_bytes()
+    assert committed == rendered, (
+        "examples/walkthrough/WALKTHROUGH.md is out of sync with scenario.py. "
+        "Regenerate it: `python examples/walkthrough/render_walkthrough.py`."
+    )
+
+
+def _response_text(response: dict[str, Any]) -> str:
+    """The text payload of a successful tools/call response.
+
+    A JSON-RPC-level error, or an MCP tool result flagged ``isError``, is a
+    failure here: the walkthrough's expected cross-project denials are
+    application-level errors carried in a normal (non-error) result payload, so
+    a tool that actually errored must never satisfy an expectation.
+    """
+    assert "result" in response, f"tools/call failed at the protocol level: {response}"
+    result = response["result"]
+    assert not result.get("isError"), f"tool returned an MCP error result: {result}"
+    return result["content"][0]["text"]
+
+
+def _resolve(value: Any, session_id: str | None) -> Any:
+    """Recursively substitute the session-id placeholder anywhere in an argument value."""
+    if value == SESSION_ID_PLACEHOLDER:
+        assert session_id is not None, "a step referenced the session id before start_session ran"
+        return session_id
+    if isinstance(value, dict):
+        return {k: _resolve(v, session_id) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_resolve(v, session_id) for v in value]
+    return value
+
+
+@pytest.mark.asyncio
+async def test_walkthrough_runs_end_to_end_over_stdio(tmp_path: Path) -> None:
+    """Every scenario step, issued to a live pinned server, meets its declared expectations."""
+    knowledge = tmp_path / "knowledge"
+    knowledge.mkdir()
+    env_extra = {
+        "TRACE_KNOWLEDGE_DIR": str(knowledge),
+        "TRACE_REGISTRY_PATH": str(tmp_path / "projects.json"),
+        "TRACE_SCRATCHPAD_DIR": str(tmp_path / "scratchpads"),
+        "TRACE_PROJECT": PROJECT,
+    }
+    proc = await _start_server(str(tmp_path / "sessions"), env_extra=env_extra)
+    session_id: str | None = None
+    try:
+        try:
+            await _initialize_server(proc)
+        except BaseException:
+            if proc.returncode is None:
+                with contextlib.suppress(ProcessLookupError):
+                    proc.kill()
+            with contextlib.suppress(Exception):
+                await asyncio.wait_for(proc.wait(), timeout=10)
+            raise
+        for i, step in enumerate(STEPS):
+            # Deep-copy so substitution never mutates the shared, frozen scenario.
+            args = _resolve(copy.deepcopy(step.arguments), session_id)
+            response = await _call_tool(proc, step.tool, args, request_id=100 + i)
+            text = _response_text(response)
+            for needle in step.expect_substrings:
+                assert needle in text, f"step {i} ({step.tool}): {needle!r} not in response:\n{text}"
+            if step.capture_session_id:
+                match = re.search(r"(?m)^Session:[ \t]+(\S+)", text)
+                assert match, f"step {i} ({step.tool}): could not capture a session id from:\n{text}"
+                session_id = match.group(1)
+            if step.expect_session_id:
+                assert session_id and session_id in text, (
+                    f"step {i} ({step.tool}): the captured session id {session_id!r} is not in:\n{text}"
+                )
+    finally:
+        await _shutdown_server(proc)
+
+    # Fail-closed on disk, not just in the response: the denied cross-project
+    # calls must not have created a store for the foreign project.
+    assert not (knowledge / f"{FOREIGN_PROJECT}.json").exists(), "a denied cross-project call created a foreign store"


### PR DESCRIPTION
## Summary

Adds a golden walkthrough of the TRACE provenance loop, generated from one scenario (`examples/walkthrough/`):

- `scenario.py` — one ordered list of Pydantic `Step`s (tool, arguments, expected substrings, narration). The single source of truth.
- `render_walkthrough.py` — renders the scenario to the committed `WALKTHROUGH.md` (pure, explicit-LF).
- `WALKTHROUGH.md` — the human-readable walkthrough (generated; regenerate with `python examples/walkthrough/render_walkthrough.py`).
- `tests/test_walkthrough_e2e.py` — drives the same scenario against a live server over MCP stdio, and a doc-sync test that re-renders the scenario and compares it to the committed markdown byte-for-byte, so the doc and the run can never drift.

The scenario: start a session (pinned, `project` omitted) → propose a decision (AI) → resolve it (human accepts) → log a contribution → log a correction → end the session and read the Attribution Audit → query the decision back and confirm proposer=AI, resolver=human, accepted → add a learning → extract (idempotent: `new_learnings: 0`) → recall it (sentinel returned with a score and a backend) → a cross-project write is denied → a cross-project read is denied, with no foreign store created.

Also: `pyrightconfig.json` now includes `examples` (with the repo root on `extraPaths`) so the example package type-checks; a CHANGELOG entry.

No production behavior change. The run pins a hermetic project with all data directories redirected to `tmp_path`, so nothing touches the real `~/.trace`.

## Why

The prior wave repeatedly hit "source tree green, deployed or documented state rotten." A single scenario feeding both the doc and the test — with a sync test forbidding drift — is the structural fix for the specific case of a manual walkthrough drifting from what the server actually does. The E2E run pins the observable provenance behavior end to end: the resolved decision's id and disposition, the full attribution (proposer *and* resolver) read back through the audit and the query API, a real sentinel recall hit, extraction idempotency, and cross-project reads and writes both failing closed with an on-disk check that no foreign store was created.

## Scope

This is a provenance-loop walkthrough and doc-sync test that runs the **source tree** (`PYTHONPATH=src`). It is not the store-migration gate and makes no lock/atomic-write/concurrency claims — that is the already-merged `tests/test_concurrency_smoke.py` and the future migration runbook. The same scenario can drive a deployed server as a canary; that is a separate invocation, not this test.

## Verification

- `uv run pytest tests/test_walkthrough_e2e.py`: 2 passed (the E2E run and the byte-for-byte doc-sync).
- Full gate: `ruff format --check`, `ruff check`, full suite (1392 passed, 12 skipped), `tests/test_invariants.py`, pyright clean tree-wide.
- Cross-vendor review (gpt-5.6-sol: three analyst lenses, two adversarial lenses, one consensus): **SHIP-WITH-NITS**. The analyst round found the first oracle too weak (substring checks an error could satisfy, attribution and idempotency and isolation not actually verified); every load-bearing finding was adopted. The adversarial round added the decision read-back (pinning the resolver, not just the proposer) and a fully hermetic documented launch. The migration-gate and deployed-artifact criticism was ruled out of scope for this PR.

## Follow-ups (not blockers; recorded from the review)

- Parse the learn-tool JSON responses for typed values (nonempty `results`, numeric `score`, `added` as an object) rather than substring-matching; the sentinel and `lrn_` checks already make a malformed response implausible.
- Read back the contribution's `related_decision_ids` to pin its link to `evt_001` (the audit shows the contribution but not its linkage).
- Demonstrate cross-process persistence by recalling from a freshly started server, not the same process.
- Shared-harness hardening used by all e2e tests (`tests/test_e2e_server.py`): drain the child's stderr continuously, use an absolute subprocess `PYTHONPATH`, move the harness out of a test module for import stability, make shutdown cancellation-safe.
- In the concurrency suite (`tests/test_concurrency_smoke.py`): add a deterministic two-contender stale-lock takeover test, and give `exclusive_file_lock` an ownership check on release (it currently unlinks unconditionally) — this is the same production gap tracked by the lock-publication follow-up.
