### PR TITLE
fix(learn): mint learning ids from a persisted counter, never from the max

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,9 +33,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   fresh ids in array order; the original is copied to
   `*.json.prerepair-<date>`, the mapping and before/after digests are appended
   to `migrations.jsonl`, and `--dry-run` reports the mapping without writing.
-  It is snapshot-gated, refuses while a writer may be active, holds the store
-  lock, and **refuses outright** when a duplicated id is referenced elsewhere
-  rather than guessing which record the reference meant.
+  It is snapshot-gated, checks that the target store is quiescent, holds the
+  store lock, and **refuses outright** when a duplicated id appears in a
+  structured field rather than guessing which record the reference meant; a
+  mention in free text is reported but does not block. When the registry cannot
+  resolve the argument it falls back to the canonical store stem, so stray and
+  quarantine stores — which `identity check` also flags — can be repaired.
 - **`trace-mcp identity check` reports duplicate learning ids** per store,
   naming the repair command. Detection lives in the core identity report
   (filesystem-only, no extension import), so the CLI and any future core caller
@@ -48,7 +51,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   refuses an aliased target before grafting anything, so a merge can no longer
   consume its sources into premerge backups while spreading the aliasing. Reads
   are deliberately unchanged: an affected store still loads, lists, and exports,
-  which is what keeps it repairable.
+  which is what keeps it repairable. Recall keeps working too — its recall-count
+  and lazy-embedding bookkeeping is dropped with a notice on the response instead
+  of failing the call, since that write mints no id. Every learn tool reports a
+  refused write as `duplicate_learning_ids` with the repair command in `detail`,
+  rather than the generic failure a bare handler would return.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Learning ids are no longer reused after a delete.** `KnowledgeStore` now
+  carries a persisted monotonic counter (`next_id`) and mints ids from it, so
+  forgetting the highest learning and adding another gives the new content a
+  fresh id instead of the released one. Previously the next id was
+  `max(existing) + 1`, which handed a recycled id to different content and left
+  dedup, recall counts, the positional embedding sidecar, and every recorded
+  reference pointing at two records with no way to tell them apart. Stores
+  written before the counter existed initialize it on load; a counter found
+  below the highest id present is raised (never lowered) and the anomaly is
+  logged. Registered as INV-12 in `docs/INVARIANTS.md` with an enumeration guard
+  over every site that appends a learning.
+
+### Added
+
+- **`trace-mcp identity repair-ids <key>`** renumbers a store that already
+  carries aliased ids. The first occurrence keeps its id and later ones take
+  fresh ids in array order; the original is copied to
+  `*.json.prerepair-<date>`, the mapping and before/after digests are appended
+  to `migrations.jsonl`, and `--dry-run` reports the mapping without writing.
+  It is snapshot-gated, refuses while a writer may be active, holds the store
+  lock, and **refuses outright** when a duplicated id is referenced elsewhere
+  rather than guessing which record the reference meant.
+- **`trace-mcp identity check` reports duplicate learning ids** per store,
+  naming the repair command. Detection lives in the core identity report
+  (filesystem-only, no extension import), so the CLI and any future core caller
+  cannot disagree about the same file.
+
+### Changed
+
+- **Knowledge-store writes fail closed on aliased ids.** `save_store` and
+  `add_learning` raise `DuplicateLearningIdError`, and `identity merge-stores`
+  refuses an aliased target before grafting anything, so a merge can no longer
+  consume its sources into premerge backups while spreading the aliasing. Reads
+  are deliberately unchanged: an affected store still loads, lists, and exports,
+  which is what keeps it repairable.
+
 ### Added
 
 - **A golden walkthrough of the provenance loop, generated from one scenario**

--- a/docs/INVARIANTS.md
+++ b/docs/INVARIANTS.md
@@ -336,6 +336,65 @@ breaking exactly one aspect of a fresh install fails exactly one check.
 
 ---
 
+## INV-12 — Learning ids are never reused  · ENFORCED
+
+**Statement.** A learning id is minted from a **persisted monotonic counter**
+(`KnowledgeStore.next_id`), never derived from the ids currently present. The
+counter is consumed on *call* rather than on append, is initialized on load for
+stores written before it existed, and is only ever **raised** — never lowered —
+so an id released by `trace_learn_forget` is never reissued to different
+content. Complementing that, every **write** path refuses a store whose ids are
+already aliased; **reads** stay permissive so an affected store remains
+readable, exportable, and repairable.
+
+**Why this is an integrity invariant.** `next_learning_id()` returned
+`max(existing) + 1`, so forgetting the highest learning and adding another gave
+the new content the old id. Dedup, recall counts, the positionally-aligned
+embedding sidecar, and any recorded reference all key on that id, so the two
+records become mutually unaddressable — and, unlike a lost update, nothing about
+the store looks wrong afterwards. The same defect shape as the rest of this
+file: a rule (ids identify one record) enforced by a scheme that quietly breaks
+under one operation.
+
+**Exhaustive site-set:**
+- Minting — `src/trace_mcp/extensions/learn/models.py` (`KnowledgeStore.next_id`,
+  `next_learning_id`, `_raise_counter_above_existing_ids`).
+- Appenders that must mint from the counter —
+  `src/trace_mcp/extensions/learn/store.py :: add_learning`;
+  `src/trace_mcp/identity_cli.py :: cmd_merge_stores`.
+- Write paths that must refuse an aliased store —
+  `src/trace_mcp/extensions/learn/store.py :: save_store`, `:: add_learning`
+  (single implementation: `_refuse_duplicate_ids`). `cmd_merge_stores` refuses an
+  aliased **target** before grafting, so a merge cannot consume the sources into
+  premerge backups and leave the operator with a hand reconstruction.
+- Detection — `src/trace_mcp/identity_report.py :: find_duplicate_learning_ids`
+  (core, filesystem-only, zero `extensions/` imports per ADR-003), consumed by
+  `trace-mcp identity check`.
+- Repair — `src/trace_mcp/identity_cli.py :: cmd_repair_ids`
+  (`trace-mcp identity repair-ids <key>`): snapshot-gated, writer-quiescence
+  checked, holds the store lock, keeps the first occurrence and renumbers later
+  ones in array order, copies the original to `*.json.prerepair-<date>`, records
+  the mapping and before/after digests in `migrations.jsonl`, and **refuses**
+  when a duplicated id is referenced elsewhere rather than guessing which record
+  the reference meant.
+
+**Guard:** `tests/test_invariants.py` —
+`test_inv12_next_learning_id_reads_and_advances_the_persisted_counter` (fails if
+`max()` arithmetic returns, or if the counter is not read and advanced),
+`test_inv12_counter_healing_never_lowers_the_counter`,
+`test_inv12_every_learning_appender_is_registered` (AST enumeration of
+`….learnings.append(…)`, with a positive control against pattern rot and a
+staleness check), `test_inv12_registered_appenders_mint_from_the_counter`, and
+`test_inv12_store_writes_refuse_an_aliased_store`. Behavior pinned by
+`tests/test_learn_models.py :: TestMonotonicIds`,
+`tests/test_learn_store.py :: TestLearningIdReuse` (forget → add → distinct id;
+refusal leaves the file byte-identical), and
+`tests/test_identity_cli.py :: TestRepairIds` / `:: TestDuplicateIdReporting`.
+
+**Status.** ENFORCED.
+
+---
+
 *To add an invariant: give it the next `INV-N`, state it, enumerate the
 exhaustive site-set, name the guard + test, and add a check that fails when a
 new site violates it — in `tests/test_invariants.py` for the AST/enumeration

--- a/docs/INVARIANTS.md
+++ b/docs/INVARIANTS.md
@@ -356,6 +356,20 @@ the store looks wrong afterwards. The same defect shape as the rest of this
 file: a rule (ids identify one record) enforced by a scheme that quietly breaks
 under one operation.
 
+**What "write" means here.** Recall is a read for its caller but persists recall
+counts and lazily-computed embeddings. That bookkeeping mints no id, so on an
+aliased store it is **dropped with a notice on the response**
+(`extensions/learn/__init__.py :: _persist_recall_bookkeeping`) rather than
+failing the recall — otherwise the guard would break reads on exactly the stores
+it exists to protect, inverting its own guarantee.
+
+**Known limitation (downgrade).** A server built before `next_id` existed loads a
+repaired store, drops the field on write, and the counter re-initializes from the
+highest id present on the next load. A forget-then-add across that window can
+still reissue an id, with nothing on disk showing the counter was lost. Consumers
+build from whatever branch is checked out in the shared working tree, so this is
+governed by the standing "keep `main` checked out" rule rather than by code.
+
 **Exhaustive site-set:**
 - Minting — `src/trace_mcp/extensions/learn/models.py` (`KnowledgeStore.next_id`,
   `next_learning_id`, `_raise_counter_above_existing_ids`).
@@ -374,22 +388,34 @@ under one operation.
   (`trace-mcp identity repair-ids <key>`): snapshot-gated, writer-quiescence
   checked, holds the store lock, keeps the first occurrence and renumbers later
   ones in array order, copies the original to `*.json.prerepair-<date>`, records
-  the mapping and before/after digests in `migrations.jsonl`, and **refuses**
-  when a duplicated id is referenced elsewhere rather than guessing which record
-  the reference meant.
+  the mapping and before/after digests in `migrations.jsonl`. It **refuses** when
+  a duplicated id appears in a *structured* field (`_find_id_references`
+  blocking set) rather than guessing which record the reference meant, and merely
+  **reports** a mention in free text — prose is resolved by no code path, and
+  refusing on it would leave a store permanently unwritable with hand-editing as
+  the only escape. When the registry cannot resolve the argument it falls back to
+  the canonical store stem, so the stray and quarantine stores `check` flags can
+  actually be repaired. Quiescence is checked on the target file only
+  (`_preflight_target_quiescent`), so one crashed writer elsewhere cannot wedge
+  the only path out of a store that refuses every write.
 
 **Guard:** `tests/test_invariants.py` —
 `test_inv12_next_learning_id_reads_and_advances_the_persisted_counter` (fails if
 `max()` arithmetic returns, or if the counter is not read and advanced),
 `test_inv12_counter_healing_never_lowers_the_counter`,
