### PR TITLE
feat(decision): accept a measurement on trace_propose_decision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`trace_propose_decision` accepts a `confidence` measurement.** A decision
+  made on a number computed in the course of the work — a bootstrap, a
+  benchmark, a held-out comparison — can now record that number where a reader
+  can inspect it, rather than only in free-text `rationale` where nothing can
+  read it. Previously the field could enter a record only through an importer,
+  so a measurement made in conversation had no path in except hand-writing a log
+  in one producer's schema. The block is validated through the same
+  `DecisionConfidence` model the importers use, so the two paths cannot be
+  validated differently, and a malformed block (bounds out of order, coverage
+  outside the unit interval, a sample size below one, a non-finite number) is
+  refused rather than stored partially. There is deliberately no such argument
+  on `trace_resolve_decision`: a measurement informs a decision and never
+  resolves it. An imported block carries `contract`, naming the producer schema
+  governing its extra keys, and a block logged in conversation does not — which
+  is what tells a reader where a measurement came from. Nothing verifies the
+  numbers or the evidence digests against any file, which was already true of
+  imported blocks. The tool documentation states the one rule that matters:
+  record only a measurement that was actually computed, because a fabricated one
+  is worse than none once it is typed.
+
 - **`trace-mcp import decision-log <log.jsonl> --project NAME`** builds a TRACE
   session from an evaluation gate's decision log (`rsi-exam-decision-log/v1`).
   One `decision` event per line, carrying the measurement that drove it as

--- a/docs/WHAT-IS-TRACE.md
+++ b/docs/WHAT-IS-TRACE.md
@@ -97,6 +97,12 @@ and interprets neither. Whether an interval was good enough to act on is the
 producer's judgment; TRACE's job is that the judgment and its basis are both
 still there to read.
 
+The same applies when a person is the one deciding. If you ran the comparison
+yourself and the numbers are in front of you, they can be recorded on the
+decision the same way — with one rule: only ever record a number that was
+actually computed. A made-up measurement is worse than none, because writing it
+in this form makes it look authoritative.
+
 ## What you get
 
 **A record you can hand over.** For a colleague, a reviewer, a client, or your

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -399,9 +399,51 @@ estimate, the interval and its coverage, the method, the sample size, and
 the evidence — instead of hunting for it in free-text `rationale`, where
 nothing can read it.
 
