### PR TITLE
fix(validate): apply the specification's semantic rules and guard every spec-version restatement

### DIFF
--- a/docs/INVARIANTS.md
+++ b/docs/INVARIANTS.md
@@ -267,8 +267,13 @@ that they equal each other.
 
 **Exhaustive site-set (spec/wire version):**
 - `docs/specification.md` — the `## Specification v<X>` heading
+- `docs/specification.md` — the §3.1 `trace_version` row's `Default: "<X>"`
+- `docs/specification.md` — the Appendix A example's `"trace_version"`
 - `schemas/trace-v<major>.<minor>.json` and its `$id`
 - `src/trace_mcp/schemas/trace-v<major>.<minor>.json` (the packaged copy)
+- `README.md` — the `**Spec:** v<X>` half of the version banner
+- `CLAUDE.md` — the `protocol/schema v<X>` half of the version banner
+- `docs/ONBOARDING.md` — the `protocol/schema \`<X>\`` half of the state line
 
 **Why this is an integrity invariant, not cosmetics.** `server.json` is the MCP
 registry manifest — a stale version there is what an installer *resolves*, not
@@ -282,6 +287,13 @@ enforced in one place but not uniformly.
 for the `__init__.py` site). Each site is read and compared to its source of
 truth; the schema-file check derives the filename from `SCHEMA_VERSION` so a
 wire bump that forgets to rename or regenerate the schema fails.
+
+**Site-set widened 2026-09-03.** The spec/wire set held three sites while five
+more prose restatements went unguarded, so a `SCHEMA_VERSION` bump could ship
+with the front-door docs and the specification's own producer guidance still
+naming the previous wire version. That is the recurring shape this file exists
+to close: an invariant enforced in one place but not uniformly. Verified by
+bumping `SCHEMA_VERSION` and confirming every added site fails.
 
 **Status.** ENFORCED.
 

--- a/src/trace_mcp/validate.py
+++ b/src/trace_mcp/validate.py
@@ -1,4 +1,5 @@
-"""Validate TRACE session JSON files against the packaged JSON Schema.
+"""Validate TRACE session JSON files against the packaged JSON Schema and the
+specification's semantic rules.
 
 This module backs the ``trace-mcp validate`` subcommand. It lives in the
 package (not ``scripts/``) and loads ``schemas/trace-v0.5.json`` as package
@@ -6,6 +7,10 @@ data via importlib.resources, so validation works identically from wheel
 installs, editable installs, and source checkouts. The packaged schema is
 written by ``scripts/generate_schema.py`` and guarded byte-identical to the
 top-level spec artifact ``schemas/trace-v0.5.json``.
+
+Validation is two passes: the schema for structure, then the Pydantic models
+for the cross-field rules of specification §4, which JSON Schema cannot state.
+A document that passes the first and fails the second is reported as FAIL.
 
 Exports: ``load_schema``, ``validate_file``, ``main``.
 
@@ -25,6 +30,10 @@ import sys
 from importlib import resources
 from pathlib import Path
 
+from pydantic import ValidationError
+
+from trace_mcp.schema import Session
+
 _SCHEMA_FILENAME = "trace-v0.5.json"
 
 
@@ -39,7 +48,15 @@ def load_schema() -> dict:
 
 
 def validate_file(path: Path, schema: dict) -> bool:
-    """Validate a single session file against the schema. Returns True if valid.
+    """Validate a session file structurally, then semantically. Returns True if valid.
+
+    Two passes, because neither alone is sufficient. The JSON Schema states the
+    document's shape; the specification's §4 rules are cross-field and cannot be
+    expressed in it (``resolved_by`` is declared optional, and every event-data
+    field is optional, so a decision claiming ``accepted`` with no resolver and
+    an event whose ``type`` contradicts its populated data both satisfy the
+    schema). Loading the document through the models applies those rules, so a
+    producer is told its output conforms only when it actually does.
 
     Side effect: prints one ``  PASS``/``  FAIL`` line to stdout.
     """
@@ -48,10 +65,18 @@ def validate_file(path: Path, schema: dict) -> bool:
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
         jsonschema.validate(data, schema)
+        Session.model_validate(data)
         print(f"  PASS  {path}")
         return True
     except jsonschema.ValidationError as e:
         print(f"  FAIL  {path}: {e.message}")
+        return False
+    except ValidationError as e:
+        # Semantic failure (specification §4). Report the first error with the
+        # field path that carried it, so the producer knows where to look.
+        first = e.errors()[0]
+        location = ".".join(str(part) for part in first["loc"]) or "(document root)"
+        print(f"  FAIL  {path}: {location}: {first['msg']}")
         return False
     except json.JSONDecodeError as e:
         print(f"  FAIL  {path}: Invalid JSON: {e}")

--- a/tests/test_installation_health.py
+++ b/tests/test_installation_health.py
@@ -358,6 +358,51 @@ class TestVersionDeclarationSites:
         schema_id = json.loads(published.read_text()).get("$id", "")
         assert schema_id.endswith(name), f"schemas/{name} has a mismatched $id: {schema_id!r}"
 
+    # ── Spec/wire version restatements (INV-10) ──────────────────────────────
+    #
+    # The three sites above (spec heading, schema filename, schema $id) were the
+    # registered set. Bumping SCHEMA_VERSION also requires editing five prose
+    # restatements that no test covered, so a bump could ship with the docs
+    # stating the previous wire version. These guard the rest of the set.
+
+    @pytest.mark.parametrize(
+        ("doc", "anchor", "template"),
+        [
+            ("README.md", "**Version:**", "**Spec:** v{version}"),
+            ("CLAUDE.md", "> **Version**:", "protocol/schema v{version}"),
+            ("docs/ONBOARDING.md", "**Current state**:", "protocol/schema `{version}`"),
+        ],
+    )
+    def test_docs_state_the_schema_version(self, doc: str, anchor: str, template: str) -> None:
+        """The banner lines restate the wire version beside the package version.
+
+        These lines carry both numbers, and the two are deliberately independent,
+        so a reader trusts each half separately.
+        """
+        expected = _spec_version()
+        matches = [ln for ln in (TRACE_ROOT / doc).read_text().split("\n") if ln.startswith(anchor)]
+
+        assert len(matches) == 1, f"expected exactly one line starting {anchor!r} in {doc}, found {len(matches)}"
+        needle = template.format(version=expected)
+        assert needle in matches[0], f"{doc} does not state {needle!r} for SCHEMA_VERSION: {matches[0]!r}"
+
+    def test_spec_default_trace_version_matches_the_schema_version(self) -> None:
+        """§3.1 tells a producer what to stamp into `trace_version`; stale here
+        means every document written from the spec carries the wrong version."""
+        expected = _spec_version()
+        text = (TRACE_ROOT / "docs" / "specification.md").read_text()
+        needle = f'Default: `"{expected}"`.'
+
+        assert needle in text, f"docs/specification.md §3.1 does not state {needle!r} for SCHEMA_VERSION"
+
+    def test_spec_example_document_states_the_schema_version(self) -> None:
+        """The Appendix A example is the shape people copy."""
+        expected = _spec_version()
+        text = (TRACE_ROOT / "docs" / "specification.md").read_text()
+        needle = f'"trace_version": "{expected}"'
+
+        assert needle in text, f"the Appendix A example does not carry {needle!r}"
+
 
 # ── Consumer Project Tests ───────────────────────────────────────────────────
 

--- a/tests/test_validate_cli.py
+++ b/tests/test_validate_cli.py
@@ -183,3 +183,76 @@ class TestCliMain:
             f"stdout: {result.stdout}\nstderr: {result.stderr}"
         )
         assert "PASS" in result.stdout
+
+
+# ── Semantic validation (specification §4) ───────────────────────────────────
+
+
+class TestSemanticValidation:
+    """`trace-mcp validate` applies the specification's semantic rules, not only
+    the structural JSON Schema.
+
+    The schema cannot express the cross-field rules of specification §4: it
+    declares `resolved_by` optional and every event-data field optional, so a
+    decision claiming `accepted` with no resolver (§4.2) and an event whose
+    `type` does not match its populated data field (§4.1) both satisfy it. Those
+    documents are invalid records, and a validator that passes them tells a
+    producer its output conforms when it does not.
+    """
+
+    @staticmethod
+    def _fixture_doc() -> dict:
+        return json.loads(FIXTURE_SESSION.read_text(encoding="utf-8"))
+
+    def test_accepts_the_unmodified_fixture(self, tmp_path: Path) -> None:
+        """Positive control: the semantic pass must not reject a valid document."""
+        good = tmp_path / "good.json"
+        good.write_text(json.dumps(self._fixture_doc()), encoding="utf-8")
+        assert main([str(good)]) == 0
+
+    def test_rejects_a_resolved_decision_with_no_resolver(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """§4.2: a non-proposed disposition MUST carry a resolved_by actor."""
+        doc = self._fixture_doc()
+        decision = next(e for e in doc["events"] if e["type"] == "decision")
+        decision["decision"]["disposition"] = "accepted"
+        decision["decision"]["resolved_by"] = None
+
+        bad = tmp_path / "unresolved.json"
+        bad.write_text(json.dumps(doc), encoding="utf-8")
+
+        # The schema alone accepts it; only the semantic pass rejects it.
+        jsonschema = pytest.importorskip("jsonschema")
+        jsonschema.validate(json.loads(bad.read_text(encoding="utf-8")), load_schema())
+
+        assert main([str(bad)]) == 1
+        assert "resolved_by" in capsys.readouterr().out
+
+    def test_rejects_an_event_whose_type_does_not_match_its_data(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """§4.1: each event populates exactly the data field its `type` names."""
+        doc = self._fixture_doc()
+        decision = next(e for e in doc["events"] if e["type"] == "decision")
+        decision["decision"] = None
+
+        bad = tmp_path / "mismatched.json"
+        bad.write_text(json.dumps(doc), encoding="utf-8")
+
+        jsonschema = pytest.importorskip("jsonschema")
+        jsonschema.validate(json.loads(bad.read_text(encoding="utf-8")), load_schema())
+
+        assert main([str(bad)]) == 1
+        assert "decision" in capsys.readouterr().out
+
+    def test_a_semantic_failure_does_not_stop_a_multi_file_run(self, tmp_path: Path) -> None:
+        """Mirrors the unreadable-file behaviour: report per file, keep going."""
+        doc = self._fixture_doc()
+        decision = next(e for e in doc["events"] if e["type"] == "decision")
+        decision["decision"]["disposition"] = "accepted"
+        decision["decision"]["resolved_by"] = None
+        bad = tmp_path / "bad.json"
+        bad.write_text(json.dumps(doc), encoding="utf-8")
+
+        assert main([str(bad), str(FIXTURE_SESSION)]) == 1


### PR DESCRIPTION
## Summary

Two independent hardening changes to the conformance surface.

**`trace-mcp validate` applies the specification's semantic rules.** Validation
checked a document against the published JSON Schema and stopped there, so it
reported PASS on records the specification calls invalid. It is now two passes:
the schema for structure, then the Pydantic models for the section 4 cross-field
rules. A semantic failure reports the field path that carried it and, like an
unreadable file, does not stop a multi-file run.

**INV-10 guards every spec-version restatement.** The registry listed three
sites (the specification heading, the schema filename, its `$id`) and left five
prose restatements unchecked. All eight are now enumerated and enforced.

## Why

The schema cannot express section 4: it declares `resolved_by` optional and
every event-data field optional, so a decision claiming `accepted` with no
resolver and an event whose type contradicts its populated data field both
satisfy it. A validator that passes those tells a producer its output conforms
when it does not, which is the failure that matters most for a format meant to
be written by implementations other than this one.

The version sites are the same defect shape the invariant registry exists to
close, an invariant enforced in one place but not uniformly. Unguarded were the
README and CLAUDE.md banners, the onboarding state line, the specification's own
section 3.1 default that tells producers what to stamp into `trace_version`, and
the Appendix A example people copy. A `SCHEMA_VERSION` bump could ship with the
front door and the producer guidance still naming the previous wire version.

## Verification

- `uv run ruff format --check .`, `uv run ruff check .`, `uv run pyright`: clean.
- `uv run pytest -q`: 1468 passed, 12 skipped.
- `uv run pytest tests/test_invariants.py -q`: 15 passed.
- New coverage: `tests/test_validate_cli.py :: TestSemanticValidation` (with a
  positive control, and an assertion that each rejected document passes the
  schema alone) and `tests/test_installation_health.py ::
  TestVersionDeclarationSites`.
- The added version sites were checked by bumping `SCHEMA_VERSION`, confirming
  each new site fails, and reverting.