-`test_inv12_every_learning_appender_is_registered` (AST enumeration of
-`….learnings.append(…)`, with a positive control against pattern rot and a
-staleness check), `test_inv12_registered_appenders_mint_from_the_counter`, and
+`test_inv12_every_learning_appender_is_registered` (AST enumeration of every site
+that grows a `.learnings` list — `append`/`extend`/`insert`, `+=`, and slice
+assignment — with a positive control against pattern rot and a staleness check;
+a local alias is beyond a static check of this shape, which the id-minting
+assertion and the behavioral tests backstop), `test_inv12_registered_appenders_mint_from_the_counter`, and
 `test_inv12_store_writes_refuse_an_aliased_store`. Behavior pinned by
 `tests/test_learn_models.py :: TestMonotonicIds`,
 `tests/test_learn_store.py :: TestLearningIdReuse` (forget → add → distinct id;
 refusal leaves the file byte-identical), and
-`tests/test_identity_cli.py :: TestRepairIds` / `:: TestDuplicateIdReporting`.
+`tests/test_identity_cli.py :: TestRepairIds`, `:: TestDuplicateIdReporting`,
+`:: TestRepairIdsReachesEveryFlaggedStore`, `:: TestRepairIdsReferenceScan`, and
+`tests/test_learn_aliased_store.py` (reads keep working and every refused write
+names the repair command).
 
 **Status.** ENFORCED.
 

--- a/src/trace_mcp/extensions/learn/__init__.py
+++ b/src/trace_mcp/extensions/learn/__init__.py
@@ -39,6 +39,37 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _aliased_store_error(exc: Exception, project: str | None) -> str:
+    """Response for a write refused because the store's learning ids are aliased.
+
+    The refusal composes a message naming the repair command; a bare
+    ``except Exception`` would discard it and hand back a generic failure, so the
+    first person to meet the guard would never learn a fix exists (INV-12).
+    """
+    logger.error("Refused a write to %r: %s", project, exc)
+    return json.dumps({"error": "duplicate_learning_ids", "detail": str(exc), "project": project})
+
+
+def _persist_recall_bookkeeping(ks: KnowledgeStore, project: str) -> str | None:
+    """Persist recall counts and lazily-computed embeddings; return a notice if skipped.
+
+    Recall is a read for its caller but writes bookkeeping back. On a store whose
+    ids are aliased that write is refused (INV-12) — and failing the recall there
+    would invert the guard's own guarantee, since reads are meant to keep working
+    so the store stays searchable until it is repaired. The bookkeeping is
+    therefore dropped rather than forced, and the reason is returned for the
+    response instead of being swallowed.
+
+    Side effect: writes the store unless the write is refused.
+    """
+    try:
+        store.save_store(ks)
+        return None
+    except store.DuplicateLearningIdError as exc:
+        logger.warning("Recall bookkeeping not persisted for %r: %s", project, exc)
+        return f"Recall counts and embeddings were not saved: {exc}"
+
+
 def _resolve_project(project: str | None) -> tuple[str, str | None]:
     """Resolve *project* against the process pin; ``(label, None)`` or ``("", error-JSON)``.
 
@@ -282,7 +313,7 @@ def register(mcp: FastMCP, storage: TraceStorage) -> None:
                 decay_config=_decay_params,
             )
             if results or embedded:
-                store.save_store(ks)
+                _persist_recall_bookkeeping(ks, project)
             return results
 
     async def _extract_hook(project: str, session_id: str) -> list[str]:
@@ -400,15 +431,19 @@ def register(mcp: FastMCP, storage: TraceStorage) -> None:
                     backend=backend,
                     decay_config=_decay_params,
                 )
+                bookkeeping_notice: str | None = None
                 if results or embedded:
-                    store.save_store(ks)
+                    bookkeeping_notice = _persist_recall_bookkeeping(ks, project)
                 payload: dict[str, Any] = {
                     "project": project,
                     "results": results,
                     "total": len(results),
                     "backend": matching.describe_backend(backend),
                 }
-                if notices := _key_notices(_eff):
+                notices = _key_notices(_eff)
+                if bookkeeping_notice:
+                    notices.append(bookkeeping_notice)
+                if notices:
                     payload["warnings"] = notices
                 return json.dumps(payload)
         except pident.RegistryUnavailableError as exc:
@@ -431,6 +466,8 @@ def register(mcp: FastMCP, storage: TraceStorage) -> None:
                         "project": project,
                     }
                 )
+            if isinstance(exc, store.DuplicateLearningIdError):
+                return _aliased_store_error(exc, project)
             logger.exception("Error recalling learnings")
             return json.dumps({"error": "Failed to recall learnings", "project": project})
 
@@ -524,6 +561,8 @@ def register(mcp: FastMCP, storage: TraceStorage) -> None:
                         "project": project,
                     }
                 )
+            if isinstance(exc, store.DuplicateLearningIdError):
+                return _aliased_store_error(exc, project)
             logger.exception("Error adding learning")
             return json.dumps({"error": "Failed to add learning", "project": project})
 
@@ -575,6 +614,8 @@ def register(mcp: FastMCP, storage: TraceStorage) -> None:
                     return json.dumps({"removed": False, "error": f"Learning '{learning_id}' not found"})
                 store.save_store(ks)
                 return json.dumps({"removed": True, "learning_id": learning_id})
+        except store.DuplicateLearningIdError as exc:
+            return _aliased_store_error(exc, project)
         except Exception:
             logger.exception("Error removing learning")
             return json.dumps({"error": "Failed to remove learning", "project": project})
@@ -673,5 +714,7 @@ def register(mcp: FastMCP, storage: TraceStorage) -> None:
                         "project": project,
                     }
                 )
+            if isinstance(exc, store.DuplicateLearningIdError):
+                return _aliased_store_error(exc, project)
             logger.exception("Error extracting learnings")
             return json.dumps({"error": "Failed to extract learnings", "project": project})

--- a/src/trace_mcp/extensions/learn/models.py
+++ b/src/trace_mcp/extensions/learn/models.py
@@ -1,9 +1,35 @@
-"""Pydantic models for the trace-learn knowledge store."""
+"""Pydantic models for the trace-learn knowledge store.
 
+Exports:
+    LearningCategory  the closed set of categories a Learning may carry
+    Learning          one extracted or manually added learning
+    KnowledgeStore    a project's store, including its monotonic id counter
+"""
+
+import logging
 from datetime import UTC, datetime
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
+
+logger = logging.getLogger(__name__)
+
+_LEARNING_ID_PREFIX = "lrn_"
+
+
+def learning_id_number(learning_id: str) -> int | None:
+    """The numeric suffix of a ``lrn_NNN`` id, or None for any other id shape.
+
+    Pure. Ids that do not follow the scheme (hand-written or imported) simply do
+    not participate in counter arithmetic.
+    """
+    if not learning_id.startswith(_LEARNING_ID_PREFIX):
+        return None
+    try:
+        return int(learning_id[len(_LEARNING_ID_PREFIX) :])
+    except ValueError:
+        return None
+
 
 # Categories that a Learning can have — superset of AnnotationData categories
 # (includes "decision" for rejected/revised decision learnings).
@@ -53,18 +79,79 @@ class KnowledgeStore(BaseModel):
     project: str
     version: str = "0.4"
     updated: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    next_id: int = Field(
+        default=1,
+        description=(
+            "Monotonic counter for the next learning id. Persisted and never decreased, so an id "
+            "released by `forget` is never reissued to different content."
+        ),
+    )
     learnings: list[Learning] = Field(default_factory=list)
 
-    def next_learning_id(self) -> str:
-        """Generate the next sequential learning ID (lrn_001, lrn_002, ...)."""
-        if not self.learnings:
-            return "lrn_001"
-        max_num = 0
+    @model_validator(mode="after")
+    def _raise_counter_above_existing_ids(self) -> "KnowledgeStore":
+        """Initialize or self-heal ``next_id`` — upward only, never downward.
+
+        A store written before the counter existed carries no ``next_id``; it is
+        initialized once to one past the highest id present. A counter that is
+        present but too low (hand-edited, or truncated by a partial restore)
+        would hand out an id that already exists, so it is raised and the
+        anomaly is logged. A counter that is AHEAD of the learnings is left
+        alone: that is exactly the post-``forget`` state this field exists to
+        preserve, and lowering it would reintroduce the reuse defect.
+        """
+        highest = 0
         for lrn in self.learnings:
-            if lrn.id.startswith("lrn_"):
-                try:
-                    num = int(lrn.id[4:])
-                    max_num = max(max_num, num)
-                except ValueError:
-                    pass
-        return f"lrn_{max_num + 1:03d}"
+            num = learning_id_number(lrn.id)
+            if num is not None and num > highest:
+                highest = num
+        if self.next_id <= highest:
+            if "next_id" in self.model_fields_set:
+                logger.warning(
+                    "Knowledge store %r declares next_id=%d but already holds %s%03d; raising the "
+                    "counter to %d so no id is reissued.",
+                    self.project,
+                    self.next_id,
+                    _LEARNING_ID_PREFIX,
+                    highest,
+                    highest + 1,
+                )
+            self.next_id = highest + 1
+        return self
+
+    def next_learning_id(self) -> str:
+        """Return the next learning id (``lrn_001``, ``lrn_002``, …) and advance the counter.
+
+        Side effect: increments ``next_id``. The id is consumed on CALL rather
+        than derived from the learnings present, so forgetting the highest
+        learning cannot hand its id to different content later — the aliasing
+        class that a ``max(existing) + 1`` scheme silently reintroduced on every
+        delete (INV-12, docs/INVARIANTS.md).
+        """
+        learning_id = f"{_LEARNING_ID_PREFIX}{self.next_id:03d}"
+        self.next_id += 1
+        return learning_id
+
+    def duplicate_learning_ids(self) -> list[str]:
+        """Ids carried by more than one learning, sorted; empty for a healthy store.
+
+        Pure. Reported rather than raised at load time so an already-aliased
+        store stays readable and exportable; the write paths are what refuse
+        (see ``store.save_store``), and ``trace-mcp identity repair-ids`` is the
+        operator's fix.
+
+        An UNSET id (the empty-string default on a not-yet-added ``Learning``) is
+        not an alias — several unsaved learnings legitimately carry no id at all,
+        and they are given one on add. Only assigned ids can collide, so blanks
+        are skipped rather than reported as a collision with each other.
+        """
+        seen: set[str] = set()
+        duplicates: set[str] = set()
+        for lrn in self.learnings:
+            if not lrn.id:
+                continue
+            if lrn.id in seen:
+                duplicates.add(lrn.id)
+            else:
+                seen.add(lrn.id)
+        return sorted(duplicates)

--- a/src/trace_mcp/extensions/learn/store.py
+++ b/src/trace_mcp/extensions/learn/store.py
@@ -2,6 +2,10 @@
 
 Stores per-project knowledge as JSON in ~/.trace/knowledge/{project}.json.
 Uses atomic writes (write to temp file, then rename) to prevent corruption.
+
+Reads are permissive and writes are fail-closed: a store whose learning ids are
+already aliased still loads, lists, and exports, but every write path refuses
+until `trace-mcp identity repair-ids` renumbers it (INV-12).
 """
 
 from __future__ import annotations
