### PR TITLE
chore(version): mark main as a development version and report stale builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `trace-mcp-init` runs again against them; a server rebuild does not rewrite a
   project's `CLAUDE.md`.
 
+- **The session-start banner reports a server older than the source it builds
+  from.** A merge is not a deploy: an MCP server keeps the build it started with
+  for the life of the host session, so work merged afterwards is unreachable from
+  it however current the checkout is. This was not hypothetical — every session
+  recorded between 2026-09-03 and 2026-09-06 carried a wire version three days
+  stale, and nothing said so; the version stamp simply read low. The failure is
+  silent in the worst way, because MCP argument models discard unknown fields: a
+  client passing an argument only a newer build knows has it dropped without an
+  error, and the event reads exactly like one where the caller chose not to
+  supply it. The check compares the running build's package and wire versions
+  against the versions declared in the source tree the project's `.mcp.json`
+  launches from, and names both numbers and the remedy. It is advisory and
+  fail-soft by construction: no config, a launch from a git ref or a registry, a
+  moved or unreadable source tree, or a malformed config all produce silence
+  rather than a warning nobody can act on, and it never raises, so a session can
+  never fail to start because the check could not run.
+
 - **`trace_propose_decision` accepts a `confidence` measurement.** A decision
   made on a number computed in the course of the work — a bootstrap, a
   benchmark, a held-out comparison — can now record that number where a reader
@@ -68,6 +85,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the oracle the parity tests compare against: a replay-mode log proving the
   seven gated-mode keys project as explicit nulls, and a gated run under a task
   profile carrying them populated with receipt evidence and a derived suite.
+
+### Changed
+
+- **`main` now declares a development version, and `CITATION.cff` no longer
+  follows it.** Two trees were both calling themselves `0.5.1`: the tag Zenodo
+  archived, and `main` with three further commits. Moving the tag was refused —
+  it would leave the tag and the minted DOI disagreeing about what `v0.5.1`
+  contains — so the package version becomes `0.5.2.dev0` instead, with no
+  release, tag or DOI. `CITATION.cff` stays at the released version, because a
+  citation file must name a version an archive resolves to and a development
+  version has none. INV-10 therefore gains a third source of truth (the newest
+  released section of this changelog) alongside the package and wire versions,
+  and one cross-rule: when the package version differs from the released one it
+  MUST be marked as a pre-release, so a *stable* version can never silently
+  disagree with the release it shares a number with.
 
 ## [0.5.1] — 2026-09-04
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 > **Full documentation**: [README.md](README.md) (architecture, tools, configuration, changelog)
 > **Orientation**: [docs/ONBOARDING.md](docs/ONBOARDING.md) (dev + user onboarding) · [docs/WHAT-IS-TRACE.md](docs/WHAT-IS-TRACE.md) (non-technical explainer)
 > **Formal specification**: [docs/specification.md](docs/specification.md)
