### PR TITLE
fix(adapter): refresh an installed instruction block instead of skipping it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`trace-mcp-init` refreshes an installed instruction block instead of
+  skipping it forever.** The Claude Code adapter returned `skipped` the moment
+  it saw the opening marker in a project's `CLAUDE.md`, so every edit to the
+  template reached only projects that did not yet carry a block — which, in a
+  deployed fleet, is none of them. Measured across ten real consumer projects, a
+  protocol change reached zero of them, in two distinct block vintages, while
+  `trace-mcp doctor` reported all ten clean. The block now carries a stamp
+  derived from the shipped template's bytes, so any edit changes it, and the
+  installer replaces the marked region in place when the stamp differs. Only
+  that region is touched: a consumer's own instructions live in the same file
+  (157 lines of them in one real project) and are preserved on both sides, with
+  repeated runs leaving the file byte-identical. An opening marker with no
+  closing one is left untouched rather than guessed at, since guessing the
+  block's extent could delete a project's own text. A new `docs.block_stamp`
+  check reports a stale, unstamped, absent or unterminated block, so this cannot
+  go silently stale again — the same treatment the hook scripts already had
+  through their version stamp and `hooks.stamp` check. Registered under INV-11.
+
 ### Added
 
 - **The protocol instructions now tell an agent that decision confidence

--- a/docs/INVARIANTS.md
+++ b/docs/INVARIANTS.md
@@ -301,6 +301,16 @@ bumping `SCHEMA_VERSION` and confirming every added site fails.
 
 ## INV-11 — A freshly initialized project is conformance-clean  · ENFORCED
 
+**Extended 2026-09-06 to the instruction block.** The block installed into a
+consumer's `CLAUDE.md` now carries a stamp derived from the shipped template's
+bytes, the installer refreshes the marked region in place when that stamp
+differs, and `docs.block_stamp` reports a block that is not this build's. Before
+this, an installed block was never refreshed: a template edit reached only
+projects that did not yet have one, so the guidance went stale across the whole
+fleet while every check reported those projects clean. The stamp is a content
+digest rather than a hand-maintained number so that any edit changes it, closing
+the same gap the hook scripts' `[trace-hooks vX.Y]` stamp closes for them.
+
 **Statement.** For every host adapter TRACE actually installs, running
 `trace-mcp-init` on an empty directory must produce a deployment that
 `trace_mcp.conformance.run_doctor` reports as `ok` — no failing check — using

--- a/src/trace_mcp/adapters/claude_code/__init__.py
+++ b/src/trace_mcp/adapters/claude_code/__init__.py
@@ -7,7 +7,9 @@ hook scripts under ``.claude/hooks/``, hook registrations merged into
 
 from __future__ import annotations
 
+import hashlib
 import json
+import re
 import shutil
 from pathlib import Path
 
@@ -20,6 +22,41 @@ _CLAUDE_BLOCK_SRC = _ASSETS / "CLAUDE_BLOCK.md"
 
 MARKER_START = "<!-- trace-mcp:claude-code -->"
 MARKER_END = "<!-- /trace-mcp:claude-code -->"