@@ -72,6 +76,35 @@ class StoreLoadError(Exception):
     """Raised when a knowledge store file exists but cannot be parsed."""
 
 
+class DuplicateLearningIdError(Exception):
+    """Raised when a WRITE is attempted on a store carrying aliased learning ids."""
+
+
+def _refuse_duplicate_ids(store: KnowledgeStore) -> None:
+    """Fail closed before any write to a store whose ids are already aliased.
+
+    Reads are deliberately unaffected (``load_store`` never raises on duplicates)
+    so an aliased store stays recoverable, exportable, and searchable. Writing,
+    though, extends the damage: dedup, recall counts, the positional embedding
+    sidecar, and every recorded reference key on the id, so a second learning
+    under an existing id makes both unaddressable. Raising here turns a silent
+    corruption into an operator task with a named fix (INV-12).
+
+    Raises:
+        DuplicateLearningIdError: at least one id is carried by two learnings.
+    """
+    duplicates = store.duplicate_learning_ids()
+    if not duplicates:
+        return
+    raise DuplicateLearningIdError(
+        f"knowledge store for project {store.project!r} carries aliased learning id(s): "
+        f"{', '.join(duplicates)}. Refusing to write — a reference naming one of these ids "
+        "cannot be resolved, and writing would spread the aliasing. Repair it with "
+        "`trace-mcp identity snapshot` then "
+        f"`trace-mcp identity repair-ids {store.project}`."
+    )
+
+
 def _assert_store_identity(ks: KnowledgeStore, project: str, path: Path) -> None:
     """Fail closed if a store's own project disagrees with the key it loaded as.
 
@@ -131,6 +164,11 @@ def save_store(store: KnowledgeStore, directory: str | None = None) -> Path:
     Writes to a temporary file in the same directory then renames, so a
     crash mid-write can never leave a half-written store file.
     """
+    # Fail closed BEFORE touching the filesystem: an aliased store must not be
+    # rewritten under any caller (INV-12). This is the single choke point every
+    # write path funnels through, so no future writer can bypass the check.
+    _refuse_duplicate_ids(store)
+
     path = _store_path(store.project, directory)
     path.parent.mkdir(parents=True, exist_ok=True)
 
@@ -170,7 +208,16 @@ def add_learning(
     extraction_method: Literal["llm", "rule-based", "manual"] | None = None,
     generated_by: str | None = None,
 ) -> Learning:
-    """Add a learning to the store and return it."""
+    """Add a learning to the store and return it.
+
+    Side effect: appends to ``store.learnings`` and consumes one id from the
+    store's monotonic counter.
+
+    Raises:
+        DuplicateLearningIdError: the store already carries aliased ids, so the
+            caller is told at the point of the attempt rather than at save time.
+    """
+    _refuse_duplicate_ids(store)
     learning = Learning(
         id=store.next_learning_id(),
         content=content,

--- a/src/trace_mcp/extensions/learn/store.py
+++ b/src/trace_mcp/extensions/learn/store.py
@@ -96,12 +96,20 @@ def _refuse_duplicate_ids(store: KnowledgeStore) -> None:
     duplicates = store.duplicate_learning_ids()
     if not duplicates:
         return
+    # Name the CANONICAL key in the remediation command: `project` is a free-text
+    # display label, and the repair command addresses stores by canonical key.
+    from trace_mcp.project_identity import ProjectKeyError, canonical_project_key
+
+    try:
+        key = canonical_project_key(store.project)
+    except ProjectKeyError:
+        key = store.project
     raise DuplicateLearningIdError(
         f"knowledge store for project {store.project!r} carries aliased learning id(s): "
         f"{', '.join(duplicates)}. Refusing to write — a reference naming one of these ids "
         "cannot be resolved, and writing would spread the aliasing. Repair it with "
         "`trace-mcp identity snapshot` then "
-        f"`trace-mcp identity repair-ids {store.project}`."
+        f"`trace-mcp identity repair-ids {key}`."
     )
 
 

--- a/src/trace_mcp/identity_cli.py
+++ b/src/trace_mcp/identity_cli.py
@@ -481,6 +481,29 @@ def _preflight_merge(paths: list[Path], out) -> bool:
     return True
 
 
+def _preflight_target_quiescent(path: Path, out) -> bool:
+    """True when *path* has not been touched inside the writer-liveness window.
+
+    Narrower than ``_preflight_merge`` on purpose: it looks only at the file being
+    repaired, so an unrelated project's stale lock cannot block the repair. Lock
+    ownership is enforced by the store lock, which has holder-liveness semantics
+    this timestamp check cannot express.
+    """
+    threshold = float(os.environ.get("TRACE_MERGE_MIN_AGE_SEC", "5"))
+    try:
+        age = datetime.now(UTC).timestamp() - path.stat().st_mtime
+    except OSError:
+        return True
+    if age < threshold:
+        print(
+            f"Error: {path.name} was modified {age:.1f}s ago (< {threshold}s) — a writer may be "
+            "active. Re-run in a moment.",
+            file=out,
+        )
+        return False
+    return True
+
+
 def cmd_merge_stores(args: argparse.Namespace, out) -> int:
     """Consolidate an alias group's knowledge stores into the canonical-key store.
 
@@ -670,33 +693,47 @@ def cmd_merge_stores(args: argparse.Namespace, out) -> int:
 # ── repair-ids ─────────────────────────────────────────────────────────────
 
 
-def _find_ambiguous_references(store: KnowledgeStore, duplicates: set[str]) -> list[str]:
-    """Every place a duplicated id is referenced by something other than its own record.
+# Fields that could structurally hold an identifier. A duplicated id appearing in
+# one of these is a machine-resolvable reference that renumbering would silently
+# repoint, so it blocks the repair. Free text (`content`) is deliberately NOT in
+# this set: prose is not resolved by any code path, and refusing on a passing
+# mention would leave a store permanently unwritable with hand-editing the JSON
+# as the only escape — the guard would have created a worse trap than the defect.
+_REFERENCE_FIELDS = ("source_session", "source_event", "corrects_event_ids", "tags")
 
-    Renumbering is only safe when nothing points at the id being changed. A
-    duplicated id appearing in any other field named one of two records, and
-    nothing on disk says which — so the repair reports these and refuses rather
-    than guessing, in the same spirit as alias-table-first label repair (spec
-    §8.5): never invent an attribution you cannot know.
 
-    Pure; returns [] when the duplicated ids are referenced nowhere.
+def _find_id_references(store: KnowledgeStore, duplicates: set[str]) -> tuple[list[str], list[str]]:
+    """Split references to duplicated ids into blocking and advisory.
+
+    Renumbering is only safe when nothing resolvable points at the id being
+    changed: a duplicated id named one of two records, and nothing on disk says
+    which — so a structured reference refuses the repair rather than guessing, in
+    the spirit of alias-table-first label repair (specification §8.5). A mention
+    inside free text is reported so the operator can update the wording, but it
+    never blocks, because no code resolves it and the pre-repair backup preserves
+    the original ids either way.
+
+    Pure. Returns ``(blocking, advisory)``, each a list of human-readable hits.
     """
-    hits: list[str] = []
+    blocking: list[str] = []
+    advisory: list[str] = []
     for lrn in store.learnings:
-        payload = lrn.model_dump(mode="json", exclude={"id", "embedding"})
-        for field, value in payload.items():
-            if isinstance(value, str):
-                candidates = [value]
-            elif isinstance(value, list):
-                candidates = [item for item in value if isinstance(item, str)]
-            else:
-                continue
+        for field in _REFERENCE_FIELDS:
+            value = getattr(lrn, field, None)
+            items = value if isinstance(value, list) else [value]
+            for item in items:
+                if isinstance(item, str) and item in duplicates:
+                    hit = f"{lrn.id}.{field} == {item}"
+                    if hit not in blocking:
+                        blocking.append(hit)
+        content = getattr(lrn, "content", "")
+        if isinstance(content, str):
             for dup in sorted(duplicates):
-                if any(dup in candidate for candidate in candidates):
-                    hit = f"{lrn.id}.{field} refers to {dup}"
-                    if hit not in hits:
-                        hits.append(hit)
-    return hits
+                if dup in content:
+                    hit = f"{lrn.id}.content mentions {dup}"
+                    if hit not in advisory:
+                        advisory.append(hit)
+    return blocking, advisory
 
 
 def cmd_repair_ids(args: argparse.Namespace, out) -> int:
@@ -724,19 +761,37 @@ def cmd_repair_ids(args: argparse.Namespace, out) -> int:
     try:
         registry = pident.get_registry_cached()
     except pident.RegistryUnavailableError as exc:
-        print(f"Error: registry is unreadable ({exc}); enroll projects before repairing.", file=out)
+        # A damaged registry is fail-closed everywhere else; repairing a store
+        # while identity itself is unreadable could target the wrong file.
+        print(f"Error: registry is unreadable ({exc}); fix it before repairing a store.", file=out)
         return 1
-    if registry is None:
-        print("Error: no registry yet — run scan → apply before repair-ids.", file=out)
-        return 1
-    key = registry.resolve(args.key)
+
+    knowledge = identity_report.knowledge_dir()
+    key = registry.resolve(args.key) if registry is not None else None
     if key is None:
-        print(f"Error: '{args.key}' resolves to no registered project.", file=out)
-        return 1
-    if key != args.key:
+        # `identity check` reports duplicates for EVERY store on disk, including
+        # stray, quarantine, and not-yet-enrolled ones. If the repair could only
+        # reach registered projects, those stores would be flagged and refused for
+        # all writes with no supported fix, so fall back to the canonical store
+        # stem whenever a file actually exists for it.
+        try:
+            candidate = pident.canonical_project_key(args.key)
+        except pident.ProjectKeyError:
+            print(f"Error: '{args.key}' is not a usable project name.", file=out)
+            return 1
+        if not (knowledge / f"{candidate}.json").is_file():
+            print(
+                f"Error: '{args.key}' resolves to no registered project and no knowledge store "
+                f"'{candidate}.json' exists.",
+                file=out,
+            )
+            return 1
+        key = candidate
+        print(f"  '{args.key}' is not registered; repairing the store file '{key}.json' directly.", file=out)
+    elif key != args.key:
         print(f"  '{args.key}' resolved to registered key '{key}'.", file=out)
 
-    path = identity_report.knowledge_dir() / f"{key}.json"
+    path = knowledge / f"{key}.json"
     if not path.is_file():
         print(f"Nothing to repair: no knowledge store for '{key}'.", file=out)
         return 0
@@ -744,7 +799,14 @@ def cmd_repair_ids(args: argparse.Namespace, out) -> int:
         print(f"identity repair-ids: no aliased learning ids in '{key}.json' — nothing to do.", file=out)
         return 0
 
-    if not _preflight_merge([path], out):
+    # Quiescence is checked on the TARGET only. The merge preflight refuses when
+    # ANY lock file exists in the knowledge directory, which cannot tell a stale
+    # lock from a live one and trips on unrelated projects — acceptable for an
+    # optional consolidation, but here it would let one crashed writer wedge the
+    # only path out of a store that refuses every write. Lock contention is left
+    # to the store lock itself, which steals a provably-dead holder's lock and
+    # fails closed on a live one.
+    if not _preflight_target_quiescent(path, out):
         return 1
 
     try:
@@ -756,17 +818,19 @@ def cmd_repair_ids(args: argparse.Namespace, out) -> int:
                 return 1
 
             duplicates = set(store.duplicate_learning_ids())
-            ambiguous = _find_ambiguous_references(store, duplicates)
-            if ambiguous:
+            blocking, advisory = _find_id_references(store, duplicates)
+            if blocking:
                 print(
                     f"Error: '{key}.json' is ambiguous — a duplicated id is referenced elsewhere, "
                     "so renumbering would silently repoint the reference:",
                     file=out,
                 )
-                for hit in ambiguous:
+                for hit in blocking:
                     print(f"    {hit}", file=out)
                 print("  Resolve those references by hand, then re-run. Refusing to guess.", file=out)
                 return 1
+            for hit in advisory:
+                print(f"  note: {hit} — free text is not repointed; review the wording after the repair.", file=out)
 
             sha_before = _sha256(path)
             renumbered: list[dict[str, str]] = []

--- a/src/trace_mcp/identity_cli.py
+++ b/src/trace_mcp/identity_cli.py
@@ -1,7 +1,7 @@
 """``trace-mcp identity`` — provenance-honest project-identity migration tooling (ADR-006 S6).
 
 Core module (stdlib + core identity types; the learn extension is imported lazily
-inside ``merge-stores`` only, per ADR-003). Seven subcommands turn the enforcement
+inside ``merge-stores`` only, per ADR-003). Eight subcommands turn the enforcement
 machinery of ADR-006 into an operator can actually run against an existing store
 that predates canonical identity:
 
@@ -10,6 +10,7 @@ that predates canonical identity:
     apply         mint the human-approved plan into the registry
     check         report drift; non-zero exit on findings
     merge-stores  consolidate an alias group's knowledge stores (reversible)
+    repair-ids    renumber aliased learning ids in one store (reversible)
     adopt         re-home an ``auto`` session into a real project (append-shaped)
     bundle        export one project as a self-contained tarball
 
@@ -34,15 +35,19 @@ import asyncio
 import hashlib
 import json
 import os
+import shutil
 import sys
 import tarfile
 from collections.abc import Iterable
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from trace_mcp import identity_report
 from trace_mcp import project_identity as pident
+
+if TYPE_CHECKING:  # type-only: the learn extension stays a runtime-optional import (ADR-003)
+    from trace_mcp.extensions.learn.models import KnowledgeStore
 
 # ── Paths ──────────────────────────────────────────────────────────────────
 
@@ -401,6 +406,18 @@ def cmd_check(args: argparse.Namespace, out) -> int:
     if stray:
         findings.append(f"{len(stray)} knowledge store(s) not backed by a registered key: {', '.join(stray)}")
 
+    # Aliased learning ids are an integrity fault independent of the registry, so
+    # this runs even before any project is enrolled. Writes to an affected store
+    # are refused (INV-12), which makes this finding actionable rather than
+    # advisory: the named command is the way back to a writable store.
+    duplicate_ids = identity_report.find_duplicate_learning_ids()
+    if duplicate_ids:
+        detail = "; ".join(f"{stem}: {', '.join(ids)}" for stem, ids in sorted(duplicate_ids.items()))
+        findings.append(
+            f"{len(duplicate_ids)} knowledge store(s) carry duplicate learning ids ({detail}) — "
+            "writes to them are refused until `trace-mcp identity repair-ids <key>` renumbers them"
+        )
+
     if registry is not None:
         unknown_labels: dict[str, int] = {}
         for path in _iter_session_files():
@@ -562,6 +579,19 @@ def cmd_merge_stores(args: argparse.Namespace, out) -> int:
                 except learn_store.StoreLoadError as exc:
                     print(f"Error: target store for '{key}' is unreadable ({exc}). Repair or move it first.", file=out)
                     return 1
+                # Refuse an aliased TARGET before grafting anything: the merge
+                # would write the store (spreading the aliasing) and consume the
+                # sources into premerge backups, turning a one-command repair
+                # into a hand reconstruction (INV-12).
+                target_duplicates = target_store.duplicate_learning_ids()
+                if target_duplicates:
+                    print(
+                        f"Error: target store for '{key}' carries duplicate learning id(s) "
+                        f"({', '.join(target_duplicates)}). Run `trace-mcp identity repair-ids {key}` "
+                        "first — merging would write the aliased store and consume the sources.",
+                        file=out,
+                    )
+                    return 1
                 before_target = len(target_store.learnings)
                 merge_records: list[dict[str, Any]] = []
                 for src in source_paths:
@@ -634,6 +664,157 @@ def cmd_merge_stores(args: argparse.Namespace, out) -> int:
 
     if not merged_any:
         print("Nothing to merge: no aliased source stores found for the target key(s).", file=out)
+    return 0
+
+
+# ── repair-ids ─────────────────────────────────────────────────────────────
+
+
+def _find_ambiguous_references(store: KnowledgeStore, duplicates: set[str]) -> list[str]:
+    """Every place a duplicated id is referenced by something other than its own record.
+
+    Renumbering is only safe when nothing points at the id being changed. A
+    duplicated id appearing in any other field named one of two records, and
+    nothing on disk says which — so the repair reports these and refuses rather
+    than guessing, in the same spirit as alias-table-first label repair (spec
+    §8.5): never invent an attribution you cannot know.
+
+    Pure; returns [] when the duplicated ids are referenced nowhere.
+    """
+    hits: list[str] = []
+    for lrn in store.learnings:
+        payload = lrn.model_dump(mode="json", exclude={"id", "embedding"})
+        for field, value in payload.items():
+            if isinstance(value, str):
+                candidates = [value]
+            elif isinstance(value, list):
+                candidates = [item for item in value if isinstance(item, str)]
+            else:
+                continue
+            for dup in sorted(duplicates):
+                if any(dup in candidate for candidate in candidates):
+                    hit = f"{lrn.id}.{field} refers to {dup}"
+                    if hit not in hits:
+                        hits.append(hit)
+    return hits
+
+
+def cmd_repair_ids(args: argparse.Namespace, out) -> int:
+    """Renumber aliased learning ids in one project's store (reversible).
+
+    The first occurrence of each duplicated id keeps it and every later one takes
+    a fresh id from the store's monotonic counter — array order, so the outcome
+    is deterministic and needs no timestamp heuristics. The original file is
+    copied to ``*.json.prerepair-<date>`` before the write and the mapping is
+    recorded in the append-only migrations log, so the repair is itself auditable.
+
+    Requires a snapshot marker, refuses while a writer may be active, and holds
+    the store lock across the whole load→renumber→save span.
+
+    Side effects: writes the store, a pre-repair backup, and a migrations record.
+    """
+    if not _require_snapshot(out):
+        return 1
+    try:
+        from trace_mcp.extensions.learn import store as learn_store
+    except ImportError as exc:
+        print(f"Error: the trace-learn extension is unavailable ({exc}); cannot repair ids.", file=out)
+        return 1
+
+    try:
+        registry = pident.get_registry_cached()
+    except pident.RegistryUnavailableError as exc:
+        print(f"Error: registry is unreadable ({exc}); enroll projects before repairing.", file=out)
+        return 1
+    if registry is None:
+        print("Error: no registry yet — run scan → apply before repair-ids.", file=out)
+        return 1
+    key = registry.resolve(args.key)
+    if key is None:
+        print(f"Error: '{args.key}' resolves to no registered project.", file=out)
+        return 1
+    if key != args.key:
+        print(f"  '{args.key}' resolved to registered key '{key}'.", file=out)
+
+    path = identity_report.knowledge_dir() / f"{key}.json"
+    if not path.is_file():
+        print(f"Nothing to repair: no knowledge store for '{key}'.", file=out)
+        return 0
+    if not identity_report.find_duplicate_learning_ids().get(path.stem):
+        print(f"identity repair-ids: no aliased learning ids in '{key}.json' — nothing to do.", file=out)
+        return 0
+
+    if not _preflight_merge([path], out):
+        return 1
+
+    try:
+        with learn_store.project_lock(key):
+            try:
+                store = learn_store.load_store(key)
+            except learn_store.StoreLoadError as exc:
+                print(f"Error: store for '{key}' is unreadable ({exc}). Repair or move it first.", file=out)
+                return 1
+
+            duplicates = set(store.duplicate_learning_ids())
+            ambiguous = _find_ambiguous_references(store, duplicates)
+            if ambiguous:
+                print(
+                    f"Error: '{key}.json' is ambiguous — a duplicated id is referenced elsewhere, "
+                    "so renumbering would silently repoint the reference:",
+                    file=out,
+                )
+                for hit in ambiguous:
+                    print(f"    {hit}", file=out)
+                print("  Resolve those references by hand, then re-run. Refusing to guess.", file=out)
+                return 1
+
+            sha_before = _sha256(path)
+            renumbered: list[dict[str, str]] = []
+            seen: set[str] = set()
+            for lrn in store.learnings:
+                if lrn.id in seen:
+                    new_id = store.next_learning_id()
+                    renumbered.append({"old": lrn.id, "new": new_id})
+                    lrn.id = new_id
+                seen.add(lrn.id)
+
+            if args.dry_run:
+                print(
+                    f"identity repair-ids (dry run): '{key}.json' would renumber {len(renumbered)} learning(s):",
+                    file=out,
+                )
+                for mapping in renumbered:
+                    print(f"    {mapping['old']} → {mapping['new']}", file=out)
+                return 0
+
+            backup = path.with_name(f"{path.name}.prerepair-{_today()}")
+            suffix = 1
+            while backup.exists():
+                backup = path.with_name(f"{path.name}.prerepair-{_today()}-{suffix}")
+                suffix += 1
+            shutil.copy2(path, backup)
+
+            # save_store refuses an aliased store (INV-12); by here the ids are
+            # unique, so this write is exactly what lifts the refusal.
+            learn_store.save_store(store)
+    except TimeoutError as exc:
+        print(f"Error: could not acquire the store lock for '{key}' ({exc}). Aborting.", file=out)
+        return 1
+
+    _append_migration(
+        {
+            "op": "repair-ids",
+            "key": key,
+            "renumbered": renumbered,
+            "sha256_before": sha_before,
+            "sha256_after": _sha256(path),
+            "prerepair_file": backup.name,
+        }
+    )
+    print(f"  repaired '{key}.json': renumbered {len(renumbered)} aliased learning id(s)", file=out)
+    for mapping in renumbered:
+        print(f"    {mapping['old']} → {mapping['new']}", file=out)
+    print(f"  pre-repair copy kept as {backup.name}", file=out)
     return 0
 
 
@@ -870,6 +1051,10 @@ def build_parser() -> argparse.ArgumentParser:
     p_merge = sub.add_parser("merge-stores", help="consolidate an alias group's knowledge stores (reversible)")
     p_merge.add_argument("--key", default=None, help="a single canonical key to merge (default: every registered key)")
 
+    p_repair = sub.add_parser("repair-ids", help="renumber aliased learning ids in one project's store")
+    p_repair.add_argument("key", help="canonical key (or any alias/display label) of the project to repair")
+    p_repair.add_argument("--dry-run", action="store_true", help="report the renumbering without writing")
+
     p_adopt = sub.add_parser("adopt", help="re-home an 'auto' session into a real project")
     p_adopt.add_argument("session_id", help="the auto session to adopt")
     p_adopt.add_argument("--project", required=True, help="target project name")
@@ -888,6 +1073,7 @@ _COMMANDS = {
     "apply": cmd_apply,
     "check": cmd_check,
     "merge-stores": cmd_merge_stores,
+    "repair-ids": cmd_repair_ids,
     "adopt": cmd_adopt,
     "bundle": cmd_bundle,
 }

--- a/src/trace_mcp/identity_report.py
+++ b/src/trace_mcp/identity_report.py
@@ -13,11 +13,13 @@ extension absent and never triggers a store load.
 Exports:
     ``registry_status`` — ``"ok"`` / ``"absent"`` / ``"unavailable"``.
     ``find_stray_stores`` — knowledge-store stems not backed by a registered key.
+    ``find_duplicate_learning_ids`` — stores whose learning ids are aliased.
     ``knowledge_dir`` — the knowledge directory path (env-aware, no side effects).
 """
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Literal
 
@@ -96,3 +98,49 @@ def find_stray_stores(
             continue
         stray.append(path.stem)
     return sorted(stray)
+
+
+def find_duplicate_learning_ids(directory: str | None = None) -> dict[str, list[str]]:
+    """Map each knowledge-store stem to the learning ids it carries more than once.
+
+    Aliased ids are an integrity fault, not cosmetics: dedup, recall counts, the
+    positional embedding sidecar, and any recorded reference all key on the id, so
+    two learnings sharing one make both unaddressable. Detection lives here — core,
+    filesystem-only, zero imports from ``extensions/`` (ADR-003) — so the CLI and
+    any future core caller can never disagree about the same file, exactly as with
+    ``find_stray_stores``.
+
+    Reads each store as raw JSON rather than validating it, so an unreadable or
+    unexpectedly-shaped file is skipped (other checks report those) instead of
+    aborting the scan. Stores with no duplicates are absent from the result.
+
+    No side effects.
+    """
+    kdir = knowledge_dir(directory)
+    if not kdir.is_dir():
+        return {}
+    duplicates: dict[str, list[str]] = {}
+    for path in sorted(kdir.glob("*.json")):
+        try:
+            raw = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        learnings = raw.get("learnings") if isinstance(raw, dict) else None
+        if not isinstance(learnings, list):
+            continue
+        seen: set[str] = set()
+        aliased: set[str] = set()
+        for entry in learnings:
+            if not isinstance(entry, dict):
+                continue
+            learning_id = entry.get("id")
+            # An unset id is not an alias: only assigned ids can collide.
+            if not isinstance(learning_id, str) or not learning_id:
+                continue
+            if learning_id in seen:
+                aliased.add(learning_id)
+            else:
+                seen.add(learning_id)
+        if aliased:
+            duplicates[path.stem] = sorted(aliased)
+    return duplicates

--- a/tests/test_identity_cli.py
+++ b/tests/test_identity_cli.py
@@ -620,3 +620,159 @@ class TestSnapshotExternalKnowledge:
             assert any("waggle.json" in n for n in tar.getnames()), (
                 "the external knowledge store was counted but not archived"
             )
+
+
+def _write_duplicated_store(
+    home: Path,
+    stem: str,
+    *,
+    project: str | None = None,
+    extra: list[dict] | None = None,
+) -> Path:
+    """A store carrying the live-data shape: two learnings sharing one id."""
+    learnings = [
+        {"id": "lrn_001", "content": "unique first", "category": "learning"},
+        {"id": "lrn_002", "content": "kept — first occurrence", "category": "learning"},
+        {"id": "lrn_003", "content": "unique third", "category": "learning"},
+        {"id": "lrn_002", "content": "renumbered — later occurrence", "category": "gotcha"},
+    ]
+    if extra:
+        learnings.extend(extra)
+    path = home / "knowledge" / f"{stem}.json"
+    path.write_text(json.dumps({"project": project or stem, "learnings": learnings}, indent=2))
+    return path
+
+
+class TestRepairIds:
+    def _prepare(self) -> None:
+        _run("snapshot")
+        _enroll("trace-mcp", display="trace-mcp", aliases=["TRACE"])
+
+    def test_requires_a_snapshot_marker(self, _isolated_home: Path) -> None:
+        _enroll("trace-mcp")
+        _write_duplicated_store(_isolated_home, "trace-mcp")
+        code, out = _run("repair-ids", "trace-mcp")
+        assert code == 1 and "snapshot" in out.lower()
+
+    def test_unknown_key_errors(self, _isolated_home: Path) -> None:
+        self._prepare()
+        code, out = _run("repair-ids", "never-enrolled")
+        assert code == 1 and "resolves to no registered project" in out
+
+    def test_clean_store_is_a_no_op(self, _isolated_home: Path) -> None:
+        self._prepare()
+        _write_store(_isolated_home, "trace-mcp", learnings=["a", "b"], project="trace-mcp")
+        code, out = _run("repair-ids", "trace-mcp")
+        assert code == 0 and "no aliased" in out.lower()
+        assert not list((_isolated_home / "knowledge").glob("*.prerepair-*"))
+
+    def test_renumbers_later_duplicates_and_keeps_the_first(self, _isolated_home: Path) -> None:
+        self._prepare()
+        path = _write_duplicated_store(_isolated_home, "trace-mcp", project="trace-mcp")
+
+        code, out = _run("repair-ids", "trace-mcp")
+        assert code == 0, out
+
+        repaired = json.loads(path.read_text())
+        ids = [lrn["id"] for lrn in repaired["learnings"]]
+        assert len(ids) == len(set(ids)), "duplicates survived the repair"
+        by_content = {lrn["content"]: lrn["id"] for lrn in repaired["learnings"]}
+        assert by_content["kept — first occurrence"] == "lrn_002", "first occurrence must keep its id"
+        assert by_content["renumbered — later occurrence"] == "lrn_004", "later duplicate takes a fresh id"
+        assert repaired["next_id"] == 5, "the counter must advance past the ids it handed out"
+
+    def test_writes_a_prerepair_backup(self, _isolated_home: Path) -> None:
+        self._prepare()
+        path = _write_duplicated_store(_isolated_home, "trace-mcp", project="trace-mcp")
+        before = path.read_bytes()
+
+        assert _run("repair-ids", "trace-mcp")[0] == 0
+        backups = list((_isolated_home / "knowledge").glob("trace-mcp.json.prerepair-*"))
+        assert len(backups) == 1, "the pre-repair copy is the operator's undo"
+        assert backups[0].read_bytes() == before
+
+    def test_records_the_repair_in_the_migrations_log(self, _isolated_home: Path) -> None:
+        self._prepare()
+        _write_duplicated_store(_isolated_home, "trace-mcp", project="trace-mcp")
+        assert _run("repair-ids", "trace-mcp")[0] == 0
+
+        records = [
+            json.loads(line) for line in (_isolated_home / "migrations.jsonl").read_text().splitlines() if line.strip()
+        ]
+        repair = [r for r in records if r.get("op") == "repair-ids"]
+        assert len(repair) == 1, "the repair must be recorded in the append-only log"
+        entry = repair[0]
+        assert entry["key"] == "trace-mcp"
+        assert entry["renumbered"] == [{"old": "lrn_002", "new": "lrn_004"}]
+        assert entry["sha256_before"] != entry["sha256_after"]
+
+    def test_dry_run_reports_without_writing(self, _isolated_home: Path) -> None:
+        self._prepare()
+        path = _write_duplicated_store(_isolated_home, "trace-mcp", project="trace-mcp")
+        before = path.read_bytes()
+
+        code, out = _run("repair-ids", "trace-mcp", "--dry-run")
+        assert code == 0
+        assert "lrn_002" in out and "lrn_004" in out
+        assert path.read_bytes() == before, "dry run must not write"
+        assert not list((_isolated_home / "knowledge").glob("*.prerepair-*"))
+        logged = (_isolated_home / "migrations.jsonl").read_text()
+        assert "repair-ids" not in logged, "a dry run must record nothing"
+
+    def test_refuses_when_a_duplicated_id_is_referenced_elsewhere(self, _isolated_home: Path) -> None:
+        """Ambiguity is refused, never guessed: which of the two did the reference mean?"""
+        self._prepare()
+        path = _write_duplicated_store(
+            _isolated_home,
+            "trace-mcp",
+            project="trace-mcp",
+            extra=[
+                {
+                    "id": "lrn_005",
+                    "content": "supersedes lrn_002",
+                    "category": "correction",
+                    "corrects_event_ids": ["lrn_002"],
+                }
+            ],
+        )
+        before = path.read_bytes()
+
+        code, out = _run("repair-ids", "trace-mcp")
+        assert code == 1
+        assert "lrn_002" in out and "ambiguous" in out.lower()
+        assert path.read_bytes() == before, "an ambiguous store must be left untouched"
+
+    def test_repaired_store_accepts_writes_again(self, _isolated_home: Path) -> None:
+        self._prepare()
+        _write_duplicated_store(_isolated_home, "trace-mcp", project="trace-mcp")
+        assert _run("repair-ids", "trace-mcp")[0] == 0
+
+        from trace_mcp.extensions.learn import store as learn_store
+
+        ks = learn_store.load_store("trace-mcp")
+        added = learn_store.add_learning(ks, content="post-repair write")
+        learn_store.save_store(ks)
+        assert added.id == "lrn_005", "the counter continues past the renumbered ids"
+
+
+class TestDuplicateIdReporting:
+    def test_check_flags_duplicate_learning_ids(self, _isolated_home: Path) -> None:
+        _enroll("trace-mcp")
+        _write_duplicated_store(_isolated_home, "trace-mcp", project="trace-mcp")
+        code, out = _run("check")
+        assert code == 1
+        assert "lrn_002" in out and "duplicate" in out.lower()
+        assert "repair-ids" in out
+
+    def test_merge_stores_refuses_a_duplicated_target(self, _isolated_home: Path) -> None:
+        _run("snapshot")
+        _enroll("trace-mcp", display="trace-mcp", aliases=["TRACE"])
+        target = _write_duplicated_store(_isolated_home, "trace-mcp", project="trace-mcp")
+        _write_store(_isolated_home, "trace", learnings=["source only"], project="TRACE")
+        before = target.read_bytes()
+
+        code, out = _run("merge-stores", "--key", "trace-mcp")
+        assert code == 1
+        assert "repair-ids" in out
+        assert target.read_bytes() == before, "target must not be rewritten"
+        assert (_isolated_home / "knowledge" / "trace.json").exists(), "source must not be consumed"

--- a/tests/test_identity_cli.py
+++ b/tests/test_identity_cli.py
@@ -776,3 +776,79 @@ class TestDuplicateIdReporting:
         assert "repair-ids" in out
         assert target.read_bytes() == before, "target must not be rewritten"
         assert (_isolated_home / "knowledge" / "trace.json").exists(), "source must not be consumed"
+
+
+class TestRepairIdsReachesEveryFlaggedStore:
+    """`check` reports duplicates for every store on disk, so the repair must be
+    able to reach the same population — otherwise a flagged store is refused for
+    all writes with no supported fix."""
+
+    def _prepare(self) -> None:
+        _run("snapshot")
+        _enroll("registered-one")
+
+    def test_repairs_a_store_that_is_not_registered(self, _isolated_home: Path) -> None:
+        self._prepare()
+        path = _write_duplicated_store(_isolated_home, "stray-store", project="stray-store")
+        assert _run("check")[0] == 1, "precondition: check flags the stray store"
+
+        code, out = _run("repair-ids", "stray-store")
+        assert code == 0, out
+        ids = [lrn["id"] for lrn in json.loads(path.read_text())["learnings"]]
+        assert len(ids) == len(set(ids))
+
+    def test_unknown_name_with_no_store_still_errors(self, _isolated_home: Path) -> None:
+        self._prepare()
+        code, out = _run("repair-ids", "never-heard-of-it")
+        assert code == 1 and "resolves to no registered project" in out
+
+    def test_an_unrelated_projects_lock_does_not_block_the_repair(self, _isolated_home: Path) -> None:
+        """A stale lock belonging to another store must not wedge the only fix path."""
+        self._prepare()
+        _write_duplicated_store(_isolated_home, "target", project="target")
+        (_isolated_home / "knowledge" / "someone-else.json.lock").write_text("held")
+
+        code, out = _run("repair-ids", "target")
+        assert code == 0, out
+
+
+class TestRepairIdsReferenceScan:
+    def _prepare(self) -> None:
+        _run("snapshot")
+        _enroll("proj")
+
+    def test_a_structured_reference_refuses(self, _isolated_home: Path) -> None:
+        self._prepare()
+        path = _write_duplicated_store(
+            _isolated_home,
+            "proj",
+            project="proj",
+            extra=[
+                {
+                    "id": "lrn_005",
+                    "content": "unrelated text",
+                    "category": "correction",
+                    "corrects_event_ids": ["lrn_002"],
+                }
+            ],
+        )
+        before = path.read_bytes()
+        code, out = _run("repair-ids", "proj")
+        assert code == 1 and "ambiguous" in out.lower() and "lrn_002" in out
+        assert path.read_bytes() == before
+
+    def test_a_prose_mention_warns_but_repairs(self, _isolated_home: Path) -> None:
+        """Free text is not a machine-resolvable reference; refusing on it would
+        leave a store permanently unwritable with hand-editing the only escape."""
+        self._prepare()
+        path = _write_duplicated_store(
+            _isolated_home,
+            "proj",
+            project="proj",
+            extra=[{"id": "lrn_005", "content": "this supersedes lrn_002 in prose", "category": "learning"}],
+        )
+        code, out = _run("repair-ids", "proj")
+        assert code == 0, out
+        assert "lrn_005" in out and "mentions" in out.lower(), "the prose mention must still be reported"
+        ids = [lrn["id"] for lrn in json.loads(path.read_text())["learnings"]]
+        assert len(ids) == len(set(ids))

--- a/tests/test_invariants.py
+++ b/tests/test_invariants.py
@@ -310,3 +310,115 @@ def test_inv9_learn_tools_guard_reserved_projects() -> None:
         f"call _resolve_project at entry: {sorted(missing)}. A foreign label could bypass the TRACE_PROJECT "
         "pin, or a reserved-key label could reach a store."
     )
+
+
+# ── INV-12: learning ids are never reused ────────────────────────────────
+# `next_learning_id` used to return max(existing) + 1, so forgetting the highest
+# learning handed its id to different content on the next add — aliasing every
+# reference that named it. The durable fix is a PERSISTED counter plus a refusal
+# to write an already-aliased store; these guards fail if either half regresses
+# or if a new appender mints ids some other way.
+INV12_LEARNING_APPENDERS = {
+    ("extensions/learn/store.py", "add_learning"),
+    ("identity_cli.py", "cmd_merge_stores"),
+}
+
+INV12_DUPLICATE_REFUSERS = {
+    ("extensions/learn/store.py", "save_store"),
+    ("extensions/learn/store.py", "add_learning"),
+}
+
+
+def _functions_appending_learnings() -> set[tuple[str, str]]:
+    """Every (relpath, function) whose body calls ``….learnings.append(…)``."""
+    found: set[tuple[str, str]] = set()
+    for path in _src_files():
+        tree = ast.parse(path.read_text(), filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+                continue
+            for sub in ast.walk(node):
+                if (
+                    isinstance(sub, ast.Call)
+                    and isinstance(sub.func, ast.Attribute)
+                    and sub.func.attr == "append"
+                    and isinstance(sub.func.value, ast.Attribute)
+                    and sub.func.value.attr == "learnings"
+                ):
+                    found.add((_rel(path), node.name))
+    return found
+
+
+def _knowledge_store_method(name: str) -> ast.FunctionDef:
+    tree = ast.parse((SRC / "extensions" / "learn" / "models.py").read_text())
+    fn = next(
+        (n for n in ast.walk(tree) if isinstance(n, ast.FunctionDef) and n.name == name),
+        None,
+    )
+    assert fn is not None, f"KnowledgeStore.{name} disappeared — INV-12's guard has nothing to check."
+    return fn
+
+
+def test_inv12_next_learning_id_reads_and_advances_the_persisted_counter() -> None:
+    """The id must come from ``next_id``, never from arithmetic over existing ids."""
+    fn = _knowledge_store_method("next_learning_id")
+    calls = {_call_name(c) for c in ast.walk(fn) if isinstance(c, ast.Call)}
+    assert "max" not in calls, (
+        "INV-12 violation: next_learning_id derives an id from max() over existing ids again. "
+        "Forgetting the highest learning then re-adding reissues its id, aliasing every "
+        "reference that named it. Mint from the persisted next_id counter instead."
+    )
+    assert any(isinstance(n, ast.Attribute) and n.attr == "next_id" for n in ast.walk(fn)), (
+        "INV-12 violation: next_learning_id no longer reads the persisted next_id counter."
+    )
+    assert any(
+        isinstance(n, ast.AugAssign) and isinstance(n.target, ast.Attribute) and n.target.attr == "next_id"
+        for n in ast.walk(fn)
+    ), "INV-12 violation: next_learning_id does not advance next_id, so two calls can collide."
+
+
+def test_inv12_counter_healing_never_lowers_the_counter() -> None:
+    """The load-time validator may only raise the counter — lowering it reissues ids."""
+    fn = _knowledge_store_method("_raise_counter_above_existing_ids")
+    assigns = [
+        n
+        for n in ast.walk(fn)
+        if isinstance(n, ast.Assign) and any(isinstance(t, ast.Attribute) and t.attr == "next_id" for t in n.targets)
+    ]
+    assert assigns, "INV-12 violation: the counter validator no longer initializes next_id."
+    for node in assigns:
+        assert isinstance(node.value, ast.BinOp) and isinstance(node.value.op, ast.Add), (
+            "INV-12 violation: next_id is assigned something other than <highest existing> + 1; "
+            "the validator must only ever raise the counter."
+        )
+
+
+def test_inv12_every_learning_appender_is_registered() -> None:
+    appenders = _functions_appending_learnings()
+    assert appenders, "the learnings-append detector matched nothing — the AST pattern has rotted."
+    unregistered = appenders - INV12_LEARNING_APPENDERS
+    assert not unregistered, (
+        f"INV-12 violation (docs/INVARIANTS.md): unregistered learning appender(s): {sorted(unregistered)}. "
+        "Mint the id with KnowledgeStore.next_learning_id() and register the site in "
+        "INV12_LEARNING_APPENDERS."
+    )
+    stale = INV12_LEARNING_APPENDERS - appenders
+    assert not stale, f"INV-12 registry is stale — these no longer append learnings: {sorted(stale)}."
+
+
+def test_inv12_registered_appenders_mint_from_the_counter() -> None:
+    minters = _functions_calling("next_learning_id")
+    missing = INV12_LEARNING_APPENDERS - minters
+    assert not missing, (
+        f"INV-12 violation: these append learnings without minting an id from the store counter: {sorted(missing)}."
+    )
+
+
+def test_inv12_store_writes_refuse_an_aliased_store() -> None:
+    """Reads stay permissive; every write path must fail closed on duplicate ids."""
+    refusers = _functions_calling("_refuse_duplicate_ids")
+    missing = INV12_DUPLICATE_REFUSERS - refusers
+    assert not missing, (
+        f"INV-12 violation: these write paths no longer refuse an aliased store: {sorted(missing)}. "
+        "Writing to a store with duplicate learning ids spreads the aliasing."
+    )

--- a/tests/test_invariants.py
+++ b/tests/test_invariants.py
@@ -329,23 +329,49 @@ INV12_DUPLICATE_REFUSERS = {
 }
 
 
+_LIST_GROWERS = {"append", "extend", "insert"}
+
+
+def _is_learnings_attr(node: ast.expr) -> bool:
+    return isinstance(node, ast.Attribute) and node.attr == "learnings"
+
+
+def _grows_learnings(sub: ast.AST) -> bool:
+    """True if *sub* adds entries to a ``.learnings`` list.
+
+    Covers ``x.learnings.append/extend/insert(...)``, ``x.learnings += [...]``,
+    and slice assignment ``x.learnings[a:b] = ...``. A local alias
+    (``lst = x.learnings; lst.append(...)``) is beyond a check of this shape; the
+    behavioral tests in tests/test_learn_store.py are the backstop there, and the
+    id-minting assertion below fails for any registered site that stops using the
+    counter regardless of how it appends.
+    """
+    if (
+        isinstance(sub, ast.Call)
+        and isinstance(sub.func, ast.Attribute)
+        and sub.func.attr in _LIST_GROWERS
+        and _is_learnings_attr(sub.func.value)
+    ):
+        return True
+    if isinstance(sub, ast.AugAssign) and _is_learnings_attr(sub.target):
+        return True
+    if isinstance(sub, ast.Assign) and any(
+        isinstance(t, ast.Subscript) and _is_learnings_attr(t.value) for t in sub.targets
+    ):
+        return True
+    return False
+
+
 def _functions_appending_learnings() -> set[tuple[str, str]]:
-    """Every (relpath, function) whose body calls ``….learnings.append(…)``."""
+    """Every (relpath, function) whose body grows a ``.learnings`` list."""
     found: set[tuple[str, str]] = set()
     for path in _src_files():
         tree = ast.parse(path.read_text(), filename=str(path))
         for node in ast.walk(tree):
             if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
                 continue
-            for sub in ast.walk(node):
-                if (
-                    isinstance(sub, ast.Call)
-                    and isinstance(sub.func, ast.Attribute)
-                    and sub.func.attr == "append"
-                    and isinstance(sub.func.value, ast.Attribute)
-                    and sub.func.value.attr == "learnings"
-                ):
-                    found.add((_rel(path), node.name))
+            if any(_grows_learnings(sub) for sub in ast.walk(node)):
+                found.add((_rel(path), node.name))
     return found
 
 

--- a/tests/test_learn_aliased_store.py
+++ b/tests/test_learn_aliased_store.py
@@ -1,0 +1,114 @@
+"""Behavior of the learn tools against a store whose learning ids are aliased.
+
+INV-12 refuses WRITES to such a store while leaving READS working, so the store
+stays recoverable, exportable, and searchable until
+``trace-mcp identity repair-ids`` renumbers it. Two things make that split real
+rather than aspirational, and both are pinned here:
+
+* Recall is not a pure read — it persists recall counts and any embeddings it
+  computed lazily. That bookkeeping must degrade to "not persisted" rather than
+  failing the recall, or the guarantee is inverted for exactly the stores the
+  guard exists to protect.
+* The refusal composes a message naming the repair command. A bare
+  ``except Exception`` in the tool would discard it and hand back a generic
+  failure, so the first person to meet the guard would have no idea a fix exists.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from mcp.server.fastmcp import FastMCP
+
+import trace_mcp.project_identity as pident
+from trace_mcp.extensions.learn import register
+from trace_mcp.storage.json_file import JsonFileStorage
+
+PROJECT = "aliased-proj"
+
+# Two learnings share lrn_002 — the live shape this guard was written for.
+ALIASED_STORE: dict[str, Any] = {
+    "project": PROJECT,
+    "learnings": [
+        {"id": "lrn_001", "content": "peregrine falcon telemetry sentinel", "category": "learning"},
+        {"id": "lrn_002", "content": "kept first occurrence about falcons", "category": "learning"},
+        {"id": "lrn_002", "content": "later occurrence about falcons", "category": "gotcha"},
+    ],
+}
+
+
+@pytest.fixture()
+def learn_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Isolated dirs and an offline keyword backend, with the aliased store planted."""
+    knowledge = tmp_path / "knowledge"
+    knowledge.mkdir(parents=True)
+    (knowledge / f"{PROJECT}.json").write_text(json.dumps(ALIASED_STORE, indent=2), encoding="utf-8")
+
+    monkeypatch.setenv("TRACE_KNOWLEDGE_DIR", str(knowledge))
+    monkeypatch.setenv("TRACE_SESSIONS_DIR", str(tmp_path / "sessions"))
+    monkeypatch.setenv("TRACE_REGISTRY_PATH", str(tmp_path / "projects.json"))
+    monkeypatch.setenv("TRACE_EMBEDDING_BACKEND", "none")
+    monkeypatch.setenv("TRACE_LLM_ENABLED", "false")
+    monkeypatch.setenv("TRACE_STRICT_LLM", "false")
+    for var in ("TRACE_PROJECT", "OPENAI_API_KEY", "TRACE_LOCAL_ONLY"):
+        monkeypatch.delenv(var, raising=False)
+    pident._reset_registry_cache()
+    mcp = FastMCP("learn-aliased-test")
+    register(mcp, JsonFileStorage(directory=str(tmp_path / "sessions")))
+    yield mcp, knowledge
+    pident._reset_registry_cache()
+
+
+async def _call(mcp: FastMCP, tool: str, args: dict[str, Any]) -> dict:
+    out = await mcp.call_tool(tool, args)
+    if isinstance(out, tuple):
+        out = out[0]
+    return json.loads(out[0].text)  # type: ignore[union-attr]
+
+
+class TestReadsStayUsable:
+    async def test_recall_returns_hits_and_warns_instead_of_failing(self, learn_env) -> None:
+        mcp, _ = learn_env
+        payload = await _call(mcp, "trace_learn_recall", {"context": "falcon telemetry", "project": PROJECT})
+
+        assert "error" not in payload, f"recall must not fail on an aliased store: {payload}"
+        assert payload["total"] >= 1, "recall returned no hits, so the read guarantee is not real"
+        warnings = " ".join(payload.get("warnings", []))
+        assert "repair-ids" in warnings, "the operator is never told why bookkeeping was not persisted"
+
+    async def test_recall_does_not_rewrite_the_aliased_store(self, learn_env) -> None:
+        """Bookkeeping is skipped, not forced through — the file is left as it was."""
+        mcp, knowledge = learn_env
+        before = (knowledge / f"{PROJECT}.json").read_bytes()
+        await _call(mcp, "trace_learn_recall", {"context": "falcon telemetry", "project": PROJECT})
+        assert (knowledge / f"{PROJECT}.json").read_bytes() == before
+
+    async def test_list_still_enumerates_every_learning(self, learn_env) -> None:
+        mcp, _ = learn_env
+        payload = await _call(mcp, "trace_learn_list", {"project": PROJECT})
+        assert "error" not in payload
+        assert payload["total"] == 3
+
+
+class TestWritesRefuseWithGuidance:
+    async def test_add_names_the_repair_command(self, learn_env) -> None:
+        mcp, _ = learn_env
+        payload = await _call(mcp, "trace_learn_add", {"content": "new insight", "project": PROJECT})
+        assert payload.get("error") == "duplicate_learning_ids", payload
+        assert "repair-ids" in payload.get("detail", "")
+
+    async def test_forget_names_the_repair_command(self, learn_env) -> None:
+        """`forget` is the natural reaction to a bad learning, so it is the likely first contact."""
+        mcp, _ = learn_env
+        payload = await _call(mcp, "trace_learn_forget", {"learning_id": "lrn_001", "project": PROJECT})
+        assert payload.get("error") == "duplicate_learning_ids", payload
+        assert "repair-ids" in payload.get("detail", "")
+
+    async def test_a_refused_write_leaves_the_store_untouched(self, learn_env) -> None:
+        mcp, knowledge = learn_env
+        before = (knowledge / f"{PROJECT}.json").read_bytes()
+        await _call(mcp, "trace_learn_add", {"content": "new insight", "project": PROJECT})
+        assert (knowledge / f"{PROJECT}.json").read_bytes() == before

--- a/tests/test_learn_models.py
+++ b/tests/test_learn_models.py
@@ -229,3 +229,81 @@ class TestRecallTrackingFields:
         restored = Learning.model_validate(data)
         assert restored.recall_count == 3
         assert restored.last_surfaced is not None
+
+
+class TestMonotonicIds:
+    """``next_id`` is a persisted counter, so a forgotten id is never reused (INV-12)."""
+
+    def test_repeated_calls_return_distinct_ids(self):
+        """The counter advances on call, not on append — two calls can never collide."""
+        ks = KnowledgeStore(project="test")
+        assert ks.next_learning_id() == "lrn_001"
+        assert ks.next_learning_id() == "lrn_002"
+
+    def test_legacy_store_initializes_the_counter_above_the_max(self):
+        ks = KnowledgeStore.model_validate(
+            {
+                "project": "legacy",
+                "learnings": [
+                    {"id": "lrn_001", "content": "a"},
+                    {"id": "lrn_007", "content": "b"},
+                ],
+            }
+        )
+        assert ks.next_id == 8
+        assert ks.next_learning_id() == "lrn_008"
+
+    def test_counter_survives_a_json_roundtrip(self):
+        ks = KnowledgeStore(project="test")
+        ks.next_learning_id()
+        restored = KnowledgeStore.model_validate(json.loads(ks.model_dump_json()))
+        assert restored.next_id == 2
+
+    def test_counter_self_heals_upward(self):
+        """A stale counter below the highest existing id is raised, never trusted."""
+        ks = KnowledgeStore.model_validate(
+            {
+                "project": "test",
+                "next_id": 2,
+                "learnings": [{"id": "lrn_009", "content": "a"}],
+            }
+        )
+        assert ks.next_id == 10
+
+    def test_counter_is_never_lowered(self):
+        """A counter ahead of the learnings (the forget case) is preserved as-is."""
+        ks = KnowledgeStore.model_validate(
+            {
+                "project": "test",
+                "next_id": 50,
+                "learnings": [{"id": "lrn_001", "content": "a"}],
+            }
+        )
+        assert ks.next_id == 50
+        assert ks.next_learning_id() == "lrn_050"
+
+    def test_duplicate_ids_are_reported_not_raised(self):
+        """Loading a duplicated store must succeed — reads keep working; writes refuse."""
+        ks = KnowledgeStore.model_validate(
+            {
+                "project": "test",
+                "learnings": [
+                    {"id": "lrn_002", "content": "a"},
+                    {"id": "lrn_002", "content": "b"},
+                    {"id": "lrn_003", "content": "c"},
+                ],
+            }
+        )
+        assert ks.duplicate_learning_ids() == ["lrn_002"]
+
+    def test_clean_store_reports_no_duplicates(self):
+        ks = KnowledgeStore(project="test", learnings=[Learning(id="lrn_001", content="a")])
+        assert ks.duplicate_learning_ids() == []
+
+    def test_unset_ids_are_not_reported_as_aliases(self):
+        """Several not-yet-added learnings legitimately carry no id at all."""
+        ks = KnowledgeStore(
+            project="test",
+            learnings=[Learning(content="a"), Learning(content="b")],
+        )
+        assert ks.duplicate_learning_ids() == []

--- a/tests/test_learn_store.py
+++ b/tests/test_learn_store.py
@@ -13,6 +13,7 @@ import pytest
 from trace_mcp.extensions.learn.models import KnowledgeStore
 from trace_mcp.extensions.learn.store import (
     DedupResult,
+    DuplicateLearningIdError,
     StoreLoadError,
     add_learning,
     add_learning_dedup,
@@ -290,3 +291,83 @@ class TestStorePathSanitized:
         path.write_text("{broken json!!!", encoding="utf-8")
         with pytest.raises(StoreLoadError, match="Corrupt JSON"):
             load_store("corrupt", directory=str(tmp_path))
+
+
+class TestLearningIdReuse:
+    """Forgetting the highest id must never recycle it, and a duplicated store
+    must fail closed on WRITE while still serving reads (INV-12)."""
+
+    def test_forget_then_add_does_not_reuse_the_id(self, tmp_path):
+        """The reproduction: remove the highest id, add again, expect a fresh id."""
+        ks = load_store("reuse", directory=str(tmp_path))
+        first = add_learning(ks, content="first insight")
+        second = add_learning(ks, content="second insight")
+        save_store(ks, directory=str(tmp_path))
+
+        ks = load_store("reuse", directory=str(tmp_path))
+        assert remove_learning(ks, second.id)
+        save_store(ks, directory=str(tmp_path))
+
+        ks = load_store("reuse", directory=str(tmp_path))
+        third = add_learning(ks, content="third insight")
+        assert third.id not in {first.id, second.id}
+
+    def test_legacy_store_on_disk_gains_a_counter(self, tmp_path):
+        """A store written before the counter existed initializes it on load."""
+        path = tmp_path / "legacy.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "project": "legacy",
+                    "learnings": [{"id": "lrn_001", "content": "a"}, {"id": "lrn_004", "content": "b"}],
+                }
+            )
+        )
+        ks = load_store("legacy", directory=str(tmp_path))
+        assert ks.next_id == 5
+        save_store(ks, directory=str(tmp_path))
+        assert json.loads(path.read_text())["next_id"] == 5
+
+    def _duplicated_store(self, tmp_path):
+        path = tmp_path / "dupes.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "project": "dupes",
+                    "learnings": [
+                        {"id": "lrn_001", "content": "a"},
+                        {"id": "lrn_002", "content": "b"},
+                        {"id": "lrn_002", "content": "c"},
+                    ],
+                }
+            )
+        )
+        return path
+
+    def test_reads_still_work_on_a_duplicated_store(self, tmp_path):
+        """Loading must not raise — a duplicated store stays readable and exportable."""
+        self._duplicated_store(tmp_path)
+        ks = load_store("dupes", directory=str(tmp_path))
+        assert len(list_learnings(ks)) == 3
+        assert ks.duplicate_learning_ids() == ["lrn_002"]
+
+    def test_save_refuses_while_duplicates_are_present(self, tmp_path):
+        self._duplicated_store(tmp_path)
+        ks = load_store("dupes", directory=str(tmp_path))
+        with pytest.raises(DuplicateLearningIdError) as exc:
+            save_store(ks, directory=str(tmp_path))
+        assert "repair-ids" in str(exc.value)
+
+    def test_add_learning_refuses_while_duplicates_are_present(self, tmp_path):
+        self._duplicated_store(tmp_path)
+        ks = load_store("dupes", directory=str(tmp_path))
+        with pytest.raises(DuplicateLearningIdError):
+            add_learning(ks, content="would alias an existing id")
+
+    def test_refusal_leaves_the_file_untouched(self, tmp_path):
+        path = self._duplicated_store(tmp_path)
+        before = path.read_bytes()
+        ks = load_store("dupes", directory=str(tmp_path))
+        with pytest.raises(DuplicateLearningIdError):
+            save_store(ks, directory=str(tmp_path))
+        assert path.read_bytes() == before