-**`confidence` is not written by `trace_propose_decision`.** There is no
-argument for it, deliberately. A measurement comes from a producer that
-computed it, so the write path is an importer:
+There are two ways a measurement gets into a record, and the difference
+between them matters when you read one back.
+
+### Logged in conversation
+
+When the number is in front of you — a bootstrap you just ran, a benchmark
+whose output is on screen — pass it to `trace_propose_decision`:
+
+```python
+trace_propose_decision(
+  session_id=...,
+  description="Keep median imputation over mean for the station readings",
+  rationale="Checked on the 24 stations held out of the imputation.",
+  proposed_by_type="ai", proposed_by_id="claude",
+  suggestion_type="proactive",
+  confidence={
+    "statistic": "mae_reduction",
+    "estimate": 0.42,                # oriented so positive favours this decision
+    "unit": "mm",
+    "direction": "lower",            # the raw metric's sense: lower MAE is better
+    "interval": {"lower": 0.18, "upper": 0.67, "level": 0.95},
+    "method": {"name": "percentile_bootstrap", "resamples": 2000},
+    "sample_size": 24,
+  },
+)
+```
+
+**Pass this only for a number that was actually computed.** Never estimate one,
+round it from memory, or reconstruct it — a fabricated measurement is worse
+than none, because being typed makes it read as authoritative. When no
+measurement exists, omit the field and put the reasoning in `rationale`, which
+is honest prose and reads as such.
+
+A malformed block is refused outright rather than stored partially: bounds out
+of order, a coverage outside the unit interval, a sample size below one, or a
+non-finite estimate all raise instead of writing a half-recorded measurement.
+
+The measurement informs the decision; it never resolves it. There is no
+`confidence` argument on `trace_resolve_decision`, and a decision is never
+accepted *because* a number cleared a threshold — a participant still decides.
+
+### Imported from a producer
+
+When a program made the decision — an evaluation gate running unattended — the
+measurements arrive with the record:
 
 ```bash
 trace-mcp import decision-log decisions.jsonl \
@@ -476,6 +518,13 @@ The block on each event:
   makes no family-wise claim.
 - Evidence digests are the producer's assertion about files it read. TRACE
   records them; it does not verify them.
+
+**Telling the two paths apart.** An imported block carries `contract`, naming
+the producer schema whose rules govern its extra keys. A block logged in
+conversation has no producer, so `contract` is absent — which is how a reader
+distinguishes a measurement that came with a machine's record from one a
+participant entered. Neither is verified by TRACE; the difference is in what
+each one claims about its own origin.
 
 `direction` deserves a note: it records the raw metric's sense (`higher` means
 larger raw values are better), while the producer orients `estimate` so that a

--- a/examples/walkthrough/WALKTHROUGH.md
+++ b/examples/walkthrough/WALKTHROUGH.md
@@ -155,7 +155,66 @@ Look for in the response:
 
 - `Logged annotation:`
 
-## Step 6 — End the session
+## Step 6 — Propose a measured decision (AI)
+
+A decision backed by a number carries that number, in a shape a reader can inspect: the estimate, the interval and its coverage, how it was computed, and how much data it rested on. `direction` is the raw metric's sense — mean absolute error, where lower is better — while the estimate is oriented so a positive value favours what the decision proposes. Pass this ONLY for a measurement that was actually computed; when there is none, omit it and put the reasoning in `rationale`.
+
+```json
+{
+  "tool": "trace_propose_decision",
+  "arguments": {
+    "description": "Keep median imputation over mean for the station readings.",
+    "proposed_by_type": "ai",
+    "proposed_by_id": "claude",
+    "suggestion_type": "proactive",
+    "rationale": "Checked on the 24 stations held out of the imputation.",
+    "confidence": {
+      "statistic": "mae_reduction",
+      "estimate": 0.42,
+      "unit": "mm",
+      "direction": "lower",
+      "interval": {
+        "lower": 0.18,
+        "upper": 0.67,
+        "level": 0.95
+      },
+      "method": {
+        "name": "percentile_bootstrap",
+        "resamples": 2000
+      },
+      "sample_size": 24
+    },
+    "session_id": "$SESSION_ID"
+  }
+}
+```
+
+Look for in the response:
+
+- `Decision proposed: evt_004`
+
+## Step 7 — Resolve the measured decision (human accepts)
+
+The measurement informs the decision; it never resolves it. A human still accepts, and the record keeps both the number and who acted on it.
+
+```json
+{
+  "tool": "trace_resolve_decision",
+  "arguments": {
+    "event_id": "evt_004",
+    "disposition": "accepted",
+    "resolved_by_type": "human",
+    "resolved_by_id": "human",
+    "session_id": "$SESSION_ID"
+  }
+}
+```
+
+Look for in the response:
+
+- `Decision evt_004 resolved: accepted`
+
+## Step 8 — End the session
 
 Ending the session prints the Attribution Audit, and this is where the attribution is read back: the contribution's direction and execution, the decision proposed by the AI and accepted, and the correction linked to `evt_001`. The audit names the session id.
 
@@ -164,7 +223,7 @@ Ending the session prints the Attribution Audit, and this is where the attributi
   "tool": "trace_end_session",
   "arguments": {
     "session_id": "$SESSION_ID",
-    "summary": "Walkthrough complete: one decision proposed, accepted, applied, and corrected.",
+    "summary": "Walkthrough complete: a decision proposed, accepted, applied and corrected, and a second backed by a measurement.",
     "write_scratchpad": false
   }
 }
@@ -177,14 +236,14 @@ Look for in the response:
 - `Contributions (1):`
 - `direction=human, execution=ai`
 - `artifact=data/stations.csv`
-- `Decisions (1):`
+- `Decisions (2):`
 - `proposed_by=ai`
 - `disposition=accepted`
 - `Corrections: 1 (corrects: evt_001)`
 
-## Step 7 — Read the decision back
+## Step 9 — Read the decision back
 
-Query the completed session's decisions. The record kept both halves of the attribution: proposed by the AI, resolved by the human, accepted. That proposer-vs-resolver split is the distinction the whole system exists to preserve.
+Query the completed session's decisions. The record kept both halves of the attribution: proposed by the AI, resolved by the human, accepted. That proposer-vs-resolver split is the distinction the whole system exists to preserve. The second decision also reads back its measurement, interval and coverage intact.
 
 ```json
 {
@@ -200,8 +259,10 @@ Look for in the response:
 - `"proposed_by":{"type":"ai"`
 - `"resolved_by":{"type":"human"`
 - `"disposition":"accepted"`
+- `"statistic":"mae_reduction"`
+- `"level":0.95`
 
-## Step 8 — Add a learning
+## Step 10 — Add a learning
 
 Learnings persist in the project's knowledge store on disk. `project` is omitted and resolves to the pin, the same as the session tools. The response echoes the new learning's id and content.
 
@@ -221,7 +282,7 @@ Look for in the response:
 - `"id": "lrn_`
 - `peregrine falcon telemetry sentinel`
 
-## Step 9 — Extract learnings from the record
+## Step 11 — Extract learnings from the record
 
 Extraction mines the session's decisions and annotations into durable learnings. It already ran when the session ended, so running it again here adds nothing: extraction is idempotent, and this call reports `new_learnings: 0`.
 
@@ -236,7 +297,7 @@ Look for in the response:
 
 - `"new_learnings": 0`
 
-## Step 10 — Recall a learning
+## Step 12 — Recall a learning
 
 Recall ranks the store against a query and reports the backend that ranked it. The sentinel learning comes back with a score; the backend name makes a degraded ranker visible, never silent.
 
@@ -256,7 +317,7 @@ Look for in the response:
 - `"backend"`
 - `peregrine falcon telemetry sentinel`
 
-## Step 11 — A write is denied across projects
+## Step 13 — A write is denied across projects
 
 Under a pin, WRITING to another project fails closed the same way reading does — the error names both the pinned key and the label asked for, and no foreign store is created.
 
@@ -276,7 +337,7 @@ Look for in the response:
 - `walkthrough`
 - `some-other-project`
 
-## Step 12 — A read is denied across projects
+## Step 14 — A read is denied across projects
 
 And reading another project fails closed too. Cross-project reads and writes do not silently cross; a follow-up check confirms no `some-other-project` store was created.
 

--- a/examples/walkthrough/scenario.py
+++ b/examples/walkthrough/scenario.py
@@ -149,11 +149,57 @@ STEPS: tuple[Step, ...] = (
         ),
     ),
     Step(
+        name="Propose a measured decision (AI)",
+        tool="trace_propose_decision",
+        arguments={
+            "description": "Keep median imputation over mean for the station readings.",
+            "proposed_by_type": "ai",
+            "proposed_by_id": "claude",
+            "suggestion_type": "proactive",
+            "rationale": "Checked on the 24 stations held out of the imputation.",
+            "confidence": {
+                "statistic": "mae_reduction",
+                "estimate": 0.42,
+                "unit": "mm",
+                "direction": "lower",
+                "interval": {"lower": 0.18, "upper": 0.67, "level": 0.95},
+                "method": {"name": "percentile_bootstrap", "resamples": 2000},
+                "sample_size": 24,
+            },
+            "session_id": SESSION_ID_PLACEHOLDER,
+        },
+        expect_substrings=("Decision proposed: evt_004",),
+        narration=(
+            "A decision backed by a number carries that number, in a shape a reader can inspect: "
+            "the estimate, the interval and its coverage, how it was computed, and how much data it "
+            "rested on. `direction` is the raw metric's sense — mean absolute error, where lower is "
+            "better — while the estimate is oriented so a positive value favours what the decision "
+            "proposes. Pass this ONLY for a measurement that was actually computed; when there is "
+            "none, omit it and put the reasoning in `rationale`."
+        ),
+    ),
+    Step(
+        name="Resolve the measured decision (human accepts)",
+        tool="trace_resolve_decision",
+        arguments={
+            "event_id": "evt_004",
+            "disposition": "accepted",
+            "resolved_by_type": "human",
+            "resolved_by_id": "human",
+            "session_id": SESSION_ID_PLACEHOLDER,
+        },
+        expect_substrings=("Decision evt_004 resolved: accepted",),
+        narration=(
+            "The measurement informs the decision; it never resolves it. A human still accepts, and "
+            "the record keeps both the number and who acted on it."
+        ),
+    ),
+    Step(
         name="End the session",
         tool="trace_end_session",
         arguments={
             "session_id": SESSION_ID_PLACEHOLDER,
-            "summary": "Walkthrough complete: one decision proposed, accepted, applied, and corrected.",
+            "summary": "Walkthrough complete: a decision proposed, accepted, applied and corrected, and a second backed by a measurement.",
             "write_scratchpad": False,
         },
         expect_substrings=(
@@ -162,7 +208,7 @@ STEPS: tuple[Step, ...] = (
             "Contributions (1):",
             "direction=human, execution=ai",
             "artifact=data/stations.csv",
-            "Decisions (1):",
+            "Decisions (2):",
             "proposed_by=ai",
             "disposition=accepted",
             "Corrections: 1 (corrects: evt_001)",
@@ -182,11 +228,14 @@ STEPS: tuple[Step, ...] = (
             '"proposed_by":{"type":"ai"',
             '"resolved_by":{"type":"human"',
             '"disposition":"accepted"',
+            '"statistic":"mae_reduction"',
+            '"level":0.95',
         ),
         narration=(
             "Query the completed session's decisions. The record kept both halves of the "
             "attribution: proposed by the AI, resolved by the human, accepted. That proposer-"
-            "vs-resolver split is the distinction the whole system exists to preserve."
+            "vs-resolver split is the distinction the whole system exists to preserve. The second "
+            "decision also reads back its measurement, interval and coverage intact."
         ),
     ),
     Step(

--- a/src/trace_mcp/server.py
+++ b/src/trace_mcp/server.py
@@ -660,6 +660,7 @@ async def trace_propose_decision(
     suggestion_type: SuggestionType | None = None,
     tags: list[str] | None = None,
     conversation_snippet: str | None = None,
+    confidence: dict[str, Any] | None = None,
     session_id: str | None = None,
 ) -> str:
     """Propose a methodological decision for the workflow.
@@ -671,6 +672,23 @@ async def trace_propose_decision(
 
     suggestion_type can be 'proactive' (AI volunteered), 'requested' (human asked),
     or 'collaborative' (emerged from discussion).
+
+    confidence records a measurement that motivated the decision, when there was
+    one. Pass it ONLY for a number that was actually computed — from an
+    evaluation run, a benchmark, a statistical test whose output you have in
+    front of you. Never estimate, round from memory, or reconstruct one: a
+    fabricated measurement is worse than none, because it is typed and therefore
+    reads as authoritative. When there is no computed measurement, omit the
+    field and put the reasoning in `rationale`, which is honest prose.
+
+    Shape: `{"statistic": "mean_paired_delta", "estimate": 518.75,
+    "unit": "game_score", "direction": "higher",
+    "interval": {"lower": 467.5, "upper": 575.0, "level": 0.9},
+    "method": {"name": "percentile_bootstrap", "resamples": 5000},
+    "sample_size": 8}`. `direction` is the raw metric's sense; orient
+    `estimate` so a positive value favours the option this decision describes.
+    `evidence` may carry `{role, locator, sha256}` entries for the files
+    measured. Nothing here verifies the numbers or the digests.
 
     session_id is optional — if omitted, uses the current session or
     auto-creates one.
@@ -695,6 +713,7 @@ async def trace_propose_decision(
             suggestion_type=suggestion_type,
             tags=tags,
             conversation_snippet=conversation_snippet,
+            confidence=confidence,
         )
         result = f"{prefix}Decision proposed: {event_id}"
 

--- a/src/trace_mcp/tools/decision_tools.py
+++ b/src/trace_mcp/tools/decision_tools.py
@@ -4,9 +4,16 @@ from __future__ import annotations
 
 import os
 from datetime import UTC, datetime
-from typing import get_args
+from typing import Any, get_args
 
-from trace_mcp.schema import Actor, DecisionData, DecisionDisposition, Session, TraceEvent
+from trace_mcp.schema import (
+    Actor,
+    DecisionConfidence,
+    DecisionData,
+    DecisionDisposition,
+    Session,
+    TraceEvent,
+)
 from trace_mcp.storage.base import TraceStorage
 from trace_mcp.storage.locked import locked_disk_session
 from trace_mcp.tools.session_tools import append_event
@@ -31,8 +38,36 @@ async def propose_decision(
     suggestion_type: str | None = None,
     tags: list[str] | None = None,
     conversation_snippet: str | None = None,
+    confidence: dict[str, Any] | None = None,
 ) -> str:
-    """Propose a methodological decision for the workflow."""
+    """Propose a methodological decision for the workflow.
+
+    *confidence*, when given, is the measurement that motivated the decision
+    (specification 3.6.1): the estimate, its interval and nominal coverage, the
+    method, the sample size, the raw metric's direction, and any digest-bound
+    evidence. It is validated here through ``DecisionConfidence`` — the same
+    model the importers use — so a block written in conversation and one built by
+    an importer cannot be validated two different ways.
+
+    A malformed block raises `ValueError` rather than being stored partially: a
+    measurement that cannot be constructed is not recorded at all, since a
+    half-written one would misstate what was measured.
+
+    The field records what the producer measured. It is not a probability that
+    the decision was correct, and nothing here verifies the numbers or the
+    evidence digests against any file.
+    """
+    measurement: DecisionConfidence | None = None
+    if confidence is not None:
+        try:
+            measurement = DecisionConfidence.model_validate(confidence)
+        except Exception as exc:
+            raise ValueError(
+                f"confidence is not a valid measurement block: {exc}. It requires at least "
+                "statistic, estimate, direction ('higher' or 'lower'), sample_size, "
+                "interval {lower, upper, level}, and method {name}."
+            ) from exc
+
     event = TraceEvent(
         session_id=session.id,
         type="decision",
@@ -45,6 +80,7 @@ async def propose_decision(
             revises_event_id=revises_event_id,
             suggestion_type=suggestion_type,  # type: ignore[arg-type]
             tags=tags or [],
+            confidence=measurement,
         ),
     )
     if conversation_snippet is not None:

--- a/tests/test_confidence_on_propose.py
+++ b/tests/test_confidence_on_propose.py
@@ -1,0 +1,304 @@
+"""`trace_propose_decision` accepts the measurement that motivated a decision.
+
+Before this, `decision.confidence` could only enter a record through an importer,
+so a measurement made in conversation — a bootstrap run in a notebook, a benchmark
+whose numbers are on screen — had no path into TRACE except hand-writing a log in
+one specific producer's schema.
+
+The block is validated through `DecisionConfidence`, the same model the importers
+use, so a measurement logged in conversation and one built by an importer cannot be
+validated two different ways. A malformed block is refused outright rather than
+stored partially: a half-written measurement misstates what was measured.
+
+Nothing here verifies the numbers or the evidence digests against any file. That is
+true of an imported block too; what differs is that an imported one carries
+`contract`, naming whose rules govern it, and a block logged in conversation does
+not — which is what distinguishes the two in a record.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import pytest
+from test_e2e_server import _call_tool, _initialize_server, _shutdown_server, _start_server
+
+from trace_mcp.schema import Session
+from trace_mcp.storage.json_file import JsonFileStorage
+from trace_mcp.tools import decision_tools, session_tools
+
+# A real measurement's shape: the fixture's replication line, which cleared.
+MEASUREMENT: dict[str, Any] = {
+    "statistic": "mean_paired_delta",
+    "estimate": 518.75,
+    "unit": "game_score",
+    "direction": "higher",
+    "interval": {"lower": 467.5, "upper": 575.0, "level": 0.9},
+    "method": {
+        "name": "percentile_bootstrap",
+        "algorithm": "rsi-exam-gate/percentile-bootstrap/1",
+        "resamples": 5000,
+        "seed": 20260902,
+    },
+    "sample_size": 8,
+}
+
+
+@pytest.fixture
+def storage(tmp_path: Path) -> JsonFileStorage:
+    return JsonFileStorage(directory=str(tmp_path))
+
+
+@pytest.fixture
+def active() -> dict[str, Session]:
+    return {}
+
+
+async def _session(storage: JsonFileStorage, active: dict[str, Session]) -> Session:
+    result = await session_tools.start_session(
+        storage, active, project="confidence-test", description="Measured decision test session"
+    )
+    return active[result.split("Session: ")[1].split("\n")[0]]
+
+
+class TestMeasurementIsRecorded:
+    async def test_a_decision_carries_the_measurement(
+        self, storage: JsonFileStorage, active: dict[str, Session]
+    ) -> None:
+        session = await _session(storage, active)
+
+        event_id = await decision_tools.propose_decision(
+            storage,
+            session,
+            description="Adopt the v3 policy",
+            proposed_by_type="ai",
+            proposed_by_id="assistant",
+            confidence=MEASUREMENT,
+        )
+
+        stored = await storage.get_session(session.id)
+        event = next(e for e in stored.events if e.id == event_id)
+        assert event.decision is not None
+        block = event.decision.confidence
+        assert block is not None
+        assert block.estimate == 518.75
+        assert block.interval.lower == 467.5
+        assert block.interval.level == 0.9
+        assert block.method.name == "percentile_bootstrap"
+        assert block.sample_size == 8
+        assert block.direction == "higher"
+
+    async def test_a_decision_without_one_is_unchanged(
+        self, storage: JsonFileStorage, active: dict[str, Session]
+    ) -> None:
+        """The field is optional and its absence must stay the ordinary case."""
+        session = await _session(storage, active)
+
+        event_id = await decision_tools.propose_decision(
+            storage,
+            session,
+            description="Rename the module",
+            proposed_by_type="human",
+            proposed_by_id="user",
+        )
+
+        stored = await storage.get_session(session.id)
+        event = next(e for e in stored.events if e.id == event_id)
+        assert event.decision is not None
+        assert event.decision.confidence is None
+
+    async def test_evidence_entries_are_carried(self, storage: JsonFileStorage, active: dict[str, Session]) -> None:
+        session = await _session(storage, active)
+        digest = "a" * 64
+        measured = {
+            **MEASUREMENT,
+            "evidence": [{"role": "parent", "locator": "results/v1/result.json", "sha256": digest}],
+            "evidence_digests": {"parent": f"sha256:{digest}"},
+        }
+
+        event_id = await decision_tools.propose_decision(
+            storage,
+            session,
+            description="Adopt the v3 policy",
+            proposed_by_type="ai",
+            proposed_by_id="assistant",
+            confidence=measured,
+        )
+
+        stored = await storage.get_session(session.id)
+        event = next(e for e in stored.events if e.id == event_id)
+        assert event.decision is not None and event.decision.confidence is not None
+        evidence = event.decision.confidence.evidence
+        assert evidence is not None and evidence[0].role == "parent"
+        assert evidence[0].sha256 == digest
+
+    async def test_a_conversational_block_carries_no_contract(
+        self, storage: JsonFileStorage, active: dict[str, Session]
+    ) -> None:
+        """What distinguishes a logged measurement from an imported one.
+
+        An importer sets `contract` to the producer schema whose rules govern the
+        block's extra keys. A measurement logged in conversation has no such
+        producer, so the field stays absent — and that absence is the honest
+        signal, without inventing a field to carry it.
+        """
+        session = await _session(storage, active)
+
+        event_id = await decision_tools.propose_decision(
+            storage,
+            session,
+            description="Adopt the v3 policy",
+            proposed_by_type="ai",
+            proposed_by_id="assistant",
+            confidence=MEASUREMENT,
+        )
+
+        stored = await storage.get_session(session.id)
+        event = next(e for e in stored.events if e.id == event_id)
+        assert event.decision is not None and event.decision.confidence is not None
+        assert event.decision.confidence.contract is None
+
+
+class TestMalformedBlocksAreRefused:
+    """A measurement that cannot be constructed is not recorded at all."""
+
+    @pytest.mark.parametrize(
+        ("mutation", "why"),
+        [
+            ({"interval": {"lower": 600.0, "upper": 500.0, "level": 0.9}}, "bounds out of order"),
+            ({"interval": {"lower": 1.0, "upper": 2.0, "level": 1.5}}, "coverage outside the unit interval"),
+            ({"sample_size": 0}, "sample size below one"),
+            ({"direction": "sideways"}, "direction outside the vocabulary"),
+            ({"statistic": ""}, "empty statistic"),
+            ({"estimate": float("inf")}, "non-finite estimate"),
+        ],
+    )
+    async def test_a_malformed_block_raises(
+        self, storage: JsonFileStorage, active: dict[str, Session], mutation: dict[str, Any], why: str
+    ) -> None:
+        session = await _session(storage, active)
+
+        with pytest.raises(ValueError, match="not a valid measurement block"):
+            await decision_tools.propose_decision(
+                storage,
+                session,
+                description=f"Should be refused: {why}",
+                proposed_by_type="ai",
+                proposed_by_id="assistant",
+                confidence={**MEASUREMENT, **mutation},
+            )
+
+    async def test_nothing_is_written_when_the_block_is_refused(
+        self, storage: JsonFileStorage, active: dict[str, Session]
+    ) -> None:
+        """The refusal happens before the event is appended, not after."""
+        session = await _session(storage, active)
+        before = len((await storage.get_session(session.id)).events)
+
+        with pytest.raises(ValueError):
+            await decision_tools.propose_decision(
+                storage,
+                session,
+                description="Adopt the v3 policy",
+                proposed_by_type="ai",
+                proposed_by_id="assistant",
+                confidence={**MEASUREMENT, "sample_size": 0},
+            )
+
+        assert len((await storage.get_session(session.id)).events) == before
+
+
+class TestValidatedTheSameWayAsAnImport:
+    """One model validates both paths, so the two cannot disagree."""
+
+    async def test_an_importer_block_is_accepted_verbatim(
+        self, storage: JsonFileStorage, active: dict[str, Session]
+    ) -> None:
+        fixture = Path(__file__).parent / "fixtures" / "decision_log_v1" / "expected_session_nullfilled.json"
+        imported = json.loads(fixture.read_text(encoding="utf-8"))
+        block = next(e["decision"]["confidence"] for e in imported["events"] if e.get("decision"))
+        session = await _session(storage, active)
+
+        event_id = await decision_tools.propose_decision(
+            storage,
+            session,
+            description="A block an importer produced, logged through the tool",
+            proposed_by_type="ai",
+            proposed_by_id="assistant",
+            confidence=block,
+        )
+
+        stored = await storage.get_session(session.id)
+        event = next(e for e in stored.events if e.id == event_id)
+        assert event.decision is not None and event.decision.confidence is not None
+        # The producer's rule-state extras survive, uninterpreted.
+        dumped = event.decision.confidence.model_dump(mode="json")
+        assert dumped["contract"] == "rsi-exam-decision-log/v1"
+        assert "verdict" in dumped and "min_effect" in dumped
+
+
+class TestOverTheWire:
+    """The argument reaches the tool through a real MCP server."""
+
+    async def test_a_measured_decision_round_trips_over_mcp(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            proc = await _start_server(tmpdir)
+            try:
+                await _initialize_server(proc)
+                started = await _call_tool(
+                    proc,
+                    "trace_start_session",
+                    {"project": "confidence-e2e", "description": "Measured decision over the wire"},
+                    request_id=2,
+                )
+                session_id = json.dumps(started).split("Session: ")[1].split("\\n")[0]
+                proposed = await _call_tool(
+                    proc,
+                    "trace_propose_decision",
+                    {
+                        "description": "Adopt the v3 policy",
+                        "proposed_by_type": "ai",
+                        "proposed_by_id": "assistant",
+                        "confidence": MEASUREMENT,
+                    },
+                    request_id=3,
+                )
+                assert "Decision proposed" in json.dumps(proposed)
+
+                events = await _call_tool(
+                    proc, "trace_get_events", {"session_id": session_id, "type": "decision"}, request_id=4
+                )
+                text = json.dumps(events)
+                assert "mean_paired_delta" in text
+                assert "518.75" in text or "518.8" in text
+            finally:
+                await _shutdown_server(proc)
+
+    async def test_a_malformed_block_is_reported_not_stored(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            proc = await _start_server(tmpdir)
+            try:
+                await _initialize_server(proc)
+                await _call_tool(
+                    proc,
+                    "trace_start_session",
+                    {"project": "confidence-e2e", "description": "Refusal over the wire"},
+                    request_id=2,
+                )
+                result = await _call_tool(
+                    proc,
+                    "trace_propose_decision",
+                    {
+                        "description": "Should be refused",
+                        "proposed_by_type": "ai",
+                        "proposed_by_id": "assistant",
+                        "confidence": {**MEASUREMENT, "sample_size": 0},
+                    },
+                    request_id=3,
+                )
+                assert "not a valid measurement block" in json.dumps(result)
+            finally:
+                await _shutdown_server(proc)


### PR DESCRIPTION
> Follows #70, which is merged; this branch is one commit on top of `main`.

## Summary

Adds an optional `confidence` argument to `trace_propose_decision`, so a
measurement made in the course of the work can be recorded on the decision it
drove.

Until now `decision.confidence` could enter a record **only through an importer**.
Someone who ran a paired bootstrap in a notebook had no path into TRACE except
hand-writing a JSONL file in one specific gate's schema — which left the typed
field available to machine-made decisions and unavailable to the human-and-AI
collaboration the protocol is otherwise about.

- Validated through the same `DecisionConfidence` model the importers use, so the
  two write paths cannot be validated differently.
- A malformed block is refused **before the event is appended**, not stored
  partially — bounds out of order, coverage outside the unit interval, a sample
  size below one, a non-finite number.
- Walkthrough scenario gains a measured decision and its human acceptance, so the
  generated doc, the doc-sync check and the MCP end-to-end run all exercise it.
- `docs/examples.md` Example 10 now shows both write paths; `docs/WHAT-IS-TRACE.md`
  covers the human case alongside the machine one.

## Why this, and a correction

An earlier framing in this project held that the argument's absence was a
deliberate design decision, on the reasoning that ADR 007 describes the first
producer as an evaluation gate whose log is imported. Checking the sources, that
was inference rather than something written down:

- **ADR 007 says nothing about the MCP surface** — no mention of the server, the
  tool, or interactive logging.
- **Specification §3.6.1** says a decision "MAY carry that measurement", with no
  constraint on the writer, and §1 states the specification is technology-agnostic,
  naming MCP servers, IDE plugins, Jupyter extensions, CLI wrappers and manual
  logging tools as equally conforming.
- The decision-confidence roadmap lists the argument under **Deferred**, with an
  acceptance criterion already written: after the library-API PR, validated through
  `DecisionConfidence.model_validate`, one tool test and one e2e.

So it was sequencing, not prohibition. The stated gate — the library-API PR — is
Wave-2 PR C, which is unstarted and sits inside a wave parked until a pilot funds
it, so waiting on it meant waiting indefinitely. The gate's actual purpose was one
shared validation path, and that already exists: the importer validates through
`DecisionConfidence` directly, and so does this.

## The fabrication question

A conversationally written measurement can be fabricated in a way an imported one
cannot. This is the real objection, and it is answered rather than dismissed:

- It is **not new**. `rationale` already accepts "F1=0.78 on our 30-pair validation
  set" with no checking at all, and the examples doc recommends writing exactly
  that. The choice is between legible unverified numbers and prose unverified
  numbers, not between verified and unverified.
- **Typed is more inspectable, not less.** A reader can check recorded digests
  against files; prose gives them nothing to check.
- **The distinguishing signal already exists in the data.** An imported block
  carries `contract`, naming the producer schema governing its extras; a
  conversational block does not. A test pins this. No field was invented.
- **The tool documentation leads with the rule**: record only a number that was
  actually computed; when there is none, omit the field and use `rationale`. A
  fabricated measurement is worse than none precisely because being typed makes it
  read as authoritative.

`trace_resolve_decision` deliberately gets no such argument: a measurement informs
a decision and never resolves one.

## Verification

- Full suite: **1612 passed, 12 skipped**; `ruff format --check`, `ruff check`,
  `pyright src/` clean; invariant guard 15 passed.
- New module, 14 tests: the round trip through storage; evidence entries; the
  absent `contract` on a conversational block; six parametrized malformed-block
  refusals; that nothing is written when one is refused; that an
  importer-produced block is accepted verbatim with its rule-state extras intact;
  and the MCP wire path for both a successful measured decision and a refusal.
- Walkthrough: the scenario's measured decision is appended after the existing
  correction, so every earlier event id is unchanged. The doc-sync test and the
  live MCP stdio run both pass.

## Note

Example 10's previous text asserted the field could not be written by
`trace_propose_decision`. That claim was wrong and is corrected in this PR rather
than left standing.