+
+# The opening marker is matched by PREFIX, not by the literal above, because an
+# installed block may carry a stamp the literal does not have — and blocks
+# installed before stamping existed carry none at all. Both must be recognised,
+# or the installer would append a second block beside the first.
+MARKER_START_RE = re.compile(r"<!-- trace-mcp:claude-code(?:\s+block=([0-9a-f]+))?\s*-->")
+
+
+def get_block_stamp() -> str:
+    """The short digest identifying the instruction block this build ships.
+
+    Derived from the asset's own bytes, so *any* edit to the block changes the
+    stamp. A hand-maintained version number would only change when someone
+    remembered to change it, which is the failure this replaces: the block was
+    installed once and never refreshed again, and nothing could tell.
+    """
+    return hashlib.sha256(_CLAUDE_BLOCK_SRC.read_bytes()).hexdigest()[:12]
+
+
+def render_claude_block() -> str:
+    """The block as it should appear in a project, with its stamp in the marker."""
+    stamp = get_block_stamp()
+    return _CLAUDE_BLOCK_SRC.read_text().replace(MARKER_START, f"<!-- trace-mcp:claude-code block={stamp} -->", 1)
+
+
+def read_installed_block_stamp(text: str) -> str | None:
+    """The stamp on an installed block, or None if absent or unstamped.
+
+    Returning None for both cases is deliberate: a block predating stamping and
+    a project with no block at all are equally not-this-build, and the caller
+    distinguishes them by whether a marker was found.
+    """
+    match = MARKER_START_RE.search(text)
+    return match.group(1) if match else None
+
 
 HOOK_ASSETS_DIR = _HOOKS_SRC
 """The shipped hook scripts — the single source for which hooks a correct
@@ -74,7 +111,10 @@ class ClaudeCodeAdapter(Adapter):
         claude_md = directory / "CLAUDE.md"
         if not claude_md.is_file():
             errors.append(f"missing {claude_md}")
-        elif MARKER_START not in claude_md.read_text():
+        elif MARKER_START_RE.search(claude_md.read_text()) is None:
+            # Matched by pattern, not by the bare literal: an installed block
+            # carries a stamp in its opening marker, and a block predating
+            # stamping carries none. Both are present blocks.
             errors.append(f"{claude_md} missing TRACE marker {MARKER_START}")
 
         return errors
@@ -200,13 +240,39 @@ def _merge_settings(directory: Path, *, dry_run: bool) -> InstallResult:
 
 
 def _append_claude_block(directory: Path, *, dry_run: bool) -> InstallResult:
+    """Install the TRACE block, or refresh it in place when it is out of date.
+
+    An installed block used to be left alone forever, so every edit to the
+    template reached only projects that did not yet have one — the block went
+    stale everywhere and nothing reported it. The marked region is now replaced
+    when its stamp differs from this build's.
+
+    Only the marked region is touched. Everything a project wrote around it is
+    preserved, which is the whole reason the markers exist: a consumer's own
+    instructions live in the same file and are not ours to rewrite.
+    """
     dst = directory / "CLAUDE.md"
-    block = _CLAUDE_BLOCK_SRC.read_text()
+    block = render_claude_block()
 
     if dst.is_file():
         existing = dst.read_text()
-        if MARKER_START in existing:
-            return InstallResult(path=dst, disposition="skipped")
+        match = MARKER_START_RE.search(existing)
+        if match is not None:
+            if match.group(1) == get_block_stamp():
+                return InstallResult(path=dst, disposition="skipped")
+            end = existing.find(MARKER_END, match.end())
+            if end == -1:
+                # An opening marker with no closing one: the block's extent is
+                # unknowable, and guessing it risks eating a project's own text.
+                # Left untouched; `trace-mcp doctor` reports it.
+                return InstallResult(path=dst, disposition="skipped")
+            if not dry_run:
+                # `end` points just past the closing marker, so the replacement
+                # must not carry the asset's own trailing newline: the text that
+                # followed the old block already supplies it. Without this a
+                # blank line accumulates on every refresh.
+                dst.write_text(existing[: match.start()] + block.rstrip("\n") + existing[end + len(MARKER_END) :])
+            return InstallResult(path=dst, disposition="updated")
         if not dry_run:
             sep = "\n" if existing.endswith("\n") else "\n\n"
             dst.write_text(existing + sep + block)
@@ -217,4 +283,14 @@ def _append_claude_block(directory: Path, *, dry_run: bool) -> InstallResult:
     return InstallResult(path=dst, disposition="installed")
 
 
-__all__ = ["HOOK_ASSETS_DIR", "SETTINGS_TEMPLATE_PATH", "ClaudeCodeAdapter", "MARKER_END", "MARKER_START"]
+__all__ = [
+    "HOOK_ASSETS_DIR",
+    "MARKER_END",
+    "MARKER_START",
+    "MARKER_START_RE",
+    "SETTINGS_TEMPLATE_PATH",
+    "ClaudeCodeAdapter",
+    "get_block_stamp",
+    "read_installed_block_stamp",
+    "render_claude_block",
+]

--- a/src/trace_mcp/conformance/__init__.py
+++ b/src/trace_mcp/conformance/__init__.py
@@ -51,11 +51,13 @@ from trace_mcp.conformance.fleet import (
 )
 from trace_mcp.conformance.probes import (
     CONFIG_CHECKS,
+    DOCS_CHECKS,
     HOOK_CHECKS,
     LIVE_CHECKS,
     PIN_CHECKS,
     check_config,
     check_hooks,
+    check_instruction_block,
     check_pin_coherence,
     check_served_build,
 )
@@ -64,6 +66,7 @@ _OFFLINE_PROBES: tuple[tuple[str, Callable[[Path], list[Finding]], tuple[str, ..
     ("config", check_config, CONFIG_CHECKS),
     ("hooks", check_hooks, HOOK_CHECKS),
     ("pin", check_pin_coherence, PIN_CHECKS),
+    ("docs", check_instruction_block, DOCS_CHECKS),
 )
 
 
@@ -111,6 +114,7 @@ def _guarded(name: str, owned: tuple[str, ...], probe: Callable[[], list[Finding
 
 __all__ = [
     "CONFIG_CHECKS",
+    "DOCS_CHECKS",
     "FLEET_ROOTS_ENV",
     "MAX_DEPTH",
     "CORE_TOOLS",

--- a/src/trace_mcp/conformance/probes.py
+++ b/src/trace_mcp/conformance/probes.py
@@ -78,6 +78,7 @@ HOOK_CHECKS = (
     "hooks.decision_audit_matcher",
 )
 PIN_CHECKS = ("pin.trace_project_file", "pin.mcp_env", "pin.claude_md_line", "pin.coherence")
+DOCS_CHECKS = ("docs.block_stamp",)
 LIVE_CHECKS = ("live.spawn", "live.version", "live.tool_surface")
 """Every check id each probe owns, in emission order.
 