### PR DESCRIPTION
## Summary

Learning ids are now minted from a persisted monotonic counter on `KnowledgeStore`
(`next_id`) instead of `max(existing) + 1`, so an id released by
`trace_learn_forget` is never reissued to different content. Writes to a store
whose ids are already aliased fail closed, `trace-mcp identity check` reports
affected stores, and a new `trace-mcp identity repair-ids <key>` renumbers one.
Registered as INV-12 in `docs/INVARIANTS.md` with an enumeration guard.

## Why

`next_learning_id()` derived the next id from the ids currently present, so
forgetting the highest learning and adding another handed the new content the id
just released. Deduplication, recall counts, the positionally-aligned embedding
sidecar, and any recorded reference all key on that id, so the two records become
mutually unaddressable — and, unlike a lost update, nothing about the store looks
wrong afterwards. This is the same defect shape the invariants registry exists to
catch: a rule (an id identifies one record) enforced by a scheme that quietly
breaks under one operation.

The read/write split is deliberate. Raising on load would make an affected
store's recall, list, and export fail and would turn a recoverable file into an
unreadable one — the failure `load_store` already warns against. Allowing writes
would let the aliasing spread. So reads stay permissive and every write path
refuses with a message naming the repair command.

`repair-ids` refuses rather than guesses when a duplicated id appears in a
structured field of another record: after renumbering, nothing on disk would say
which of the two records that reference meant. This mirrors the alias-table-first
rule for label repair in specification §8.5 — never invent an attribution you
cannot know. A mention in free text is reported instead of blocking, because no
code path resolves prose and refusing on it would leave the store unwritable.