-> **Version**: 0.5.1 (package) · protocol/schema v0.5.1
+> **Version**: 0.5.2.dev0 (package, unreleased; latest release 0.5.1) · protocol/schema v0.5.1
 > **TRACE project name**: "trace-mcp" (canonical project key: `trace-mcp`)
 
 ---

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ TRACE runs as a **sidecar** alongside your domain MCP servers. It doesn't proxy 
 
 > **New here?** [docs/ONBOARDING.md](https://github.com/Thru-Echoes/TRACE/blob/main/docs/ONBOARDING.md) is the map for a developer or a user — the mental model, the attribution rules, project identity, hooked-vs-bare projects, and the dev workflow. [docs/WHAT-IS-TRACE.md](https://github.com/Thru-Echoes/TRACE/blob/main/docs/WHAT-IS-TRACE.md) explains the same thing without assuming a technical background.
 
-**Version:** 0.5.1 | **Spec:** v0.5.1 | **Schema:** `https://trace-protocol.org/v0.3` | **License:** Apache 2.0
+**Version:** 0.5.2.dev0 (unreleased; latest release v0.5.1) | **Spec:** v0.5.1 | **Schema:** `https://trace-protocol.org/v0.3` | **License:** Apache 2.0
 
 > The schema URI is an identifier (per W3C PROV convention) and is not currently a resolvable URL. The machine-readable JSON Schema lives at [`schemas/trace-v0.5.json`](https://github.com/Thru-Echoes/TRACE/blob/main/schemas/trace-v0.5.json) in this repository.
 

--- a/docs/INVARIANTS.md
+++ b/docs/INVARIANTS.md
@@ -251,19 +251,30 @@ by delegation).
 
 ## INV-10 — Every restatement of a version agrees with its source of truth  · ENFORCED
 
-**Statement.** The package version has exactly one source of truth
-(`pyproject.toml :: version`) and the spec/wire version exactly one
-(`schema/session.py :: SCHEMA_VERSION`). Every other file that restates either
-number must agree with it. The two are **independent** — a hardening release
-may bump the package while the wire format stands still — so nothing asserts
-that they equal each other.
+**Statement.** Three version numbers each have exactly one source of truth: the
+package version (`pyproject.toml :: version`), the spec/wire version
+(`schema/session.py :: SCHEMA_VERSION`), and the **released** version (the newest
+dated section heading in `CHANGELOG.md`). Every other file that restates one of
+them must agree with *that* one. All three are **independent** — a hardening
+release may bump the package while the wire format stands still, and `main` may
+run ahead of the last release — so nothing asserts that any two are equal.
+
+One cross-rule ties the package and released versions together without equating
+them: when they differ, the package version MUST be marked as a pre-release
+(`X.Y.Z.devN`, `aN`, `bN`, `rcN`). A *stable* package version that differs from
+the last release is the ambiguity this rule exists to prevent — two different
+trees both claiming to be the same release, one of them the archived artifact a
+DOI resolves to.
 
 **Exhaustive site-set (package version):**
 - `src/trace_mcp/__init__.py :: __version__`
 - `server.json :: version` and `server.json :: packages[*].version`
-- `CITATION.cff :: version`
 - `README.md` — the `**Version:**` banner
 - `CLAUDE.md` — the `> **Version**:` banner
+- `docs/ONBOARDING.md` — the `package \`<X>\`` half of the state line
+
+**Exhaustive site-set (released version):**
+- `CITATION.cff :: version`
 
 **Exhaustive site-set (spec/wire version):**
 - `docs/specification.md` — the `## Specification v<X>` heading
@@ -287,6 +298,16 @@ enforced in one place but not uniformly.
 for the `__init__.py` site). Each site is read and compared to its source of
 truth; the schema-file check derives the filename from `SCHEMA_VERSION` so a
 wire bump that forgets to rename or regenerate the schema fails.
+
+**The citation exception, 2026-09-06.** `CITATION.cff` was in the package-version
+set until `main` first carried work past a tag. A citation file must name a
+version that has an archive behind it: pinned to a development package version it
+would have GitHub's "Cite this repository" button and every CFF-aware tool emit a
+version no DOI resolves to. It is therefore pinned to the newest released version
+instead, and the pre-release cross-rule above keeps the package version honest
+about being ahead. This is the same reasoning that already keeps the package and
+wire versions independent — restating one number in a file that means a different
+number is the drift, not the fix.
 
 **Site-set widened 2026-09-03.** The spec/wire set held three sites while five
 more prose restatements went unguarded, so a `SCHEMA_VERSION` bump could ship

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -5,7 +5,7 @@ tool. It assumes no prior context. Read [README.md](../README.md) for the
 reference tables and [docs/specification.md](specification.md) for the
 authoritative data model; this file is the map that makes those readable.
 
