### PR TITLE
docs(citation): record the v0.5.1 Zenodo version DOI

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -29,6 +29,9 @@ identifiers:
     value: "10.5281/zenodo.21711455"
     description: "Concept DOI — always resolves to the latest archived version"
   - type: doi
+    value: "10.5281/zenodo.22310719"
+    description: "Version DOI — the v0.5.1 archive specifically"
+  - type: doi
     value: "10.5281/zenodo.21711456"
     description: "Version DOI — the v0.5.0 archive specifically"
 keywords:

--- a/README.md
+++ b/README.md
@@ -474,7 +474,7 @@ Archived on Zenodo. Cite the **concept DOI** unless you need to pin a specific a
 }
 ```
 
-The v0.5.0 archive specifically is [`10.5281/zenodo.21711456`](https://doi.org/10.5281/zenodo.21711456). [`CITATION.cff`](https://github.com/Thru-Echoes/TRACE/blob/main/CITATION.cff) carries both, so GitHub's "Cite this repository" button and any CFF-aware tool stay in sync with this section.
+The v0.5.1 archive specifically is [`10.5281/zenodo.22310719`](https://doi.org/10.5281/zenodo.22310719). [`CITATION.cff`](https://github.com/Thru-Echoes/TRACE/blob/main/CITATION.cff) lists the concept DOI alongside every version DOI, so GitHub's "Cite this repository" button and any CFF-aware tool stay in sync with this section.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

Records the Zenodo version DOI for the v0.5.1 archive, `10.5281/zenodo.22310719`,
at the two sites that name a version-specific DOI:

- `CITATION.cff` — a new `identifiers` entry, listed ahead of the v0.5.0 one.
- `README.md` — the sentence under the BibTeX block, which named the v0.5.0
  archive.

## Why

The release prep deliberately left both naming v0.5.0, because the 0.5.1 archive
did not exist yet and a citation file must never name a DOI that does not
resolve. The archive now exists, so this closes that gap.

The concept DOI (`10.5281/zenodo.21711455`) is unchanged and remains the
recommended citation in the badge and the BibTeX entry — it resolves to the
newest archive on its own, so a citation made with it does not go stale at each
release.

The v0.5.0 identifier is kept rather than replaced. A version DOI is a permanent
handle on one archive, so removing it would break a citation that deliberately
pinned that release.

## Verification

- `CITATION.cff` parses as CFF 1.2.0 with the expected version and three DOI
  identifiers.
- The DOI, its concept DOI, the title, and the version were read back from the
  Zenodo record itself rather than assumed.
- Version-declaration and invariant guards:
  `tests/test_installation_health.py` + `tests/test_invariants.py`, 47 passed.
- `ruff format --check` and `ruff check` clean.