## What changed

- `KnowledgeStore.next_id`, persisted. Stores written before the field existed
  initialize it on load; a counter found below the highest id present is raised,
  never lowered, and the anomaly is logged. Ids are consumed on call, not on
  append, so two calls can never collide.
- `save_store` and `add_learning` raise `DuplicateLearningIdError`;
  `identity merge-stores` refuses an aliased target before grafting, so a merge
  cannot consume its sources into premerge backups while spreading the aliasing.
- `identity_report.find_duplicate_learning_ids` — detection in core,
  filesystem-only, no imports from `extensions/`, so the CLI and any future core
  caller cannot disagree about the same file (the `find_stray_stores` precedent).
- `trace-mcp identity repair-ids <key> [--dry-run]` — snapshot-gated, checks the
  target store is quiescent, holds the store lock, keeps the first occurrence
  of each id and renumbers later ones in array order, copies the original to
  `*.json.prerepair-<date>`, and appends the mapping with before/after digests to
  the migrations log.
- An unset id (the empty-string default on a not-yet-added `Learning`) is not
  treated as an alias — only assigned ids can collide.

Refinements from review, in the second commit:

- **Recall keeps working.** Recall is a read for its caller but persists recall
  counts and lazily-computed embeddings; on an aliased store that write was
  refused, so every recall returning hits failed. That bookkeeping mints no id,
  so it is now dropped with a notice on the response instead of failing the
  call. The auto-recall hook degrades the same way.