-**Current state**: package `0.5.1`, protocol/schema `0.5.1`, 22 MCP tools, 12
+**Current state**: package `0.5.2.dev0` (unreleased; latest release `0.5.1`), protocol/schema `0.5.1`, 22 MCP tools, 12
 registered invariants. Not published to PyPI (see [Distribution](#distribution)).
 
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "trace-mcp"
-version = "0.5.1"
+version = "0.5.2.dev0"
 description = "TRACE: Transparent Recording of AI-assisted Collaboration Experiments — MCP audit protocol for scientific workflows"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.thru-echoes/trace-mcp",
   "description": "TRACE: an MCP server providing a standardized decision-provenance audit trail for AI-assisted research and coding workflows — who proposed what, who accepted or revised it, and why.",
-  "version": "0.5.1",
+  "version": "0.5.2.dev0",
   "websiteUrl": "https://github.com/Thru-Echoes/TRACE",
   "repository": {
     "url": "https://github.com/Thru-Echoes/TRACE",
@@ -13,7 +13,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "trace-mcp",
-      "version": "0.5.1",
+      "version": "0.5.2.dev0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/trace_mcp/__init__.py
+++ b/src/trace_mcp/__init__.py
@@ -1,3 +1,3 @@
 """TRACE: Transparent Recording of AI-assisted Collaboration Experiments."""
 
-__version__ = "0.5.1"
+__version__ = "0.5.2.dev0"

--- a/src/trace_mcp/conformance/staleness.py
+++ b/src/trace_mcp/conformance/staleness.py
@@ -1,0 +1,144 @@
+"""Report when the running server is older than the source it was built from.
+
+A merge is not a deploy. An MCP server keeps the build it started with for the
+life of the host session, so work merged after a server started is unreachable
+from that server no matter how current the checkout is. This was not
+hypothetical: every session recorded between 2026-09-03 and 2026-09-06 was
+stamped with a wire version three days out of date, because the servers writing
+them had been running since before the schema bump landed.
+
+The failure is silent in the worst way. MCP argument models discard unknown
+fields, so a client calling a tool with an argument a newer build added gets it
+dropped without an error — the event is written without it, and the record is
+indistinguishable from one where the caller chose not to supply it. Nothing in
+the record says the build was old; the version stamp just quietly reads low.
+
+This module closes that by comparing the running build's own versions against
+the versions declared in the source tree the project's ``.mcp.json`` launches
+from, and surfacing the difference where a reader will see it: the session-start
+banner.
+
+It is advisory and fail-soft by construction. A project with no config, a config
+that does not build from a local path, an unreadable or moved source tree, or a
+launch that installs from a git ref or a registry all yield no notice rather
+than a warning nobody can act on. It never raises, so a session can never fail
+to start because this check could not run.
+
+Side effects: reads ``<project_dir>/.mcp.json`` and two files under the source
+tree it names. Writes nothing.
+
+Exports:
+    get_stale_build_notice   advisory line for the session-start banner, or None
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+from trace_mcp import __version__
+from trace_mcp.adapters.base import MCP_SERVER_KEY
+from trace_mcp.schema import SCHEMA_VERSION
+
+_PACKAGE_VERSION_RE = re.compile(r"^version\s*=\s*[\"']([^\"']+)[\"']", re.MULTILINE)
+_SCHEMA_VERSION_RE = re.compile(r"^SCHEMA_VERSION\s*=\s*[\"']([^\"']+)[\"']", re.MULTILINE)
+
+
+def _source_dir_from_config(project_dir: Path) -> Path | None:
+    """The local directory this project's TRACE server builds from, if any.
+
+    Returns None when there is no config, no trace server entry, no ``--from``
+    argument, or the value is not an existing local directory — a git ref or a
+    registry name is a legitimate configuration this check simply cannot compare.
+    """
+    config_path = project_dir / ".mcp.json"
+    if not config_path.is_file():
+        return None
+    try:
+        config = json.loads(config_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(config, dict):
+        return None
+
+    entry = (config.get("mcpServers") or {}).get(MCP_SERVER_KEY)
+    if not isinstance(entry, dict):
+        return None
+    args = entry.get("args")
+    if not isinstance(args, list) or "--from" not in args:
+        return None
+
+    index = args.index("--from")
+    if index + 1 >= len(args):
+        return None
+    candidate = args[index + 1]
+    if not isinstance(candidate, str) or candidate.startswith("git+"):
+        return None
+
+    try:
+        source = Path(candidate).expanduser()
+        return source if source.is_dir() else None
+    except (OSError, ValueError):
+        return None
+
+
+def _declared_versions(source_dir: Path) -> tuple[str | None, str | None]:
+    """The package and wire versions the source tree declares, by reading files.
+
+    Read with regexes rather than by importing: importing a second copy of the
+    package into a running server is exactly the kind of side effect a check
+    that runs on every session start must not have.
+    """
+    package = schema = None
+    try:
+        text = (source_dir / "pyproject.toml").read_text(encoding="utf-8")
+        match = _PACKAGE_VERSION_RE.search(text)
+        package = match.group(1) if match else None
+    except OSError:
+        pass
+    try:
+        text = (source_dir / "src" / "trace_mcp" / "schema" / "session.py").read_text(encoding="utf-8")
+        match = _SCHEMA_VERSION_RE.search(text)
+        schema = match.group(1) if match else None
+    except OSError:
+        pass
+    return package, schema
+
+
+def get_stale_build_notice(project_dir: Path | None = None) -> str | None:
+    """Advisory line naming a running build older than its source, or None.
+
+    Inputs: *project_dir*, the directory holding the project's ``.mcp.json``
+    (default: the process working directory, which is where a host launches the
+    server).
+
+    Output: a one-or-two-line notice naming both versions and the remedy, or
+    None when the versions agree or the comparison cannot be made.
+
+    Side effects: reads the config and two source files. Never raises — any
+    failure yields None, because a session must never fail to start over an
+    advisory check.
+    """
+    try:
+        source_dir = _source_dir_from_config(project_dir or Path.cwd())
+        if source_dir is None:
+            return None
+
+        declared_package, declared_schema = _declared_versions(source_dir)
+        drift: list[str] = []
+        if declared_package and declared_package != __version__:
+            drift.append(f"package {__version__} running vs {declared_package} in source")
+        if declared_schema and declared_schema != SCHEMA_VERSION:
+            drift.append(f"wire {SCHEMA_VERSION} running vs {declared_schema} in source")
+        if not drift:
+            return None
+
+        return (
+            f"⚠️  This server is running an older build than its source: {'; '.join(drift)}. "
+            "A merge is not a deploy — an MCP server keeps the build it started with, and a tool "
+            "argument this build does not know is dropped silently rather than reported. "
+            "Restart the host session to pick up the current build."
+        )
+    except Exception:  # noqa: BLE001 — advisory only; never block a session start
+        return None

--- a/src/trace_mcp/tools/session_tools.py
+++ b/src/trace_mcp/tools/session_tools.py
@@ -498,6 +498,14 @@ def format_bootstrap_message(
     else:
         orientation = f"Prior context: No prior TRACE sessions recorded for '{project}'."
 
+    # Advisory, fail-soft: a server keeps the build it started with, so work
+    # merged after it started is unreachable from it and an argument this build
+    # does not know is dropped silently. Surfaced here because session start is
+    # the one moment a reader is looking at the server rather than through it.
+    from trace_mcp.conformance.staleness import get_stale_build_notice
+
+    stale_notice = get_stale_build_notice()
+
     lines = [
         "TRACE audit logging is now active.",
         f"Session: {session_id}",
@@ -506,6 +514,8 @@ def format_bootstrap_message(
         orientation,
         _BOOTSTRAP_CADENCE,
     ]
+    if stale_notice:
+        lines.insert(1, stale_notice)
     msg = "\n".join(lines)
     if recalled_block:
         msg += recalled_block
@@ -580,10 +590,18 @@ async def start_session(
     # Core-level, fail-safe probe of the OPTIONAL trace-learn extension
     # (keeps the core/extension boundary intact — see
     # docs/adr/003-core-extension-boundary.md).
+    # Same advisory as the bootstrap banner: this is the other entry point a
+    # caller sees a session start through, and a stale build is equally invisible
+    # from here.
+    from trace_mcp.conformance.staleness import get_stale_build_notice
     from trace_mcp.extension_status import get_extension_status
+
+    stale_notice = get_stale_build_notice()
+    stale_line = f"{stale_notice}\n" if stale_notice else ""
 
     return (
         f"TRACE audit logging is now active.\n"
+        f"{stale_line}"
         f"Session: {session.id}\n"
         f"Project: {project}\n"
         f"File: {path}\n"

--- a/tests/test_build_staleness.py
+++ b/tests/test_build_staleness.py
@@ -1,0 +1,195 @@
+"""The session-start notice for a server older than the source it builds from.
+
+A merge is not a deploy: an MCP server keeps the build it started with for the
+life of the host session. Every session recorded between 2026-09-03 and
+2026-09-06 carried a wire version three days stale for exactly this reason, and
+nothing said so — the version stamp simply read low.
+
+What makes it worth a check rather than a docs note is the silence. MCP argument
+models discard unknown fields, so calling a tool with an argument only a newer
+build knows drops it without an error: the event is written without it and reads
+exactly like one where the caller chose not to supply it.
+
+These tests pin both halves: that a real drift is reported with both numbers and
+a remedy, and — the half that decides whether anyone keeps the check — that every
+configuration it cannot evaluate stays silent instead of crying wolf.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from trace_mcp import __version__
+from trace_mcp.conformance.staleness import get_stale_build_notice
+from trace_mcp.schema import SCHEMA_VERSION
+
+
+def _write_source(root: Path, *, package: str, schema: str) -> Path:
+    """A minimal source tree carrying the two version declarations."""
+    source = root / "source"
+    (source / "src" / "trace_mcp" / "schema").mkdir(parents=True, exist_ok=True)
+    (source / "pyproject.toml").write_text(f'[project]\nname = "trace-mcp"\nversion = "{package}"\n', encoding="utf-8")
+    (source / "src" / "trace_mcp" / "schema" / "session.py").write_text(
+        f'SCHEMA_VERSION = "{schema}"\n', encoding="utf-8"
+    )
+    return source
+
+
+def _write_config(project: Path, args: list[str], *, server_key: str = "trace") -> None:
+    project.mkdir(parents=True, exist_ok=True)
+    (project / ".mcp.json").write_text(
+        json.dumps({"mcpServers": {server_key: {"command": "uvx", "args": args}}}), encoding="utf-8"
+    )
+
+
+def _launch_args(source: Path) -> list[str]:
+    return ["--from", str(source), "--refresh-package", "trace-mcp", "trace-mcp"]
+
+
+class TestDriftIsReported:
+    def test_a_stale_wire_version_is_named(self, tmp_path: Path) -> None:
+        source = _write_source(tmp_path, package=__version__, schema="9.9.9")
+        project = tmp_path / "project"
+        _write_config(project, _launch_args(source))
+
+        notice = get_stale_build_notice(project)
+
+        assert notice is not None
+        assert SCHEMA_VERSION in notice and "9.9.9" in notice
+        assert "Restart" in notice
+
+    def test_a_stale_package_version_is_named(self, tmp_path: Path) -> None:
+        source = _write_source(tmp_path, package="9.9.9", schema=SCHEMA_VERSION)
+        project = tmp_path / "project"
+        _write_config(project, _launch_args(source))
+
+        notice = get_stale_build_notice(project)
+
+        assert notice is not None
+        assert __version__ in notice and "9.9.9" in notice
+
+    def test_both_drifts_are_reported_together(self, tmp_path: Path) -> None:
+        source = _write_source(tmp_path, package="9.9.9", schema="8.8.8")
+        project = tmp_path / "project"
+        _write_config(project, _launch_args(source))
+
+        notice = get_stale_build_notice(project)
+
+        assert notice is not None
+        assert "9.9.9" in notice and "8.8.8" in notice
+
+    def test_the_notice_explains_the_silent_failure(self, tmp_path: Path) -> None:
+        """A reader must learn *why* it matters, not only that it happened."""
+        source = _write_source(tmp_path, package=__version__, schema="9.9.9")
+        project = tmp_path / "project"
+        _write_config(project, _launch_args(source))
+
+        notice = get_stale_build_notice(project)
+
+        assert notice is not None
+        assert "dropped silently" in notice
+
+
+class TestSilenceWhenItCannotJudge:
+    """A check that cries wolf gets ignored, so every unevaluable case is quiet."""
+
+    def test_matching_versions_produce_no_notice(self, tmp_path: Path) -> None:
+        source = _write_source(tmp_path, package=__version__, schema=SCHEMA_VERSION)
+        project = tmp_path / "project"
+        _write_config(project, _launch_args(source))
+
+        assert get_stale_build_notice(project) is None
+
+    def test_no_config_at_all(self, tmp_path: Path) -> None:
+        assert get_stale_build_notice(tmp_path) is None
+
+    def test_config_without_a_trace_server(self, tmp_path: Path) -> None:
+        source = _write_source(tmp_path, package="9.9.9", schema="8.8.8")
+        project = tmp_path / "project"
+        _write_config(project, _launch_args(source), server_key="something-else")
+
+        assert get_stale_build_notice(project) is None
+
+    def test_unparseable_config(self, tmp_path: Path) -> None:
+        project = tmp_path / "project"
+        project.mkdir()
+        (project / ".mcp.json").write_text("{not json", encoding="utf-8")
+
+        assert get_stale_build_notice(project) is None
+
+    def test_a_git_ref_source_is_not_compared(self, tmp_path: Path) -> None:
+        """Installing from a git ref is legitimate and has no local tree to read."""
+        project = tmp_path / "project"
+        _write_config(project, ["--from", "git+https://github.com/Thru-Echoes/TRACE@v0.5.1", "trace-mcp"])
+
+        assert get_stale_build_notice(project) is None
+
+    def test_a_source_path_that_does_not_exist(self, tmp_path: Path) -> None:
+        project = tmp_path / "project"
+        _write_config(project, _launch_args(tmp_path / "moved-away"))
+
+        assert get_stale_build_notice(project) is None
+
+    def test_no_from_argument(self, tmp_path: Path) -> None:
+        project = tmp_path / "project"
+        _write_config(project, ["trace-mcp"])
+
+        assert get_stale_build_notice(project) is None
+
+    def test_a_from_argument_with_nothing_after_it(self, tmp_path: Path) -> None:
+        project = tmp_path / "project"
+        _write_config(project, ["trace-mcp", "--from"])
+
+        assert get_stale_build_notice(project) is None
+
+    def test_a_source_tree_missing_its_version_files(self, tmp_path: Path) -> None:
+        source = tmp_path / "empty-source"
+        source.mkdir()
+        project = tmp_path / "project"
+        _write_config(project, _launch_args(source))
+
+        assert get_stale_build_notice(project) is None
+
+    @pytest.mark.parametrize("shape", ['{"mcpServers": []}', '{"mcpServers": {"trace": "nope"}}', "[]"])
+    def test_malformed_config_shapes(self, tmp_path: Path, shape: str) -> None:
+        project = tmp_path / "project"
+        project.mkdir()
+        (project / ".mcp.json").write_text(shape, encoding="utf-8")
+
+        assert get_stale_build_notice(project) is None
+
+
+class TestItNeverRaises:
+    def test_an_unreadable_project_directory_is_survivable(self, tmp_path: Path) -> None:
+        """A session must never fail to start because an advisory check could not run."""
+        assert get_stale_build_notice(tmp_path / "does-not-exist") is None
+
+    def test_the_real_checkout_reports_nothing(self) -> None:
+        """Positive control against this repository: no false alarm in-tree."""
+        assert get_stale_build_notice(Path(__file__).resolve().parent.parent) is None
+
+
+class TestItReachesTheBanner:
+    async def test_the_notice_appears_in_the_session_start_banner(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from trace_mcp.schema import Session
+        from trace_mcp.storage.json_file import JsonFileStorage
+        from trace_mcp.tools import session_tools
+
+        source = _write_source(tmp_path, package=__version__, schema="9.9.9")
+        project = tmp_path / "project"
+        _write_config(project, _launch_args(source))
+        monkeypatch.chdir(project)
+
+        storage = JsonFileStorage(directory=str(tmp_path / "store"))
+        active: dict[str, Session] = {}
+        banner = await session_tools.start_session(
+            storage, active, project="staleness-test", description="banner check"
+        )
+
+        assert "older build than its source" in banner
+        assert "TRACE audit logging is now active." in banner

--- a/tests/test_installation_health.py
+++ b/tests/test_installation_health.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import shutil
 import subprocess
 from pathlib import Path
@@ -266,6 +267,23 @@ class TestPyprojectConsistency:
 # failure by loosening the assertion.
 
 
+def _latest_released_version() -> str:
+    """The newest version this repository has actually released.
+
+    Read from the newest dated section heading in CHANGELOG.md, skipping
+    ``[Unreleased]``. This is a *different* source of truth from the package
+    version: once `main` carries work beyond the last tag, the two legitimately
+    differ, and a citation must name the released one.
+
+    Pure. Fails the calling test if no released section can be located.
+    """
+    for line in (TRACE_ROOT / "CHANGELOG.md").read_text().split("\n"):
+        match = re.match(r"^## \[(\d+\.\d+\.\d+)\]", line)
+        if match:
+            return match.group(1)
+    pytest.fail("Could not find a released section heading in CHANGELOG.md")
+
+
 def _package_version() -> str:
     """Read the canonical package version out of pyproject.toml.
 
@@ -307,14 +325,39 @@ class TestVersionDeclarationSites:
         stale = {site: got for site, got in declared if got != expected}
         assert not stale, f"server.json versions disagree with pyproject.toml ({expected}): {stale}"
 
-    def test_citation_cff_declares_the_package_version(self) -> None:
-        """CITATION.cff is what a DOI archive and citation tooling read."""
-        expected = _package_version()
+    def test_citation_cff_declares_the_latest_released_version(self) -> None:
+        """CITATION.cff must name a version that has an archive behind it.
+
+        It is pinned to the newest *released* version, not to the package
+        version. Once `main` carries work past the last tag its package version
+        is a development version, and a citation file naming one would have
+        citation tooling emit a version no archive resolves to.
+        """
+        expected = _latest_released_version()
         lines = [ln for ln in (TRACE_ROOT / "CITATION.cff").read_text().split("\n") if ln.startswith("version:")]
 
         assert len(lines) == 1, f"expected exactly one top-level `version:` line in CITATION.cff, found {len(lines)}"
         assert lines[0].split(":", 1)[1].strip().strip("\"'") == expected, (
-            f"CITATION.cff version != pyproject.toml version ({expected}): {lines[0]!r}"
+            f"CITATION.cff version != the newest released version in CHANGELOG.md ({expected}): {lines[0]!r}"
+        )
+
+    def test_a_package_version_ahead_of_the_release_is_marked_as_such(self) -> None:
+        """`main` may run ahead of the last release, but never silently.
+
+        Either the package version equals the newest released version, or it is
+        a pre-release/development version. A *stable* package version that
+        differs from the last release is the ambiguity this rule exists to
+        prevent: two different trees both claiming to be the same release, one
+        of which is the archived artifact a DOI resolves to.
+        """
+        package, released = _package_version(), _latest_released_version()
+        if package == released:
+            return
+
+        assert re.match(r"^\d+\.\d+\.\d+(a|b|rc|\.dev)\d+$", package), (
+            f"pyproject version {package!r} differs from the newest released version {released!r} "
+            "but is not marked as a pre-release. Either release it, or mark it (e.g. "
+            f"{released.rsplit('.', 1)[0]}.{int(released.rsplit('.', 1)[1]) + 1}.dev0)."
         )
 
     @pytest.mark.parametrize(

--- a/uv.lock
+++ b/uv.lock
@@ -2145,7 +2145,7 @@ wheels = [
 
 [[package]]
 name = "trace-mcp"
-version = "0.5.1"
+version = "0.5.2.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "mcp" },


### PR DESCRIPTION
> Independent of #72; both touch `CLAUDE.md` but in different sections.

## Summary

Two changes that came out of the same question — *which build is this?*

**1. `main` stops claiming to be the released 0.5.1.** Two trees were both calling themselves `0.5.1`: the tag Zenodo archived behind DOI `10.5281/zenodo.22310719`, and `main` with three further commits. The package version becomes `0.5.2.dev0` — no release, no tag, no DOI churn.

**2. The session-start banner reports a server older than its source.** A merge is not a deploy.

## Why not just move the tag

Retagging `v0.5.1` onto current `main` would not change the Zenodo archive; it would leave the tag and the minted DOI disagreeing about what `v0.5.1` contains. Minting a version mismatch is a poor thing for a provenance tool to do to itself.

## Why CITATION.cff does not follow the bump

A citation file must name a version an archive resolves to, and a development version has none — pinned to `0.5.2.dev0` it would have GitHub's "Cite this repository" button and every CFF-aware tool emit a version no DOI answers.

So INV-10 now recognises a **third** source of truth — the newest released section of `CHANGELOG.md` — alongside the package and wire versions, plus one cross-rule: **when the package version differs from the released one it must be marked as a pre-release.** A bare `0.5.2` on `main` now fails the guard, which is the ambiguity being closed. Registry entry updated in `docs/INVARIANTS.md`.

## The staleness defect this exposed

Not hypothetical. `SCHEMA_VERSION` went to 0.5.1 when #66 merged on **2026-09-03T22:48**, and every session written since — through 2026-09-06 — is stamped `trace_version: 0.5.0`. The servers writing them started before the merge. A freshly spawned server with the identical consumer command reports 0.5.1 and 22 tools, so packaging is fine; what never happens is a refresh of a server already running.

The failure is silent in the worst way: **MCP argument models discard unknown fields.** A client passing `confidence` to an older server has it dropped with no error, and the decision is written without it — indistinguishable from choosing not to record one. Same shape as the `trace_learn_recall` `query` defect.

This also explains why `fleet-check --live` reported every consumer healthy: it spawns new processes, so it measures what a restart *would* serve, not what is running.

## Design of the check

Compares the running build's package and wire versions against those declared in the source tree the project's `.mcp.json` launches from, and names both numbers plus the remedy.

**Advisory and fail-soft throughout**, which is the half that decides whether anyone keeps it: no config, a launch from a git ref or registry, a moved or unreadable source tree, and every malformed config shape produce silence rather than a warning nobody can act on. It never raises — a session must not fail to start because an advisory check could not run. Versions are read with regexes rather than by importing, since importing a second copy of the package into a running server is exactly the side effect a per-session-start check must not have.

## Verification

- Full suite **1632 passed, 12 skipped**; `ruff format --check`, `ruff check`, `pyright src/` clean; invariant guard 48 passed.
- 19 new cases: both drifts reported together, the remedy and the *reason* present in the text, ten unevaluable configurations staying silent, a positive control against this repository, and the notice reaching both session-start entry points.
- The new INV-10 cross-rule was checked against `0.5.1`, `0.5.2`, `0.5.2.dev0` and `0.6.0rc1` — a bare `0.5.2` fails, as intended.