@@ -721,6 +722,57 @@ class _LiveResult:
     tool_names: tuple[str, ...] = ()
     error: str | None = None
     stderr_tail: str = ""
+
+
+def check_instruction_block(project_dir: Path) -> list[Finding]:
+    """The TRACE block in the project's CLAUDE.md is the one this build ships.
+
+    The hook scripts carry a version stamp and are checked against it because
+    an asset installed once and never refreshed goes stale invisibly. The
+    instruction block had neither, and did exactly that: a block installed
+    before a template change kept its old text indefinitely while every other
+    check reported the project clean.
+
+    A block is what tells a model what to record. One that is months behind the
+    template is a project quietly running an older protocol.
+    """
+    from trace_mcp.adapters.claude_code import MARKER_END, MARKER_START_RE, get_block_stamp
+
+    claude_md = project_dir / "CLAUDE.md"
+    if not claude_md.is_file():
+        return [_unevaluated("docs.block_stamp", f"{claude_md} does not exist")]
+
+    text = claude_md.read_text(encoding="utf-8", errors="replace")
+    match = MARKER_START_RE.search(text)
+    if match is None:
+        return [
+            _bad(
+                "docs.block_stamp",
+                f"{claude_md} carries no TRACE instruction block — the project's model is given no "
+                "protocol to follow. Run `trace-mcp-init`.",
+            )
+        ]
+    if text.find(MARKER_END, match.end()) == -1:
+        return [
+            _bad(
+                "docs.block_stamp",
+                f"{claude_md} has an opening TRACE marker with no closing one, so the block's extent "
+                "cannot be determined and the installer will not rewrite it. Repair the markers by hand.",
+            )
+        ]
+
+    expected = get_block_stamp()
+    installed = match.group(1)
+    if installed == expected:
+        return [_ok("docs.block_stamp", f"instruction block is current ({expected})")]
+    found = installed or "unstamped (installed before block stamping existed)"
+    return [
+        _bad(
+            "docs.block_stamp",
+            f"instruction block is {found}, but this build ships {expected} — the project is following "
+            "an older protocol than the server it runs. Re-run `trace-mcp-init` to refresh it in place.",
+        )
+    ]
 
 
 def check_served_build(project_dir: Path, *, live: bool = False, timeout: float | None = None) -> list[Finding]:

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -14,7 +14,11 @@ import pytest
 
 from trace_mcp.adapters import detect_adapter, get_adapter, list_adapters
 from trace_mcp.adapters.base import MCP_SERVER_KEY