- **Refused writes name the fix.** Each learn tool returned a generic failure
  through a bare handler that discarded the remediation message. They now
  return `duplicate_learning_ids` with it in `detail`.
- **`repair-ids` reaches every store `check` flags.** It resolved only through
  the registry, so a stray, quarantine, or not-yet-enrolled store could be
  flagged and refused for all writes with no supported fix. It now falls back to
  the canonical store stem when a store file exists.
- **The reference scan no longer traps the store.** It matched a duplicated id
  as a substring of any field, including free-text content, so a learning whose
  prose merely mentioned an id would have refused the repair permanently. A
  structured field now blocks on an exact match; a prose mention is reported and
  does not block, since no code path resolves it.
- **One crashed writer cannot wedge the fix.** `repair-ids` inherited a preflight
  refusing when any lock file existed anywhere in the knowledge directory.
  Quiescence is now checked on the target file alone; ownership is left to the
  store lock, which already steals a provably-dead holder's lock and fails closed
  on a live one.
- **The enumeration guard widened** from `.learnings.append(...)` to any growth
  of a `.learnings` list (`extend`, `insert`, `+=`, slice assignment).

## Verification

- Full suite 1433 passed / 12 skipped; both ruff gates, pyright over
  `src tests scripts examples`, and the invariant guard clean.
