### PR TITLE
docs(protocol): tell agents that decision confidence exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **The protocol instructions now tell an agent that decision confidence
+  exists.** The field shipped with no guidance pointing at it: `confidence`
+  occurred nowhere in the `CLAUDE_BLOCK.md` adapter template — the only channel
+  that reaches a consumer project — nor in this project's own instructions, so
+  in practice nothing would ever record a measurement. Both now carry when a
+  measurement is worth recording, the block's shape, that `estimate` is oriented
+  so a positive value favours what the decision proposes, and the rule that
+  decides whether the field is worth having at all: record only a number that
+  was actually computed, never one estimated, rounded from memory, or
+  reconstructed, because a fabricated measurement is worse than none once being
+  typed makes it read as authoritative. Existing consumers pick this up when
+  `trace-mcp-init` runs again against them; a server rebuild does not rewrite a
+  project's `CLAUDE.md`.
+
 - **`trace_propose_decision` accepts a `confidence` measurement.** A decision
   made on a number computed in the course of the work — a bootstrap, a
   benchmark, a held-out comparison — can now record that number where a reader

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,6 +191,20 @@ read as separate projects.
     actor who authored the proposal *content* (whose words populate
     `description`), not the speaker of the resolving directive.
     Question→AI-proposal→accept means `proposed_by=ai`, `resolved_by=human`.
+  - **Measured decisions (v0.5.1, spec §3.6.1)**: when a decision rests on a
+    number you actually computed — a benchmark, an evaluation run, a
+    statistical test whose output is in front of you — record it as
+    `confidence` on `trace_propose_decision`:
+    `{"statistic": "...", "estimate": <n>, "direction": "higher"|"lower",
+    "interval": {"lower": <n>, "upper": <n>, "level": 0.95},
+    "method": {"name": "..."}, "sample_size": <n>}`. `direction` is the raw
+    metric's sense; orient `estimate` so a positive value favours what the
+    decision proposes. **Record only a number that was actually computed.**
+    Never estimate one, round it from memory, or reconstruct it: a fabricated
+    measurement is worse than none, because being typed makes it read as
+    authoritative. With no computed measurement, omit the field and put the
+    reasoning in `rationale`. A measurement informs a decision and never
+    resolves it — there is no such argument on `trace_resolve_decision`.
 - **Corrections** when a participant catches a mistake.
   - If the corrected entity is not a TRACE event (subagent output, tool
     result, external claim), use a URI-form reference per spec §3.7.1:

--- a/src/trace_mcp/adapters/claude_code/assets/CLAUDE_BLOCK.md
+++ b/src/trace_mcp/adapters/claude_code/assets/CLAUDE_BLOCK.md
@@ -46,6 +46,20 @@ of quietly returning keyword-ranked results.
     actor who authored the proposal *content* (whose words populate
     `description`), not the speaker of the resolving directive.
     Question→AI-proposal→accept means `proposed_by=ai`, `resolved_by=human`.
+  - **Measured decisions (v0.5.1, spec §3.6.1)**: when a decision rests on a
+    number you actually computed — a benchmark, an evaluation run, a
+    statistical test whose output is in front of you — record it as
+    `confidence` on `trace_propose_decision`:
+    `{"statistic": "...", "estimate": <n>, "direction": "higher"|"lower",
+    "interval": {"lower": <n>, "upper": <n>, "level": 0.95},
+    "method": {"name": "..."}, "sample_size": <n>}`. `direction` is the raw
+    metric's sense; orient `estimate` so a positive value favours what the
+    decision proposes. **Record only a number that was actually computed.**
+    Never estimate one, round it from memory, or reconstruct it: a fabricated
+    measurement is worse than none, because being typed makes it read as
+    authoritative. With no computed measurement, omit the field and put the
+    reasoning in `rationale`. A measurement informs a decision and never
+    resolves it — there is no such argument on `trace_resolve_decision`.
 - **Corrections** when a participant catches a mistake.
   - If the corrected entity is not a TRACE event (subagent output, tool
     result, external claim), use a URI-form reference per spec §3.7.1:


### PR DESCRIPTION
## Summary

The `confidence` field shipped with no guidance pointing at it. It occurred **nowhere** in the `CLAUDE_BLOCK.md` adapter template — the only channel that reaches a consumer project — nor in this project's own `CLAUDE.md`. An agent following the protocol would never record a measurement, so the field was inert in practice everywhere it was not already known about.

Both documents now cover when a measurement is worth recording, the block's shape, that `direction` is the raw metric's sense while `estimate` is oriented so a positive value favours what the decision proposes, and that a measurement informs a decision but never resolves it.

## Why the emphasis on fabrication

The guidance leads with the rule that decides whether the field is worth having: **record only a number that was actually computed.** Never estimate one, round it from memory, or reconstruct it.

A fabricated measurement is worse than no measurement, because being typed makes it read as authoritative in a way the same claim in prose does not. Where no measurement exists, the instruction is to omit the field and put the reasoning in `rationale`, which is honest prose and reads as such.

## Deployment

Existing consumers pick this up when `trace-mcp-init` runs against them again — a server rebuild does not rewrite a project's `CLAUDE.md`. A fleet pass across the eleven consumers follows this merge.

The machine-wide `~/.claude/CLAUDE.md` carries the same guidance; it lives outside this repository and is not version-controlled here, so it is noted rather than shipped.

## Verification

- Full suite green; adapter, conformance-doctor and installation-health suites (148 passed) cover the template's deployment path.
- `ruff format --check` clean.