-from trace_mcp.adapters.claude_code import MARKER_END, MARKER_START, ClaudeCodeAdapter
+from trace_mcp.adapters.claude_code import (
+    MARKER_END,
+    MARKER_START_RE,
+    ClaudeCodeAdapter,
+)
 from trace_mcp.adapters.codex import CodexAdapter
 
 # ── Registry ──────────────────────────────────────────────────────────────
@@ -91,7 +95,9 @@ class TestClaudeCodeInstall:
         claude_md = tmp_path / "CLAUDE.md"
         assert claude_md.is_file()
         content = claude_md.read_text()
-        assert MARKER_START in content
+        # The opening marker carries this build's block stamp, so it is matched
+        # by pattern rather than as the bare literal.
+        assert MARKER_START_RE.search(content) is not None
         assert MARKER_END in content
 
     def test_install_idempotent(self, tmp_path: Path) -> None:
@@ -108,7 +114,7 @@ class TestClaudeCodeInstall:
         a.install(tmp_path, dry_run=True)
         assert not (tmp_path / ".claude" / "hooks").exists()
         assert not (tmp_path / ".claude" / "settings.json").exists()
-        assert MARKER_START not in (tmp_path / "CLAUDE.md").read_text()
+        assert MARKER_START_RE.search((tmp_path / "CLAUDE.md").read_text()) is None
 
     def test_hook_scripts_are_executable(self, tmp_path: Path) -> None:
         a = ClaudeCodeAdapter()

