### PR TITLE
fix(docs): refresh this project's own TRACE instruction block

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,7 +152,7 @@ instructions are in the global `~/.claude/CLAUDE.md`. Key points:
 
 **trace-learn**: `trace_learn_recall`, `trace_learn_add`, `trace_learn_list`, `trace_learn_forget`, `trace_learn_extract`
 
-<!-- trace-mcp:claude-code -->
+<!-- trace-mcp:claude-code block=c45181197f52 -->
 
 ## TRACE Audit Protocol (v0.5.0+)
 
@@ -177,6 +177,15 @@ read as separate projects.
 - Without a pin, pass `project="<label>"` explicitly.
 - Never repair a wrong label by editing a captured session. Add an alias to
   the registry instead — capture records are not rewritten.
+
+**OpenAI key (optional, for semantic recall)**
+
+This project's OpenAI key belongs in its own `.env` file, not in a machine-wide
+one — per-project credentials keep one project's key from covering every
+project on the machine. `~/.trace/.env` is only a fallback, and TRACE reports at
+session start when a project is borrowing it. If a key is missing or refused,
+TRACE says so in the session banner and in the affected tool responses instead
+of quietly returning keyword-ranked results.
 
 **Session lifecycle**
 


### PR DESCRIPTION
## Summary

After #74 landed, `fleet-check` across all eleven projects reported exactly one failure — **this repository**. Its instruction block predated the template's OpenAI-key section, so the project that maintains the template was itself nine lines behind it.

Refreshed through the installer rather than by hand: the same path a consumer takes, run on the project that ships it. The block now carries its stamp and `trace-mcp doctor .` reports clean.

Fleet is now **11 of 11 clean**, up from 10 of 11.

## One thing deliberately excluded

`trace-mcp-init` also rewrote `.mcp.json`'s `"--from": "."` into `"--from": "/Users/<home>/Developer/TRACE"`. That behaviour is correct for a consumer, whose config is generated per machine and legitimately absolute — and wrong here, because this is the one project that **commits** its `.mcp.json`, where the relative "." is what makes it work for anyone who clones.

That rewrite was reverted; only the `CLAUDE.md` refresh is in this PR. Nothing currently guards against it — no test would catch the absolute path, and the doctor reports the rewritten form as healthy because for a consumer it is. A guard on the committed file would be the fix; left out here to keep this change small.

## Verification

- Full suite green; `ruff format --check` clean.
- `trace-mcp doctor .` → no failures.
- `trace-mcp fleet-check ~/Developer` → 11/11 clean, exit 0.
- Diff is 10 insertions in one file.