- Built artifact: `uv build` plus `tests/test_packaging_artifacts.py` (11 passed),
  and the new subcommand confirmed reachable from the installed wheel in an
  isolated environment.
- The guards were mutation-checked: reverting `next_learning_id` to `max()`
  arithmetic, removing the write-path refusal, and adding an `extend`-based
  appender each fail the intended INV-12 test and nothing else.
- Rehearsed on a copy of a real 312-learning store carrying three duplicate ids:
  the dry run predicted the three renumberings exactly, the repair applied them,
  `identity check` went from one finding to clean, ids became unique, the
  embedding sidecar still matched row for row, and the pre-repair backup
  preserved the original ids with content order unchanged.

## Operational note for deployment

A store that already carries duplicate ids stops accepting writes the moment this
merges — including session-end learning extraction for that project. The fix is
one command per affected store:

```
trace-mcp identity snapshot
trace-mcp identity check                 # names the affected stores
trace-mcp identity repair-ids <key> --dry-run
trace-mcp identity repair-ids <key>
```

If the store was written within the last few seconds the command aborts with "a
writer may be active" — that is the quiescence guard; re-run it a moment later.

## Known limitation

A server built before `next_id` existed loads a repaired store, drops the field
on write, and the counter re-initializes from the highest id present on the next
load; a forget-then-add across that window can still reissue an id. This is
recorded in the INV-12 entry and governed by the standing rule that consumers
build from `main`.