--- a/tests/test_claude_block_refresh.py
+++ b/tests/test_claude_block_refresh.py
@@ -1,0 +1,238 @@
+"""Refreshing the TRACE instruction block in a consumer's CLAUDE.md.
+
+An installed block used to be left alone forever: the installer returned
+`skipped` the moment it saw the opening marker. Every edit to the template
+therefore reached only projects that did not yet have a block, which in a
+deployed fleet is none of them. Measured on ten real consumer projects, a
+protocol change reached zero of them, across two distinct block vintages, while
+`trace-mcp doctor` reported all ten clean.
+
+That is the shape the hook scripts already guard against with a version stamp
+and a `hooks.stamp` check. These tests pin the same treatment for the block: it
+is stamped with a digest of the shipped template, the installer replaces the
+marked region when the stamp differs, and the doctor reports a block that is not
+this build's.
+
+The constraint that shapes the implementation: a consumer's CLAUDE.md holds
+their own instructions around the block — 157 lines of them in one real project.
+Only the marked region may ever be touched.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from trace_mcp.adapters.claude_code import (
+    MARKER_END,
+    MARKER_START,
+    ClaudeCodeAdapter,
+    get_block_stamp,
+    read_installed_block_stamp,
+    render_claude_block,
+)
+from trace_mcp.conformance.probes import check_instruction_block
+
+OWN_HEADER = "# My Project\n\nMy own instructions that are not TRACE's to rewrite.\n"
+OWN_FOOTER = "\n## After the block\n\nMore of my own text.\n"
+
+
+def _install(project: Path) -> str:
+    ClaudeCodeAdapter().install(project, dry_run=False)
+    return (project / "CLAUDE.md").read_text()
+
+
+def _legacy_block(body: str = "\n## TRACE Audit Protocol (old)\n\nOutdated guidance.\n") -> str:
+    """A block as installed before stamping existed: bare opening marker."""
+    return f"{MARKER_START}{body}{MARKER_END}\n"
+
+
+class TestStamping:
+    def test_the_stamp_tracks_the_template_contents(self) -> None:
+        """Any edit to the asset must change the stamp, or staleness hides again."""
+        assert read_installed_block_stamp(render_claude_block()) == get_block_stamp()
+
+    def test_an_unstamped_block_reads_as_no_stamp(self) -> None:
+        assert read_installed_block_stamp(_legacy_block()) is None
+
+    def test_text_with_no_block_reads_as_no_stamp(self) -> None:
+        assert read_installed_block_stamp(OWN_HEADER) is None
+
+
+class TestRefresh:
+    def test_a_legacy_block_is_replaced(self, tmp_path: Path) -> None:
+        (tmp_path / "CLAUDE.md").write_text(OWN_HEADER + "\n" + _legacy_block())
+
+        result = _install(tmp_path)
+
+        assert "Outdated guidance." not in result
+        assert read_installed_block_stamp(result) == get_block_stamp()
+
+    def test_the_projects_own_text_is_preserved_on_both_sides(self, tmp_path: Path) -> None:
+        """The reason the markers exist: a consumer writes in this file too."""
+        (tmp_path / "CLAUDE.md").write_text(OWN_HEADER + "\n" + _legacy_block() + OWN_FOOTER)
+
+        result = _install(tmp_path)
+
+        assert result.startswith(OWN_HEADER)
+        assert result.endswith(OWN_FOOTER)
+        assert "More of my own text." in result
+
+    def test_exactly_one_block_survives_a_refresh(self, tmp_path: Path) -> None:
+        """The old bug's other face: appending a second block beside the first."""
+        (tmp_path / "CLAUDE.md").write_text(OWN_HEADER + "\n" + _legacy_block())
+
+        result = _install(tmp_path)
+
+        assert result.count(MARKER_END) == 1
+
+    def test_refreshing_is_idempotent(self, tmp_path: Path) -> None:
+        (tmp_path / "CLAUDE.md").write_text(OWN_HEADER + "\n" + _legacy_block())
+        first = _install(tmp_path)
+        second = _install(tmp_path)
+
+        assert first == second
+
+    def test_repeated_refreshes_do_not_grow_the_file(self, tmp_path: Path) -> None:
+        """A refresh reflows the marked region; it must not accumulate blank lines.
+
+        Caught on a real consumer whose file continues after the block: the
+        asset's own trailing newline was added on top of the one the following
+        text already supplied, so every run left one more blank line behind.
+        """
+        (tmp_path / "CLAUDE.md").write_text(OWN_HEADER + "\n" + _legacy_block() + OWN_FOOTER)
+
+        first = _install(tmp_path)
+        second = _install(tmp_path)
+        ClaudeCodeAdapter().install(tmp_path, dry_run=False)
+        third = (tmp_path / "CLAUDE.md").read_text()
+
+        assert first == second == third
+        assert "\n\n\n" not in first
+
+    def test_a_current_block_is_skipped(self, tmp_path: Path) -> None:
+        (tmp_path / "CLAUDE.md").write_text(OWN_HEADER + "\n" + render_claude_block())
+        before = (tmp_path / "CLAUDE.md").read_text()
+
+        results = ClaudeCodeAdapter().install(tmp_path, dry_run=False)
+        claude_results = [r for r in results if r.path.name == "CLAUDE.md"]
+
+        assert (tmp_path / "CLAUDE.md").read_text() == before
+        assert any(r.disposition == "skipped" for r in claude_results)
+
+    def test_a_file_with_no_block_gets_one_appended(self, tmp_path: Path) -> None:
+        (tmp_path / "CLAUDE.md").write_text(OWN_HEADER)
+
+        result = _install(tmp_path)
+
+        assert result.startswith(OWN_HEADER)
+        assert read_installed_block_stamp(result) == get_block_stamp()
+
+    def test_a_missing_file_is_created(self, tmp_path: Path) -> None:
+        result = _install(tmp_path)
+
+        assert read_installed_block_stamp(result) == get_block_stamp()
+
+    def test_an_unterminated_block_is_left_alone(self, tmp_path: Path) -> None:
+        """Guessing the block's extent could eat a project's own instructions."""
+        damaged = OWN_HEADER + "\n" + MARKER_START + "\n## Half a block, no closing marker\n"
+        (tmp_path / "CLAUDE.md").write_text(damaged)
+
+        result = _install(tmp_path)
+
+        assert result == damaged
+
+    def test_dry_run_writes_nothing(self, tmp_path: Path) -> None:
+        original = OWN_HEADER + "\n" + _legacy_block()
+        (tmp_path / "CLAUDE.md").write_text(original)
+
+        ClaudeCodeAdapter().install(tmp_path, dry_run=True)
+
+        assert (tmp_path / "CLAUDE.md").read_text() == original
+
+
+class TestDoctorReportsStaleness:
+    def test_a_current_block_passes(self, tmp_path: Path) -> None:
+        (tmp_path / "CLAUDE.md").write_text(render_claude_block())
+
+        findings = check_instruction_block(tmp_path)
+
+        assert [f.status for f in findings] == ["pass"]
+
+    def test_an_unstamped_block_fails_and_names_the_remedy(self, tmp_path: Path) -> None:
+        (tmp_path / "CLAUDE.md").write_text(_legacy_block())
+
+        findings = check_instruction_block(tmp_path)
+
+        assert findings[0].status == "fail"
+        assert "unstamped" in findings[0].detail
+        assert "trace-mcp-init" in findings[0].detail
+
+    def test_a_differently_stamped_block_fails(self, tmp_path: Path) -> None:
+        stale = render_claude_block().replace(f"block={get_block_stamp()}", "block=0123456789ab", 1)
+        (tmp_path / "CLAUDE.md").write_text(stale)
+
+        findings = check_instruction_block(tmp_path)
+
+        assert findings[0].status == "fail"
+        assert "0123456789ab" in findings[0].detail
+        assert get_block_stamp() in findings[0].detail
+
+    def test_no_block_at_all_fails(self, tmp_path: Path) -> None:
+        (tmp_path / "CLAUDE.md").write_text(OWN_HEADER)
+
+        findings = check_instruction_block(tmp_path)
+
+        assert findings[0].status == "fail"
+        assert "no TRACE instruction block" in findings[0].detail
+
+    def test_an_unterminated_block_fails(self, tmp_path: Path) -> None:
+        (tmp_path / "CLAUDE.md").write_text(MARKER_START + "\n## no closing marker\n")
+
+        findings = check_instruction_block(tmp_path)
+
+        assert findings[0].status == "fail"
+        assert "closing" in findings[0].detail
+
+    def test_a_missing_file_is_not_evaluated(self, tmp_path: Path) -> None:
+        """Absent CLAUDE.md is another check's business, not this one's."""
+        findings = check_instruction_block(tmp_path)
+
+        assert [f.status for f in findings] == ["skip"]
+
+    def test_the_check_id_is_always_emitted(self, tmp_path: Path) -> None:
+        """Check ids are stable API; one must never silently vanish."""
+        for setup in (lambda: None, lambda: (tmp_path / "CLAUDE.md").write_text(OWN_HEADER)):
+            setup()
+            assert [f.check for f in check_instruction_block(tmp_path)] == ["docs.block_stamp"]
+
+
+class TestInstallerAndCheckerAgree:
+    """A freshly installed project must satisfy the checker (INV-11's premise)."""
+
+    def test_install_then_check_is_clean(self, tmp_path: Path) -> None:
+        (tmp_path / "CLAUDE.md").write_text(OWN_HEADER + "\n" + _legacy_block())
+        _install(tmp_path)
+
+        findings = check_instruction_block(tmp_path)
+
+        assert [f.status for f in findings] == ["pass"], findings[0].detail
+
+    @pytest.mark.parametrize(
+        "starting",
+        [
+            "",
+            OWN_HEADER,
+            OWN_HEADER + "\n" + _legacy_block(),
+            OWN_HEADER + "\n" + _legacy_block() + OWN_FOOTER,
+        ],
+        ids=["no-file", "no-block", "legacy-block", "legacy-block-with-trailing-text"],
+    )
+    def test_every_starting_state_ends_current(self, tmp_path: Path, starting: str) -> None:
+        if starting:
+            (tmp_path / "CLAUDE.md").write_text(starting)
+
+        _install(tmp_path)
+
+        assert [f.status for f in check_instruction_block(tmp_path)] == ["pass"]

