### PR TITLE
feat(server): serve the MCP tool surface over Streamable HTTP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,15 +17,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Streamable HTTP transport.** `trace-mcp --transport streamable-http
   [--host 127.0.0.1] [--port 8765]` serves the MCP tool surface at
   `http://HOST:PORT/mcp` for consumers that connect to a running endpoint
-  instead of spawning a stdio process — agent runtimes with an MCP service
-  registry, or any client on the same machine that outlives one editor
-  session. Default behavior is unchanged (`trace-mcp` with no flags still
+  instead of spawning a stdio process, such as agent runtimes with an MCP
+  service registry or any client on the same machine that outlives one
+  editor session. Default behavior is unchanged (`trace-mcp` with no flags still
   serves stdio); an unknown flag or transport exits non-zero instead of
   silently starting a stdio server. Binding a non-loopback host logs a loud
   warning, since TRACE tools carry no authentication layer. One caveat is
   inherent to the current design: the server keeps a single current-session
   pointer, so concurrent HTTP clients that do not pass `session_id`
-  explicitly on every call will interleave into one session — pass
+  explicitly on every call will interleave into one session. Pass
   `session_id`, or run one server instance per consumer.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Streamable HTTP transport.** `trace-mcp --transport streamable-http
+  [--host 127.0.0.1] [--port 8765]` serves the MCP tool surface at
+  `http://HOST:PORT/mcp` for consumers that connect to a running endpoint
+  instead of spawning a stdio process — agent runtimes with an MCP service
+  registry, or any client on the same machine that outlives one editor
+  session. Default behavior is unchanged (`trace-mcp` with no flags still
+  serves stdio); an unknown flag or transport exits non-zero instead of
+  silently starting a stdio server. Binding a non-loopback host logs a loud
+  warning, since TRACE tools carry no authentication layer. One caveat is
+  inherent to the current design: the server keeps a single current-session
+  pointer, so concurrent HTTP clients that do not pass `session_id`
+  explicitly on every call will interleave into one session — pass
+  `session_id`, or run one server instance per consumer.
+
 ### Fixed
 
 - **Learning ids are no longer reused after a delete.** `KnowledgeStore` now

--- a/README.md
+++ b/README.md
@@ -143,6 +143,33 @@ Two parts of that config are easy to omit and worth keeping:
 - **The three `--with` packages are what make this a 22-tool server.** They are the optional dependencies of the trace-learn extension. Without them the server still starts and still records provenance, but the extension does not load and you get the 17 core tools with no error to tell you why.
 - **`TRACE_PROJECT` pins the process to one project.** With it set you omit `project` from `trace_start_session`, and cross-project reads and writes fail closed. Without it, pass `project="..."` explicitly on every session start — an unpinned server rejects the call rather than guessing.
 
+### Serve over Streamable HTTP
+
+The config above spawns TRACE as a stdio subprocess, which is what editor-style
+clients do. A client that instead connects to an endpoint it did not spawn (an
+agent runtime with an MCP service registry, or any consumer that outlives one
+editor session) needs the HTTP transport:
+
+```bash
+trace-mcp --transport streamable-http --port 8765   # serves http://127.0.0.1:8765/mcp
+```
+
+`--host` (default `127.0.0.1`) and `--port` (default `8765`) apply only to this
+transport. Plain `trace-mcp` still serves stdio, and an unknown flag or
+transport exits non-zero rather than falling back to stdio while an HTTP
+consumer waits on a socket that never opens.
+
+Two things to know before pointing a runtime at it:
+
+- **There is no authentication layer.** Anything that can reach the port can
+  write to your session store, so keep the bind on loopback unless the host is
+  isolated by other means. A non-loopback bind logs a warning at startup.
+- **Pass `session_id` on every call** when more than one client shares the
+  endpoint. The process keeps a single current-session pointer (see [Known
+  limitations](#known-limitations)), so concurrent clients that rely on it
+  interleave into one session. One server instance per consumer avoids the
+  question entirely.
+
 ### Install hooks
 
 `trace-mcp-init` installs the host-side enforcement: hook scripts under `.claude/hooks/`, registrations merged into `.claude/settings.json`, and a marker block appended to `CLAUDE.md`.

--- a/src/trace_mcp/server.py
+++ b/src/trace_mcp/server.py
@@ -1054,7 +1054,7 @@ def _parse_server_args(argv: list[str]) -> argparse.Namespace:
     (``init``, ``identity``, ``doctor``, ...) have been dispatched. Outputs: a
     namespace with ``transport``, ``host``, and ``port``. Side effects: none on
     valid input; argparse prints usage and exits non-zero on an unknown flag,
-    which is the fail-loud behavior we want — a typo'd invocation must never
+    which is the fail-loud behavior we want: a typo'd invocation must never
     silently start a stdio server that a Streamable HTTP consumer then waits on.
 
     ``--host`` and ``--port`` only take effect with

--- a/src/trace_mcp/server.py
+++ b/src/trace_mcp/server.py
@@ -7,6 +7,7 @@ research workflows.
 
 from __future__ import annotations
 
+import argparse
 import json
 import logging
 import os
@@ -1014,10 +1015,79 @@ def main() -> None:
 
         raise SystemExit(validate_main(sys.argv[2:]))
 
+    args = _parse_server_args(sys.argv[1:])
+
     _load_extensions()
 
-    logger.info("Starting TRACE MCP server v%s", __version__)
+    if args.transport == "streamable-http":
+        _LOOPBACK_HOSTS = ("127.0.0.1", "localhost", "::1")
+        if args.host not in _LOOPBACK_HOSTS:
+            # Loud, not fatal: TRACE tools carry no authentication layer, so a
+            # non-loopback bind hands session write access to the network. An
+            # operator doing this deliberately (e.g. inside a container) should
+            # see exactly what they opted into.
+            logger.warning(
+                "Binding to %s exposes TRACE tools to the network WITHOUT authentication; "
+                "prefer 127.0.0.1 and a local consumer unless this host is otherwise isolated.",
+                args.host,
+            )
+        mcp.settings.host = args.host
+        mcp.settings.port = args.port
+        logger.info(
+            "Starting TRACE MCP server v%s at http://%s:%d%s (transport=streamable-http)",
+            __version__,
+            args.host,
+            args.port,
+            mcp.settings.streamable_http_path,
+        )
+        mcp.run(transport="streamable-http")
+        return
+
+    logger.info("Starting TRACE MCP server v%s (transport=stdio)", __version__)
     mcp.run(transport="stdio")
+
+
+def _parse_server_args(argv: list[str]) -> argparse.Namespace:
+    """Parse server-mode CLI flags for the default (serve) invocation.
+
+    Inputs: ``argv`` without the program name, after the named subcommands
+    (``init``, ``identity``, ``doctor``, ...) have been dispatched. Outputs: a
+    namespace with ``transport``, ``host``, and ``port``. Side effects: none on
+    valid input; argparse prints usage and exits non-zero on an unknown flag,
+    which is the fail-loud behavior we want — a typo'd invocation must never
+    silently start a stdio server that a Streamable HTTP consumer then waits on.
+
+    ``--host`` and ``--port`` only take effect with
+    ``--transport streamable-http``; the stdio transport has no socket. The
+    HTTP path is FastMCP's ``streamable_http_path`` default (``/mcp``).
+    """
+    parser = argparse.ArgumentParser(
+        prog="trace-mcp",
+        description=(
+            "Run the TRACE MCP server. With no flags, serves over stdio for a "
+            "spawning MCP client. --transport streamable-http serves HTTP at "
+            "http://HOST:PORT/mcp for clients that connect over the network, "
+            "such as an agent runtime's MCP service registry."
+        ),
+    )
+    parser.add_argument(
+        "--transport",
+        choices=("stdio", "streamable-http"),
+        default="stdio",
+        help="MCP transport to serve (default: stdio).",
+    )
+    parser.add_argument(
+        "--host",
+        default="127.0.0.1",
+        help="Bind address for streamable-http (default: 127.0.0.1).",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=8765,
+        help="TCP port for streamable-http (default: 8765).",
+    )
+    return parser.parse_args(argv)
 
 
 if __name__ == "__main__":

--- a/tests/test_streamable_http_transport.py
+++ b/tests/test_streamable_http_transport.py
@@ -2,14 +2,14 @@
 
 Two layers:
 
-1. Unit tests for `_parse_server_args` — defaults, explicit flags, and the
+1. Unit tests for `_parse_server_args`: defaults, explicit flags, and the
    fail-loud exits on unknown transports or flags (a typo'd invocation must
    never silently start a stdio server that an HTTP consumer then waits on).
 2. One end-to-end test that starts the real server as a subprocess on an
    ephemeral port and drives a full session lifecycle (start → annotate → end)
    through the `mcp` Streamable HTTP client, then asserts the session JSON
    landed in the isolated sessions dir. This is the consumer's-eye check for
-   agent runtimes that reach MCP services over HTTP — registry-style consumers
+   agent runtimes that reach MCP services over HTTP: registry-style consumers
    that connect to a running endpoint instead of spawning a stdio process.
 
 Side effects: the E2E test binds a loopback TCP port and spawns one
@@ -53,9 +53,7 @@ class TestParseServerArgs:
         assert args.port == 8765
 
     def test_streamable_http_with_host_and_port(self) -> None:
-        args = _parse_server_args(
-            ["--transport", "streamable-http", "--host", "0.0.0.0", "--port", "9000"]
-        )
+        args = _parse_server_args(["--transport", "streamable-http", "--host", "0.0.0.0", "--port", "9000"])
         assert args.transport == "streamable-http"
         assert args.host == "0.0.0.0"
         assert args.port == 9000
@@ -213,9 +211,7 @@ async def test_streamable_http_full_session_lifecycle(tmp_path: Path) -> None:
                     session.call_tool("trace_end_session", {"session_id": session_id}),
                     timeout=_REQUEST_TIMEOUT,
                 )
-                assert session_id in _result_text(end_result) or "ended" in _result_text(
-                    end_result
-                )
+                assert session_id in _result_text(end_result) or "ended" in _result_text(end_result)
 
         session_files = sorted(sessions_dir.glob("trace_*.json"))
         assert session_files, f"No session file written under {sessions_dir}"

--- a/tests/test_streamable_http_transport.py
+++ b/tests/test_streamable_http_transport.py
@@ -1,0 +1,229 @@
+"""Tests for the streamable-http transport option (`trace-mcp --transport streamable-http`).
+
+Two layers:
+
+1. Unit tests for `_parse_server_args` — defaults, explicit flags, and the
+   fail-loud exits on unknown transports or flags (a typo'd invocation must
+   never silently start a stdio server that an HTTP consumer then waits on).
+2. One end-to-end test that starts the real server as a subprocess on an
+   ephemeral port and drives a full session lifecycle (start → annotate → end)
+   through the `mcp` Streamable HTTP client, then asserts the session JSON
+   landed in the isolated sessions dir. This is the consumer's-eye check for
+   agent runtimes that reach MCP services over HTTP — registry-style consumers
+   that connect to a running endpoint instead of spawning a stdio process.
+
+Side effects: the E2E test binds a loopback TCP port and spawns one
+subprocess; all storage goes to pytest tmp dirs via the TRACE_* env overrides
+(the same isolation contract tests/conftest.py documents).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import re
+import socket
+import sys
+from pathlib import Path
+
+import pytest
+from mcp import ClientSession
+from mcp.client.streamable_http import streamable_http_client
+
+from trace_mcp.server import _parse_server_args
+
+TRACE_ROOT = Path(__file__).parent.parent
+
+# Same split rationale as tests/test_e2e_server.py: subprocess cold start
+# (interpreter boot + imports + extension discovery) dominates, so it gets its
+# own generous, overridable budget; individual requests stay on a short one.
+_STARTUP_TIMEOUT = float(os.environ.get("TRACE_E2E_HANDSHAKE_TIMEOUT", "90"))
+_REQUEST_TIMEOUT = 15.0
+
+
+# ── Unit: argument parsing ───────────────────────────────────────────────────
+
+
+class TestParseServerArgs:
+    def test_defaults_are_stdio(self) -> None:
+        args = _parse_server_args([])
+        assert args.transport == "stdio"
+        assert args.host == "127.0.0.1"
+        assert args.port == 8765
+
+    def test_streamable_http_with_host_and_port(self) -> None:
+        args = _parse_server_args(
+            ["--transport", "streamable-http", "--host", "0.0.0.0", "--port", "9000"]
+        )
+        assert args.transport == "streamable-http"
+        assert args.host == "0.0.0.0"
+        assert args.port == 9000
+
+    def test_unknown_transport_exits_loud(self) -> None:
+        with pytest.raises(SystemExit) as excinfo:
+            _parse_server_args(["--transport", "sse"])
+        assert excinfo.value.code == 2
+
+    def test_unknown_flag_exits_loud(self) -> None:
+        with pytest.raises(SystemExit) as excinfo:
+            _parse_server_args(["--prot", "8080"])
+        assert excinfo.value.code == 2
+
+    def test_non_integer_port_exits_loud(self) -> None:
+        with pytest.raises(SystemExit) as excinfo:
+            _parse_server_args(["--port", "not-a-port"])
+        assert excinfo.value.code == 2
+
+
+# ── E2E: full lifecycle over Streamable HTTP ─────────────────────────────────
+
+
+def _free_port() -> int:
+    """Return an ephemeral loopback port. Side effects: briefly binds it."""
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+async def _stderr_tail(proc: asyncio.subprocess.Process, limit: int = 4000) -> str:
+    """Kill *proc* and return the tail of its stderr (failure paths only)."""
+    if proc.stderr is None:
+        return ""
+    if proc.returncode is None:
+        proc.kill()
+    try:
+        data = await asyncio.wait_for(proc.stderr.read(), timeout=5.0)
+    except (TimeoutError, ProcessLookupError):
+        return ""
+    return data.decode("utf-8", errors="replace").strip()[-limit:]
+
+
+async def _wait_for_port(port: int, proc: asyncio.subprocess.Process) -> None:
+    """Poll until *port* accepts a TCP connection or the server dies.
+
+    Raises with the server's stderr tail on early exit or timeout, so a failed
+    boot is attributable instead of surfacing as a bare TimeoutError.
+    """
+    deadline = asyncio.get_event_loop().time() + _STARTUP_TIMEOUT
+    while True:
+        if proc.returncode is not None:
+            tail = await _stderr_tail(proc)
+            raise ConnectionError(
+                f"Server exited with {proc.returncode} before listening on {port}. "
+                + (f"Stderr:\n{tail}" if tail else "No stderr captured.")
+            )
+        try:
+            _, writer = await asyncio.open_connection("127.0.0.1", port)
+            writer.close()
+            await writer.wait_closed()
+            return
+        except OSError:
+            if asyncio.get_event_loop().time() > deadline:
+                tail = await _stderr_tail(proc)
+                raise TimeoutError(
+                    f"Port {port} not accepting connections within {_STARTUP_TIMEOUT}s. "
+                    + (f"Stderr:\n{tail}" if tail else "No stderr captured.")
+                ) from None
+            await asyncio.sleep(0.2)
+
+
+def _result_text(result: object) -> str:
+    """Concatenate the text parts of an MCP tool-call result."""
+    parts: list[str] = []
+    for block in getattr(result, "content", []):
+        text = getattr(block, "text", None)
+        if isinstance(text, str):
+            parts.append(text)
+    return "\n".join(parts)
+
+
+async def test_streamable_http_full_session_lifecycle(tmp_path: Path) -> None:
+    """Boot `--transport streamable-http`, run start → annotate → end over HTTP,
+    and verify the session JSON (with the annotation) landed on disk."""
+    port = _free_port()
+    sessions_dir = tmp_path / "sessions"
+    env = os.environ.copy()
+    env.update(
+        {
+            "TRACE_SESSIONS_DIR": str(sessions_dir),
+            "TRACE_KNOWLEDGE_DIR": str(tmp_path / "knowledge"),
+            "TRACE_SCRATCHPAD_DIR": str(tmp_path / "scratchpad"),
+            "TRACE_EGRESS_LOG": str(tmp_path / "egress.jsonl"),
+            "TRACE_REGISTRY_PATH": str(tmp_path / "projects.json"),
+            "TRACE_PROJECT": "http-transport-e2e",
+        }
+    )
+    proc = await asyncio.create_subprocess_exec(
+        sys.executable,
+        "-m",
+        "trace_mcp.server",
+        "--transport",
+        "streamable-http",
+        "--port",
+        str(port),
+        cwd=str(TRACE_ROOT),
+        env=env,
+        stdout=asyncio.subprocess.DEVNULL,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    try:
+        await _wait_for_port(port, proc)
+
+        async with streamable_http_client(f"http://127.0.0.1:{port}/mcp") as (
+            read_stream,
+            write_stream,
+            _,
+        ):
+            async with ClientSession(read_stream, write_stream) as session:
+                await asyncio.wait_for(session.initialize(), timeout=_REQUEST_TIMEOUT)
+
+                tools = await asyncio.wait_for(session.list_tools(), timeout=_REQUEST_TIMEOUT)
+                tool_names = {tool.name for tool in tools.tools}
+                assert "trace_start_session" in tool_names
+                assert "trace_log_annotation" in tool_names
+                assert "trace_end_session" in tool_names
+
+                start_result = await asyncio.wait_for(
+                    session.call_tool(
+                        "trace_start_session",
+                        {"description": "streamable-http transport e2e"},
+                    ),
+                    timeout=_REQUEST_TIMEOUT,
+                )
+                start_text = _result_text(start_result)
+                match = re.search(r"Session: (trace_\S+)", start_text)
+                assert match, f"No session id in start result: {start_text!r}"
+                session_id = match.group(1)
+
+                annotate_result = await asyncio.wait_for(
+                    session.call_tool(
+                        "trace_log_annotation",
+                        {
+                            "category": "observation",
+                            "content": "logged over streamable-http",
+                            "session_id": session_id,
+                        },
+                    ),
+                    timeout=_REQUEST_TIMEOUT,
+                )
+                assert "evt_" in _result_text(annotate_result)
+
+                end_result = await asyncio.wait_for(
+                    session.call_tool("trace_end_session", {"session_id": session_id}),
+                    timeout=_REQUEST_TIMEOUT,
+                )
+                assert session_id in _result_text(end_result) or "ended" in _result_text(
+                    end_result
+                )
+
+        session_files = sorted(sessions_dir.glob("trace_*.json"))
+        assert session_files, f"No session file written under {sessions_dir}"
+        payload = json.loads(session_files[-1].read_text())
+        assert payload["id"] == session_id
+        assert payload["status"] == "completed"
+        assert "logged over streamable-http" in session_files[-1].read_text()
+    finally:
+        if proc.returncode is None:
+            proc.kill()
+            await proc.wait()


### PR DESCRIPTION
## Summary

- Add `trace-mcp --transport streamable-http [--host HOST] [--port PORT]`, serving the MCP tool surface at `http://HOST:PORT/mcp`.
- Keep the default invocation unchanged: plain `trace-mcp` still serves stdio.
- Exit non-zero on an unknown flag or transport instead of falling back to stdio.
- Log a warning when the bind address is not loopback, since the tool surface carries no authentication layer.
- Document the transport in the README and CHANGELOG, including the session-pointer caveat below.

## Why

TRACE could only be reached by a client that spawned it as a stdio subprocess. That covers editor-style MCP clients and nothing else. A consumer that connects to an endpoint it did not spawn had no way in: agent runtimes that resolve MCP services from a registry, and any consumer whose lifetime is longer than one editor session, both connect over Streamable HTTP to a host and port they were configured with.

The failure mode this closes is not "no HTTP support" in the abstract. It is that such a runtime registers an endpoint, health-checks it, and gets a connection refused, with no way for an operator to tell whether TRACE is misconfigured or simply cannot speak the transport. FastMCP already implements the server side; what was missing was a way to ask for it.

The fail-loud behavior on a bad flag matters for the same reason. A typo that silently started a stdio server would leave an HTTP consumer waiting on a socket that never opens, which reads as a network problem rather than a usage error.

One limitation is inherent to the current design and is documented rather than worked around: the server keeps a single current-session pointer, so concurrent HTTP clients that do not pass `session_id` explicitly will interleave into one session. The README says so next to the caveat about authentication, and points at the existing "Known limitations" entry on the same underlying constraint.

## Verification

- [x] Lint / format / type check pass: `ruff check src/` clean; `pyright` reports 0 errors on `src/trace_mcp/server.py` and the new test file.
- [x] Tests pass (and new tests added for new behavior): full suite 1439 passed, 12 skipped. New `tests/test_streamable_http_transport.py` adds unit coverage for the argument parsing (defaults, explicit flags, non-zero exits on an unknown transport, unknown flag, and non-integer port) plus an end-to-end test that boots the server as a subprocess on an ephemeral port, drives start, annotate, and end through the `mcp` Streamable HTTP client, and asserts the resulting session JSON lands in an isolated store.
- [x] Built and verified the shipped artifact: `uv build`, `tests/test_packaging_artifacts.py` 11 passed, and the wheel installed into a clean venv exposes the new flags and exits 2 on an invalid transport.
- [ ] Updated the invariant registry/guard: not applicable, no invariant changed. `tests/test_invariants.py` passes unchanged.

## Risks / rollback

Additive. The stdio path is untouched apart from now being the parsed default, so existing `.mcp.json` configurations behave exactly as before. Rolling back is reverting the two commits; nothing persists state or changes the session format.
