### PR TITLE
chore(repo): ignore CLAUDE.local.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,10 @@ logs/
 .env.local
 .env.*.local
 *.local.json
+# Per-developer session notes / review-persona pointers. Historically excluded
+# only via .git/info/exclude, which does not travel with a clone — so a fresh
+# clone would offer to commit it. Tracked here so every clone ignores it.
+CLAUDE.local.md
 
 # Temporary files
 *.tmp


### PR DESCRIPTION
## Summary

Track the ignore for `CLAUDE.local.md`, the per-developer local notes / review-persona pointer file.

## Why

It was excluded only via `.git/info/exclude`, which does not travel with a clone. A fresh checkout therefore saw it as untracked, so a bulk `git add -A` would stage and commit it — which happened to surface while working from a fresh clone. Tracking the ignore makes every clone exclude it by default.

## Verification

`git check-ignore CLAUDE.local.md` matches; `git status` is otherwise unchanged. No behavior change.