--- a/tests/test_conformance_doctor.py
+++ b/tests/test_conformance_doctor.py
@@ -590,9 +590,9 @@ def test_offline_run_reports_the_live_probe_as_skipped(project: Path) -> None:
 def test_a_clean_run_emits_exactly_the_declared_check_ids(project: Path) -> None:
     """Check ids are stable API for fleet tooling — a rename or a dropped check
     must break here rather than silently in a consumer."""
-    from trace_mcp.conformance import CONFIG_CHECKS, HOOK_CHECKS, LIVE_CHECKS, PIN_CHECKS
+    from trace_mcp.conformance import CONFIG_CHECKS, DOCS_CHECKS, HOOK_CHECKS, LIVE_CHECKS, PIN_CHECKS
 
-    declared = [*CONFIG_CHECKS, *HOOK_CHECKS, *PIN_CHECKS, *LIVE_CHECKS]
+    declared = [*CONFIG_CHECKS, *HOOK_CHECKS, *PIN_CHECKS, *DOCS_CHECKS, *LIVE_CHECKS]
     emitted = [f.check for f in run_doctor(project).findings]
     assert sorted(emitted) == sorted(declared)
     assert len(emitted) == len(set(emitted)), "each check must be reported exactly once"


### PR DESCRIPTION
> Independent of #73. Both touch `CHANGELOG.md`; whichever lands second needs a trivial rebase.

## Summary

`trace-mcp-init` never updated an installed TRACE block. The Claude Code adapter returned `skipped` the moment it saw the opening marker, so **every edit to the template reached only projects that did not yet have a block** — which, in a deployed fleet, is none of them.

Found by running the fleet pass for #72 and checking whether the guidance actually arrived.

## What was measured

Across ten real consumer projects, after re-running `trace-mcp-init` from merged main:

| | |
|---|---|
| Consumers that received the new guidance | **0 of 10** |
| Distinct block vintages already deployed | **2** |
| Consumers `trace-mcp doctor` called clean | **10 of 10** |

The doctor's only `CLAUDE.md` check reads the project pin line — nothing about the block's content or vintage. So the fleet had already drifted across two template generations with no signal.

This is the shape of the decision-audit matcher defect fixed in #50: an asset installed once, never refreshed, silently stale. The hook scripts carry a `[trace-hooks vX.Y]` stamp and a `hooks.stamp` check for exactly that reason. The block had neither.

## The fix

- **The block is stamped** with a digest of the shipped template's bytes, so *any* edit changes it. A hand-maintained number would only change when someone remembered — the failure being replaced.
- **The installer replaces the marked region in place** when the stamp differs.
- **`docs.block_stamp`** reports a block that is stale, unstamped, absent, or unterminated.

## What it deliberately will not do

- **Touch anything outside the markers.** Consumers keep their own instructions in the same file — 157 lines in one real project, 208 in another. That is what the markers are for.
- **Guess at a block with no closing marker.** Guessing its extent could delete a project's own text, so it is left alone and the doctor reports it.

The replacement drops the asset's trailing newline, because the text following the block already supplies one. Without that a blank line accumulated on every refresh — caught by rerunning against a real consumer's file rather than a synthetic one, and now pinned by a test.

The opening marker is matched by pattern rather than as a bare literal now that it carries a stamp, in the adapter's validation as well as the installer, so a block predating stamping is still recognised rather than having a second one appended beside it.

## Verification

- Full suite **1637 passed, 12 skipped**; `ruff format --check`, `ruff check`, `pyright src/` clean.
- 25 new cases: stamp round trip, legacy-block replacement, a project's text preserved on both sides, exactly one block surviving, idempotence *including no file growth* across repeated runs, unterminated block untouched, dry-run writing nothing, every doctor status plus the always-emitted check id, and installer/checker agreement from four starting states.
- Against **copies of three real consumer files** (REAP, work-domains, esg-funds): the guidance lands, exactly one block remains, the doctor goes clean, and the non-block content is byte-identical after two refreshes.
- Two existing tests correctly caught the change and were updated rather than worked around: the adapter's bare-literal marker assertion, and the doctor's declared-check-id set.

Registered under INV-11 in `docs/INVARIANTS.md`.